### PR TITLE
chore: unify chinese ui copy across backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# tla
+# Teams Language Assistant (TLA) – .NET 参考实现
+
+## 项目概述
+TLA 参考实现基于 .NET 7 Minimal API 与 SQLite，支撑 Microsoft Teams 消息扩展的跨语翻译、术语优先与合规留痕能力。功能设计遵循《BOBTLA 需求说明书》对 MVP 阶段的 Must/Should 要求，包括多模型路由、PII 拦截、预算控制与 Adaptive Card 回复体验。【F:docs/BOBTLA需求说明书.txt†L40-L207】
+
+## 核心架构
+| 模块 | 路径 | 说明 |
+| --- | --- | --- |
+| Web 宿主 | `src/TlaPlugin/Program.cs` | Minimal API 启动翻译与离线草稿接口，注入配置、术语库与模型工厂。 |
+| 配置与模型 | `src/TlaPlugin/Configuration/PluginOptions.cs`、`src/TlaPlugin/Providers/*` | 以 `PluginOptions` 映射区域策略与模型参数；`MockModelProvider` 模拟多提供方与回退。 |
+| 服务层 | `src/TlaPlugin/Services/*` | 覆盖语言检测、术语合并、预算守卫、合规网关、审计日志、SQLite 草稿仓库及翻译路由。 |
+| 缓存与限流 | `src/TlaPlugin/Services/TranslationCache.cs`、`src/TlaPlugin/Services/TranslationThrottle.cs` | `TranslationCache` 依据租户与参数缓存译文，`TranslationThrottle` 控制并发与分钟速率。 |
+| 密钥与令牌 | `src/TlaPlugin/Services/KeyVaultSecretResolver.cs`、`src/TlaPlugin/Services/TokenBroker.cs` | `KeyVaultSecretResolver` 模拟 Key Vault 缓存密钥，`TokenBroker` 生成 OBO 访问令牌供模型调用使用。 |
+| Teams 适配 | `src/TlaPlugin/Teams/MessageExtensionHandler.cs` | 输出 Adaptive Card、处理预算/合规异常、保存离线草稿。 |
+| 测试 | `tests/TlaPlugin.Tests/*` | 使用 xUnit 验证合规网关、路由回退、离线草稿持久化与消息扩展错误处理。 |
+
+### 关键流程
+1. `MessageExtensionHandler` 接收翻译命令后调用 `TranslationPipeline`，先执行术语替换与语言检测，命中 `TranslationCache` 时直接返回缓存；未命中时通过 `TranslationThrottle` 获取配额后委派 `TranslationRouter` 调用模型并聚合多语言结果。【F:src/TlaPlugin/Teams/MessageExtensionHandler.cs†L22-L64】【F:src/TlaPlugin/Services/TranslationPipeline.cs†L33-L76】【F:src/TlaPlugin/Services/TranslationCache.cs†L34-L78】【F:src/TlaPlugin/Services/TranslationThrottle.cs†L27-L78】
+2. `TranslationRouter` 在调用模型前通过 `TokenBroker` 执行 OBO 令牌交换，再依次评估合规策略、预算额度与可用性，对失败的提供方自动回退并写入审计日志与令牌受众信息。【F:src/TlaPlugin/Services/TokenBroker.cs†L1-L63】【F:src/TlaPlugin/Services/TranslationRouter.cs†L30-L112】
+3. `ComplianceGateway` 在翻译前检查区域、认证、禁译词及 PII，违反策略时阻断调用；`BudgetGuard` 跟踪租户当日花费避免超支。【F:src/TlaPlugin/Services/ComplianceGateway.cs†L17-L69】【F:src/TlaPlugin/Services/BudgetGuard.cs†L8-L27】
+4. `OfflineDraftStore` 通过 SQLite 持久化草稿，支持断线场景下的恢复与清理。【F:src/TlaPlugin/Services/OfflineDraftStore.cs†L14-L82】
+
+## 开发阶段
+| 阶段 | 目标 | 进度 | 成果 |
+| --- | --- | --- | --- |
+| 阶段 0：需求吸收 | 解析说明书并确定 .NET 技术栈、SQLite 本地存储策略 | ✅ 完成 | 明确 MVP 功能、地区策略与测试范围。 |
+| 阶段 1：服务编排 | 实现模型工厂、翻译路由、合规/预算/术语服务 | ✅ 完成 | 支持多模型回退、语气模板与审计追踪。 |
+| 阶段 2：Teams 适配 | 构建消息扩展处理器与 Adaptive Card 响应 | ✅ 完成 | 返回中文 UI 文案的卡片，整合多语言结果。 |
+| 阶段 3：持久化与测试 | 集成 SQLite 草稿仓库，使用 xUnit 覆盖关键路径 | ✅ 完成 | 草稿持久化、合规守卫、预算超限等单测通过。 |
+| 阶段 4：合规加固 | 提供地区/认证校验与 PII 正则库，文档化阶段成果 | ✅ 完成 | `ComplianceGateway` 支持禁译词与区域白名单。 |
+| 阶段 5：性能护栏 | 引入缓存去重与速率/并发限制 | ✅ 完成 | `TranslationCache` 降低重复调用成本，`TranslationThrottle` 保证租户速率受控。 |
+| 阶段 6：密钥与 OBO | 集成 Key Vault 密钥缓存与 OBO 令牌代理 | ✅ 完成 | `KeyVaultSecretResolver` 缓存密钥，`TokenBroker` 缓存/刷新访问令牌并在路由前强制认证。 |
+| 阶段 7：多语广播 | 支持一次请求广播多种目标语言并在卡片中呈现 | ✅ 完成 | `TranslationRouter` 逐一重写多语结果并汇总到 Adaptive Card，`AuditLogger` 记录额外译文。 |
+| 阶段 8：多模型互联 | 统一接入 OpenAI / Claude / Groq / OpenWebUI / Ollama | ✅ 完成 | `ConfigurableChatModelProvider` 通过 HTTP 客户端与 KeyVault 密钥调用外部模型，保留本地 Mock 回退。 |
+| 阶段 9：前端体验筹备 | 为 Tab/消息扩展提供配置、状态接口并规划联调 | 🚧 进行中 | 增加配置、用语、审计、阶段状态 API，并对外公布整体进度与前端准备度指标。 |
+
+## 当前状态
+项目处于 **阶段 9：前端体验筹备**，在多模型互联的基础上补齐前端所需的数据平面：`/api/configuration`、`/api/glossary`、`/api/audit`、`/api/status` 端点提供语言、语气模板、用语表、审计与阶段快照，并额外公布整体完成度（80%）与前端准备度（数据平面 ✅、界面 ❌、联调 ❌），帮助前端同学掌握当前缺口。【F:src/TlaPlugin/Program.cs†L42-L85】【F:src/TlaPlugin/Services/ConfigurationSummaryService.cs†L1-L48】【F:src/TlaPlugin/Services/ProjectStatusService.cs†L8-L62】
+
+## 下一步规划
+1. **完成真实模型验通**：对 ConfigurableChatModelProvider 增加重试/节流策略，串联实际的 Azure OpenAI、Anthropic Claude、Groq API 并记录延迟指标。
+2. **接入真实 Key Vault/OBO**：将模拟密钥存储替换为 Azure Key Vault SDK，调用 Microsoft Graph 获取用户断言，完成端到端 OBO。【F:docs/BOBTLA需求说明书.txt†L207-L270】
+3. **实现 Teams Tab 设置页**：利用 `/api/configuration`、`/api/glossary`、`/api/status` 构建术语上传、阶段看板与语气模板配置界面，准备与消息扩展联调。
+4. **启动前后端联调测试**：基于新增 API 对 Adaptive Card 与 Tab 场景执行端到端验证，随后引入 CI 合规流水线。
+
+## 阶段成果与测试
+- **多模型路由与语气模板**：`TranslationRouter` 在首选模型失败后自动回退，利用 `ToneTemplateService` 统一敬体/商务/技术风格。【F:src/TlaPlugin/Services/TranslationRouter.cs†L18-L112】【F:src/TlaPlugin/Services/ToneTemplateService.cs†L5-L34】
+- **预算与审计留痕**：`BudgetGuard` 以租户+日期统计消耗，`AuditLogger` 保存哈希指纹与模型元数据满足审计需求。【F:src/TlaPlugin/Services/BudgetGuard.cs†L8-L27】【F:src/TlaPlugin/Services/AuditLogger.cs†L15-L43】
+- **SQLite 草稿支持**：`OfflineDraftStore` 在断线时保留草稿并支持定期清理，xUnit 覆盖持久化流程。【F:src/TlaPlugin/Services/OfflineDraftStore.cs†L14-L82】【F:tests/TlaPlugin.Tests/OfflineDraftStoreTests.cs†L1-L30】
+- **合规网关**：`ComplianceGateway` 综合地区、认证、禁译与 PII 正则，测试验证禁译词阻断与认证放行。【F:src/TlaPlugin/Services/ComplianceGateway.cs†L17-L69】【F:tests/TlaPlugin.Tests/ComplianceGatewayTests.cs†L1-L33】
+- **消息扩展体验**：`MessageExtensionHandler` 输出中文 Adaptive Card，并在预算或速率超限时返回提示卡片；单测验证卡片内容。【F:src/TlaPlugin/Teams/MessageExtensionHandler.cs†L21-L100】【F:tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs†L17-L179】
+- **缓存去重与限流**：`TranslationCache` 以租户维度缓存译文，`TranslationThrottle` 限制速率与并发；单测覆盖缓存复用与限流提示。【F:src/TlaPlugin/Services/TranslationCache.cs†L15-L88】【F:src/TlaPlugin/Services/TranslationThrottle.cs†L13-L116】【F:tests/TlaPlugin.Tests/TranslationPipelineTests.cs†L1-L110】【F:tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs†L17-L179】
+- **密钥托管与 OBO**：`KeyVaultSecretResolver` 以 TTL 缓存密钥，`TokenBroker` 使用 HMAC 生成令牌并在到期前缓存，路由在执行翻译前要求有效令牌；单测覆盖缓存刷新、异常与缺失用户的情境。【F:src/TlaPlugin/Services/KeyVaultSecretResolver.cs†L1-L63】【F:src/TlaPlugin/Services/TokenBroker.cs†L1-L63】【F:src/TlaPlugin/Services/TranslationRouter.cs†L30-L135】【F:tests/TlaPlugin.Tests/TokenBrokerTests.cs†L1-L39】【F:tests/TlaPlugin.Tests/TranslationRouterTests.cs†L1-L214】【F:tests/TlaPlugin.Tests/KeyVaultSecretResolverTests.cs†L1-L67】
+- **多语广播体验**：`TranslationRouter` 根据附加语言调整预算、逐一重写译文并将结果写入审计，Adaptive Card 与消息扩展渲染出“额外翻译”分节；单测覆盖卡片内容与审计记录。【F:src/TlaPlugin/Services/TranslationRouter.cs†L71-L169】【F:src/TlaPlugin/Services/AuditLogger.cs†L15-L43】【F:src/TlaPlugin/Teams/MessageExtensionHandler.cs†L21-L78】【F:tests/TlaPlugin.Tests/TranslationRouterTests.cs†L17-L210】【F:tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs†L17-L116】
+- **多模型接入与一键插入**：`ConfigurableChatModelProvider` 统一封装 OpenAI/Claude/Groq/OpenWebUI/Ollama 调用并在 KeyVault 中解析密钥，Adaptive Card 行动按钮支持将主译文及额外语种一键写回聊天对话框；测试验证工厂类型选择与 Teams 按钮 payload。【F:src/TlaPlugin/Providers/ConfigurableChatModelProvider.cs†L1-L209】【F:src/TlaPlugin/Services/ModelProviderFactory.cs†L9-L52】【F:src/TlaPlugin/Services/TranslationRouter.cs†L119-L169】【F:tests/TlaPlugin.Tests/ModelProviderFactoryTests.cs†L1-L62】【F:tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs†L17-L116】
+- **前端数据平面**：`ConfigurationSummaryService` 汇总租户限额、支持语言、语气模板与模型提供方；`ProjectStatusService` 暴露阶段进度、整体完成度与前端准备度；Minimal API 公开配置、用语、审计与状态端点供前端即时读取。【F:src/TlaPlugin/Services/ConfigurationSummaryService.cs†L1-L48】【F:src/TlaPlugin/Services/ProjectStatusService.cs†L8-L62】【F:src/TlaPlugin/Program.cs†L56-L85】【F:tests/TlaPlugin.Tests/ConfigurationSummaryServiceTests.cs†L1-L53】【F:tests/TlaPlugin.Tests/ProjectStatusServiceTests.cs†L1-L34】
+
+### 测试与运行
+1. `dotnet restore` – 还原 NuGet 依赖。 
+2. `dotnet test` – 执行 xUnit 测试套件，覆盖合规、路由、草稿、缓存限流、OBO 令牌与消息扩展场景。【F:tests/TlaPlugin.Tests/TranslationRouterTests.cs†L1-L205】【F:tests/TlaPlugin.Tests/TokenBrokerTests.cs†L1-L39】【F:tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs†L17-L179】
+3. `dotnet run --project src/TlaPlugin/TlaPlugin.csproj` – 启动本地 API，`POST /api/translate` 接受 `TranslationRequest` 负载返回 Adaptive Card。
+
+> 代码注释与界面文案统一为中文，避免混用多种语言，符合最新的多语言治理规范。【F:src/TlaPlugin/Services/TranslationRouter.cs†L15-L192】【F:src/TlaPlugin/Teams/MessageExtensionHandler.cs†L9-L100】

--- a/bobtla.sln
+++ b/bobtla.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TlaPlugin", "src/TlaPlugin/TlaPlugin.csproj", "{8F8CF3EC-9C1C-4D91-B6F3-0EBBA66560C3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TlaPlugin.Tests", "tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj", "{11C90498-322F-4D4F-A52A-728621A08178}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{8F8CF3EC-9C1C-4D91-B6F3-0EBBA66560C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{8F8CF3EC-9C1C-4D91-B6F3-0EBBA66560C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{8F8CF3EC-9C1C-4D91-B6F3-0EBBA66560C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{8F8CF3EC-9C1C-4D91-B6F3-0EBBA66560C3}.Release|Any CPU.Build.0 = Release|Any CPU
+{11C90498-322F-4D4F-A52A-728621A08178}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{11C90498-322F-4D4F-A52A-728621A08178}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{11C90498-322F-4D4F-A52A-728621A08178}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{11C90498-322F-4D4F-A52A-728621A08178}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/docs/BOBTLA需求说明书.txt
+++ b/docs/BOBTLA需求说明书.txt
@@ -1,0 +1,642 @@
+Teams Language Assistants (TLA) 需求说明书
+概要
+产品愿景
+TLA（Teams Language Assistants）旨在彻底改变微软 Teams 中的跨语种沟通体验。现有 Teams 自带的翻译功能只能单向转换，缺乏可编辑和回贴能力，无法满足团队在全球化协作中的即时双向交流需求。本插件通过灵活接入主流或自建的大模型，实现语言自动检测、双向翻译、术语优先、语气模板等高级功能，并提供一键“翻译并回复”体验，使用户在不离开对话的情况下完成跨语种交流。
+非目标
+不复刻通用翻译器。 插件不提供独立的文本翻译网页，也不承担离线文档批量翻译等非即时场景。
+不改变 Teams 消息原文。 原始消息始终保持不变，译文作为新回复或卡片追加呈现。
+不替代专业人译。 虽然支持术语库和语气模板，但不保证全部译文符合出版标准，重要场景仍需人工复核。
+不在插件中集成外部聊天功能。 本插件聚焦翻译与回复，不包含实时聊天或视频会议功能。
+术语表
+术语
+定义
+Teams
+Microsoft Teams 协作平台。
+Message Extension（ME）
+Teams 中一种扩展，允许在撰写区或消息的“更多操作”中触发插件。
+Adaptive Card
+一种可渲染在 Teams 等宿主中的卡片格式，支持丰富交互。
+TLA
+Teams Language Assistants 插件，为 Teams 提供即时双向翻译能力。
+LLM
+Large Language Model，大型语言模型，可提供翻译、改写等能力。
+Glossary
+术语库，包含预定义词汇及其指定翻译，用于提升术语准确性[1]。
+RAG
+Retrieval Augmented Generation，通过检索外部知识库增强大模型响应准确性[2]。
+OBO
+On-behalf-of，代表用户在后端调用 API 的身份委托流程[3]。
+业务目标与度量
+问题陈述
+现代企业在 Teams 中频繁跨语种协作，现有翻译功能只能单向展示译文；无法基于译文直接回复、编辑；也无法优先适用组织术语或自定义语气。此外，企业希望自主选择公有或私有模型以满足合规要求。[4]强调扩展不应将用户带离对话，因此需要在 Teams 内实现端到端的翻译与回复体验。
+KPI / 北极星指标
+指标
+定义
+目标（MVP）
+平均翻译回复时延（P95）
+用户点击“一键翻译并回复”至译文回贴完成的 95 分位延迟。
+≤ 2 秒（短文本）
+翻译准确率提升率
+译文满足用户意图的比例，与 Teams 默认翻译相比提升幅度。
+≥ 10 %
+术语匹配命中率
+翻译中正确应用术语库的次数 ÷ 术语出现次数。
+≥ 95 %
+用户留存率
+使用插件的月活用户 / 安装用户比例。
+≥ 80 %
+内部成本控制
+每日单租户翻译成本不超过 {DailyBudget}。
+100 % 符合法规
+成功判据
+在私有预览阶段，90 %的试点团队认为翻译质量和工作流优于 Teams 原生翻译。
+在 3 个月的公测期内，插件平均每日调用量达到 500 次/租户以上，且无重大安全事件。
+合规评审通过，满足 {ComplianceRefs} 规定，数据主权遵循 {RegionPolicy}。
+角色与权限
+角色
+权限与职责
+租户管理员
+安装与配置插件；设定模型与路由策略；管理租户级术语库与禁译库；配置成本上限与合规策略。
+普通用户
+在消息阅读或撰写时使用翻译功能；编辑译文并回复；配置个人偏好（目标语言、语气模板）。
+审计员
+访问审计日志及翻译留痕；查看原文、译文、模型、参数、操作者和时间线，确保合规。
+Bot/消息扩展
+后端身份，用于与 Teams 消息通信；通过 OBO 流程代用户调用翻译 API[3]。
+使用场景与用户旅程
+消息阅读内联翻译：用户查看一条外语消息时，可点击“翻译”按钮或在选中文本后弹出的悬浮入口，快速查看译文并在原文下方展开译文。可切换不同目标语言，支持自动或手动检测源语言。
+即时回复翻译：用户想用对方语言回复外语消息，可选择“一键翻译并回复”；系统打开编辑模式，显示原文及译文，允许用户修订译文或变更语气模板，点击“发送”后将译文作为新回复发送，并在回复卡片附带“查看原文/切换译文语言”的入口。
+群组多语广播：发送者撰写群公告，可选择多个目标语言并一次性广播；插件将根据群成员首选语言生成对应译文，并回贴多条语言版本。支持术语库和语气模板选择。
+术语库约束翻译：在医疗、金融等专业场景，发送者可选择特定术语库并启用禁译库，确保译文遵循专业规定。若术语与常用翻译冲突，系统提示并提供遵循术语/保留原意/折衷三选项。
+离线草稿：在网络不稳定或模型响应较慢时，用户可选择“离线草稿”，插件将保存原文及翻译请求，待网络恢复后自动翻译并提醒用户回贴。
+用户旅程示例 – 选中文本翻译并回复
+Given 用户在 Teams 消息中选中了部分外语文本；
+When 悬浮条显示翻译入口，用户点击“一键翻译并回复”；
+Then 插件弹出对话框，自动检测语言并展示并列的原文和译文，附带语气模板和术语策略选项；
+Then 用户可编辑译文或切换目标语言；点击“发送”后，插件通过 Bot 在原消息线程中回贴译文卡片，并附加“查看原文/切换语言”按钮。
+需求一览（MVP vs vNext）
+每条需求采用 MoSCoW 标注，便于项目优先级划分。MVP 表示私有预览必须具备的功能，vNext 为后续迭代。
+ID
+描述
+MoSCoW
+版本
+可验收条件
+R1
+支持自动检测源语言并翻译为用户 Teams 首选语言；允许覆盖目标语言
+Must
+MVP
+Given 外语消息，当用户点击翻译时，系统正确检测源语言并翻译，译文语言与用户首选匹配，用户可手动切换目标语言。
+R2
+支持双向翻译与编辑；用户可修改译文并回贴
+Must
+MVP
+When 翻译结果展示后，用户可以修改译文文本；点击发送后，修改后的译文被正确发送并显示。
+R3
+提供术语库和禁译库；支持三层级（团队/频道/个人）合并规则
+Must
+MVP
+Given 指定术语条目，当译文与术语库冲突时，系统提示并提供遵循术语、保留原意或折衷的选项；按照层级优先级应用术语。
+R4
+支持多模型路由（OpenAI、Azure OpenAI、Anthropic、Google、本地模型等）
+Should
+MVP
+管理员可配置 {ModelAllowList} 及优先级；当首选模型不可用或超出预算时，自动回退至次级模型；记录模型来源。
+R5
+成本与延迟控制：支持字数阈值、缓存去重、并发与速率限制
+Must
+MVP
+每次翻译请求不超过翻译服务的字符限制（例如 Azure Translator 50k 字符）[5]；配置每日租户预算 {DailyBudget}；系统记录请求成本和延迟并向用户提示。
+R6
+支持质量增强：利用消息线程/频道上下文与可选 RAG 来提高准确度
+Should
+vNext
+在翻译时引入上下文摘要或检索相关信息；用户可选择启用 RAG。
+R7
+完整审计与可追溯：记录原文、译文、模型、参数、操作者及时间线
+Must
+MVP
+审计员可查询任意翻译记录，查看译前文本、译文、使用的模型与参数、操作者标识及时间戳。
+R8
+国际化与方言支持：支持简体/繁体/日语敬语等多种语言及语气模板
+Should
+MVP
+在语言矩阵中支持至少 30 种语言；提供敬体、常体、商务、技术等语气模板供用户选择。
+R9
+集成 Microsoft Teams 宿主能力：Message Extension、Bot、Compose Box 插件、Tab
+Must
+MVP
+在消息的“更多操作”和撰写区可触发翻译；Bot 能处理命令并回贴卡片；Tab 提供设置页面。
+R10
+安全与合规：数据主权、密钥托管、PII/PHI 避免出境，遵循
+Must
+MVP
+系统确保数据在 {RegionPolicy} 区域处理；支持将租户密钥保存在 Azure Key Vault；不将敏感信息发送到不符合合规的模型。
+R11
+MCP Server 与 Agent 扩展：对外暴露 translation 能力，符合 Model Context Protocol，提供工具定义
+Should
+vNext
+外部 Agent 可通过 MCP 工具调用 TLA 功能，如 tla.translate、tla.detectLanguage 等，满足 JSON Schema 定义并处理错误码。
+R12
+离线草稿与消息队列支持长文本分片
+Could
+vNext
+对超出服务字符限制的长文本进行分片并异步翻译合并；在网络异常时保存草稿并重试。
+R13
+支持多语广播与群组策略
+Could
+vNext
+当用户选择多个目标语言时，插件分别生成译文并回贴；根据群成员首选语言自动推送对应版本。
+R14
+提供术语与风格编辑界面；用户可上传术语库（来自 {GlossarySources}）
+Could
+vNext
+在 Tab 页面允许导入 CSV/TermBase 等格式的术语库，并配置优先级与回退策略。
+关键功能规格
+技术选型
+开发语言：.NET Framework架构，C#优先。
+本地存储（缓存）：SQLite优先
+界面语言
+界面语言以日文作为默认语言，由于大模型能力较强，可由用户自选界面语言。
+文档语言为中文，代码注释为日文。
+语言自动检测与双向翻译
+自动检测：发送翻译请求前调用模型适配层 /detect 接口。采用统计方法或模型自带检测能力，需支持 100 种以上语言。若检测置信度 < 70%，向用户提供手动选择源语言。该功能应利用翻译服务的 Detect API，遵循字符数限制（每请求不超过 50,000 字符[5]）。
+双向翻译：核心接口 /translate 接收 sourceText、sourceLang?、targetLang、tone?、glossaryPolicy?、modelHints? 等参数，返回 translatedText、modelId、cost、latency。支持自定义语气模板（敬体、常体、商务、技术等），通过提示工程控制模型输出。需保留原文不变，译文作为回复发送。
+编辑模式：翻译完成后，用户可在 UI 中编辑译文。系统在回贴前重新调用 /rewrite 接口进行校正，保证风格统一。
+回贴按钮：编辑完成后提供“发送/Reply”按钮，点击后通过 Bot 调用 Teams API 发送 Adaptive Card；卡片中包含译文、原文引用及切换语言按钮。根据 Teams 设计规范，消息扩展应在对话框内展现搜索框、内容区域和可选标签[6]。
+时序图（文字版）1 – 选中文本翻译并回复
+User          TeamsClient          TLA ME           Gateway/API        ModelAdapter |                |                  |                  |                  | |--select text-->| |                |--invoke ME------>|--detectLang---->|--/detect-------->|--Model.detect |                |                  |<----lang--------|<---------------|  | |                |--translate----->|--/translate---->|--/translate------>|--Model.translate |                |                  |<--translated----|<---------------|  | |<-show editor---|                  |                  |                  | |--edit+send---->|--send card----->|--replyInThread->|--Teams API-------|  | |                |                  |                  |                  |
+文本说明：用户在消息中选中外语文本；Teams 客户端调用消息扩展，插件通过网关请求语言检测和翻译，返回译文后在前端显示编辑器；用户修改译文并点击发送，插件通过 Bot 回复到原线程。
+术语库/禁译库/语气模板
+术语库应用：通过 /applyGlossary 接口将术语项应用于翻译文本。根据机器翻译专家建议，术语库是含有优先翻译的词汇集合，可提升术语准确性[1]。在翻译前，模型适配层识别源文本中的术语并替换为预定义译文；当冲突发生时，提示用户选择遵循术语或保留原意等选项。
+禁译库：包含敏感词或禁止翻译的词汇，翻译时应保留原文或替换为合法词汇。租户管理员可配置行业场景开关（金融/医疗/教育等）。
+语气模板：提供敬体、常体、商务、技术四种预设模板，用户可选择在翻译时使用，以控制文体和口吻。例如敬体适合日文正式邮件，常体适合朋友聊天。模型提示词示例：请用{{tone}}语气翻译以下内容。未来支持自定义模板。
+层级合并规则：术语库分为团队、频道、个人三级。优先级：个人 > 频道 > 团队。冲突时按优先级覆盖；禁译库可配置全局强制；团队管理员可设定回退策略（如未命中术语则使用默认翻译）。
+时序图（文字版）2 – 术语匹配流程
+User           TLA ME           Gateway/API       GlossaryService      ModelAdapter |               |                   |                  |                  | |--translate-->|--/translate------>|--fetchGlossary-->|--getEntries---->|  | |               |                   |<--entries--------|                  |  | |               |--applyGlossary-->|------------------>|--applyGlossary-->|--Model pre-process |               |                   |                  |<--glossApplied--|  | |               |--call model----->|--/translate------>|--Model.translate| |               |                   |<--translated-----|<---------------|  |
+文字说明：翻译请求到达网关后，先从 GlossaryService 取回匹配到的术语；然后对源文本进行术语替换，再调用模型进行翻译；返回译文供前端显示。若术语和默认翻译冲突，前端弹窗供用户决策。
+多模型路由
+模型适配层：封装多个模型提供商，暴露统一接口，包括 /translate、/detect、/rewrite、/summarize。模型适配层根据租户配置和策略选择合适的模型进行调用；支持 OpenAI API、Azure OpenAI、Anthropic Claude、Google Translate、Ollama 本地模型等。
+路由策略：管理员在租户配置中设置模型列表 {ModelAllowList}，可根据成本、延迟、质量、合规要求排序。当首选模型不可用或响应超时（超过 15 秒[7]），自动回退至次级模型，并记录回退事件。
+成本控制：网关根据模型调用成本估算每次请求的费用并与每日预算 {DailyBudget} 对比；若预计超过预算，则拒绝请求并提示用户“今日翻译预算已用尽”。Azure Translator 按字符计费[8]，需实时统计翻译字符数。
+延迟优化：对小于 100 字符的请求，期望在 300 毫秒内返回翻译[7]；超过字符阈值将分片并行翻译；每个模型连接最大并发限制由管理员配置，默认不超过 5 并发请求。
+时序图（文字版）3 – 多模型路由与回退
+User           TLA ME         Gateway/API       ModelAdapter        ProviderA  ProviderB |               |                 |                  |               |          | |--translate-->|--/translate---->|--selectModel---->|--call A------>|--OK?     | |               |                 |                  |<--error/timeout---------| |               |                 |--retryModel----->|--call B------>|--translated |               |                 |<--translated-----|<---------------|          |
+文字说明：当首选模型（Provider A）响应错误或超时时，模型适配层根据路由策略选择 Provider B 继续翻译；网关记录耗时与成本并返回给前端。
+成本/延迟控制
+字数阈值与分片：根据 Azure Translator 每请求 50k 字符限制[5]，接口预处理将长文本分成不超过 5k 字符的片段；对于超过 2 万字符的文本，排入异步队列进行批量翻译，前端以草稿形式存储，待完成后通知用户。
+缓存与去重：在模型适配层实现语义去重缓存，使用向量索引保存近期翻译结果；对重复句子直接返回缓存，避免重复费用。可配置 TTL（默认 24 小时）和租户隔离。
+并发与速率限制：遵守第三方翻译服务的字符/小时限额：Azure Translator F0 层每小时 2 M 字符[9]；同时控制请求速率均匀分布。网关对每个租户和模型维度实施令牌桶限流，防止瞬时流量过高。
+质量增强
+上下文引用：在翻译时携带上下文摘要（如线程标题、前几条消息），帮助模型理解语境。通过调用 /summarize 接口生成上下文摘要，再拼接入翻译请求。
+可选 RAG：在专业场景，用户可启用 RAG 模式，通过检索企业知识库或公开文档获取补充材料，结合大模型产生更准确的译文。RAG 可以从外部文档或向量数据库中检索相关内容[2]，进而提高准确性；它能提供更高的命中率和准确性以及域专业化优势[10]。
+风格锁定：使用提示工程确保译文保持一致文风，结合用户历史译文训练的小模型微调实现；默认提供四种语气模板，未来支持自定义。若模型风格输出偏差较大，系统自动触发 /rewrite 调整风格。
+审计与可追溯
+日志内容：审计系统存储每个翻译的原文、译文、时间戳、操作者、使用模型 ID、参数配置、成本、延迟、模型响应 ID 等信息。审计数据按租户隔离，审计员可用时间范围和过滤条件查询。
+权限控制：审计员身份由租户管理员授权，不可修改译文；日志只读，提供导出功能（CSV/JSON）。
+不可逆哈希：为避免泄露原文，在日志中存储原文指纹（例如 SHA256 哈希 + 盐）而非全文；只有持有审计密钥的管理员才能解密。
+合规留痕：记录是否启用了术语库、禁译库、RAG、语言检测等功能；便于审计时复盘与责任追溯。
+Microsoft Teams 宿主能力映射
+宿主能力
+落地方式
+描述
+Message Extension（ME）
+撰写区触发、选择消息触发
+用户在撰写区点击插件图标或在消息“更多操作”选择“TLA”，弹出对话框显示翻译结果；支持搜索和列表视图[6]。
+Bot
+命令词/上下文卡片
+Bot 处理与外部 API 的通信；可支持命令如 /translate、/help，并通过 Adaptive Card 回贴译文。
+Compose Box 插件
+内联建议与替换
+在撰写区实时监测输入的外语，提示用户是否翻译；提供一键替换文本为目标语言。
+Tab
+个人/团队设置页面
+管理模型密钥、术语库、策略；提供文件上传以导入术语库 ({GlossarySources})；展示使用统计和预算。
+Graph/身份与权限
+AAD/OBO、SSO、租户级密钥管理
+使用 Single Sign On 简化登录[11]；Bot 通过 OBO 流程代表用户调用翻译 API，传递其身份和权限[3]；租户密钥存储在 Azure Key Vault。
+UI/UX 明细
+总体布局
+由于未提供具体草图，本说明基于微软 Teams UI Kit 及通用设计模式进行推测性还原。所有尺寸和间距可按草图调整。
+桌面端
+顶部工具条：高度 48 px，横向排列控制项，包含：
+模型选择下拉框：宽 120 px，显示当前模型名称，可展开选择列表。
+语种切换：两个下拉框，分别为“源语言”（默认为自动）和“目标语言”（默认为用户首选），各宽 100 px。
+术语策略开关：Toggle 控件，启用/禁用术语库应用。
+成本/延迟提示：文本标签，显示本次翻译预计成本（字符数×单价）与估算延迟，如“成本：0.03$ | 延迟：300ms”。
+控件间水平间距 8 px。
+主区：占用宽度自适应，高度可滚动，分为左右两栏：
+原文块：左栏，宽度 50%，背景浅灰，内含原文文本的只读框，支持复制；顶部显示源语言；底部显示字符数。
+译文块：右栏，宽度 50%，背景白色或淡黄色，用于显示模型生成的译文；当进入编辑模式时变为可编辑文本域；其下方放置“回贴/发送”按钮（主按钮，宽 88 px，高 32 px，圆角 4 px）和“取消”按钮。
+两栏之间间距 16 px；整体外边距 20 px。
+悬浮/快捷入口：当用户在消息中选中文本时，在选区附近显示浮动操作条（高度 32 px）；包含“翻译”按钮（图标 + 文本）和“翻译并回复”按钮。浮动条背景为 Fluent UI Neutral 轻色，阴影不遮挡原文。
+移动端
+布局改为上下排列：由于屏幕宽度有限，原文块在上、译文块在下；顶部工具条滚动为水平可滑动列表，允许左右滑动查看所有控制项。
+按钮尺寸增加：确保触控友好；按钮高度 ≥ 40 px，间距 12 px。
+回复卡片：在消息线程中显示紧凑版本，提供切换语言按钮，点击后在全屏对话框中展示完整译文及原文。
+默认文案与国际化 Key
+区域
+默认文案
+i18n Key
+模型选择下拉
+“选择模型”
+tla.ui.modelSelector.placeholder
+源语言下拉
+“自动检测”
+tla.ui.sourceLang.auto
+目标语言下拉
+“目标语言”
+tla.ui.targetLang.placeholder
+术语开关
+“应用术语库”
+tla.ui.glossary.toggle
+成本提示
+“预计成本：{cost}，延迟：{latency}”
+tla.ui.costLatency
+原文标题
+“原文 ({lang})”
+tla.ui.source.title
+译文标题
+“译文 ({lang})”
+tla.ui.translation.title
+编辑提示
+“您可以修改译文后发送”
+tla.ui.editable.hint
+发送按钮
+“发送”
+tla.ui.send
+取消按钮
+“取消”
+tla.ui.cancel
+悬浮条翻译
+“翻译”
+tla.ui.hover.translate
+悬浮条翻译并回复
+“翻译并回复”
+tla.ui.hover.translateReply
+Traceability 表
+下表展示界面控件、交互、调用 API 和验收用例之间的关系。
+控件
+用户交互
+调用 API/工具
+验收用例
+模型选择下拉
+选择不同模型
+更新模型适配层的 modelHints; 调用 /translate 时传入
+Given 用户切换模型，When 再次翻译时使用新的模型并显示模型 ID；Then 翻译成本和延迟变化记录。
+源语言下拉
+手动指定源语言
+将 sourceLang 传入 /translate，跳过检测
+Given 检测置信度低，When 用户手动选择源语言，Then 翻译结果应改变且不再提示自动检测。
+目标语言下拉
+切换目标语种
+更新 targetLang 参数
+Given 用户切换目标语言，Then 翻译文本立即刷新为新语言。
+术语库开关
+开启或关闭术语应用
+设置 glossaryPolicy；调用 /applyGlossary
+Given 术语库开启，When 翻译包含术语，Then 显示术语识别和三选项提示。
+成本/延迟提示
+查看成本估算
+调用 tla.getCostLatency(payloadSize, modelId)
+Given 输入文本长度变化，Then 提示中的成本和延迟自动更新。
+原文文本框
+只读展示原文
+无 API 调用
+Given 大文本时，文本框滚动正常，不允许编辑。
+译文文本框
+展示并允许编辑译文
+初始调用 /translate; 编辑后调用 /rewrite
+Given 用户编辑译文并发送，Then 回贴卡片内容应是编辑后的文本。
+发送按钮
+点击发送译文
+调用 tla.replyInThread
+Given 用户点击发送，Then Adaptive Card 显示在原消息线程并包含原文引用。
+悬浮条翻译按钮
+快速查看译文
+调用 /translate，在卡片内展示
+Given 选中文本，When 点击翻译，Then 卡片内显示译文。
+悬浮条翻译并回复
+快速翻译并弹出编辑
+调用 /translate + 进入编辑模式
+Given 选中文本，When 点击翻译并回复，Then 弹出完整编辑对话框可发送。
+Tab 上传按钮
+上传术语库文件
+调用 /applyGlossary 上传端点
+Given 上传 CSV 文件成功，Then 术语库条目可用于翻译并在系统管理界面显示。
+架构设计
+高层架构文字描述
+Teams 客户端 ←→ TLA 插件（Message Extension/Bot/Tab） ←→ 网关（API） ←→ 模型适配层（Provider SDK） ←→ 术语/RAG/缓存/审计存储
+Teams 客户端：包括桌面端、移动端和 Web。用户通过消息扩展、Bot 或撰写区插件与 TLA 交互。
+TLA 插件：前端部分由 Teams JS SDK 实现，实现 UI 渲染和用户交互逻辑；通过消息扩展调用后端 API；在 Bot 场景下接收命令并触发翻译；在 Tab 页面用于设置。
+网关（API）：核心后端服务，提供 REST 或 Graph 类接口，负责身份验证、速率限制、日志记录、成本计费、请求路由和错误处理。网关通过 OBO 流程获取用户访问令牌并保护下游服务安全。
+模型适配层：抽象不同提供商接口，统一实现 /translate、/detect、/rewrite、/summarize 方法。每个 Provider 插件实现 Provider SDK 的抽象类，负责调用相应的 API（如 OpenAI、Azure Translator 等），并返回标准化响应。
+术语/RAG/缓存/审计存储：
+术语库服务：存储和检索术语条目，根据用户租户和优先级返回匹配词汇；支持 CSV/TermBase 导入和词条管理。
+RAG 知识库：可选组件，保存向量化的文档和消息历史，为翻译提供上下文检索能力。
+缓存服务：保存近期翻译的结果，提供语义去重和 TTL 管理；按租户隔离。
+审计存储：持久化审计日志；根据 {RegionPolicy} 部署在相应区域，满足数据主权要求。
+组件职责、边界与接口
+组件
+职责
+接口
+Gateway/API
+调度请求；权限校验；租户隔离；负载均衡；成本计费；错误处理
+REST API /translate, /detect, /rewrite, /summarize, /applyGlossary, /replyInThread, /getCostLatency；WebSocket 用于异步通知。
+ModelAdapter
+根据租户配置路由请求到不同模型；封装不同模型协议；统一返回格式
+Provider SDK 抽象类，定义 translate(text, sourceLang, targetLang, options), detect(text), rewrite(text, tone), summarize(text) 等；针对 OpenAI/Azure/Anthropic/Ollama 等实现各自适配器。
+GlossaryService
+管理术语与禁译库；提供三层级优先级合并；支持批量上传和检索
+getEntries(text, tenantId, channelId, userId), applyGlossary(text, glossaryIds[], policy), uploadGlossary(file).
+RAGService (可选)
+检索上下文和知识文档并生成参考片段
+retrieve(query, topK), embed(text), addDocument(doc)；返回匹配文本供模型提示。
+CacheService
+保存翻译结果和检测结果；提供向量索引实现语义匹配
+get(key), set(key, value, ttl), searchSimilar(embedding)；单租户隔离。
+AuditService
+记录翻译任务和响应；提供审计查询接口；支持不可逆哈希
+log(entry), query(filter), export(format)；仅审计员可访问。
+QueueService
+处理超长文本与离线任务；支持重试与重组
+enqueue(job), dequeue(), updateStatus(jobId, status)；保证任务执行顺序和幂等性。
+缓存策略
+语义去重：使用向量索引（如 cosine similarity）比较新翻译请求与缓存中已有请求；相似度 > 0.95 则直接返回缓存结果，减少重复费用。
+TTL 管理：缓存条目默认 24 小时，管理员可配置；命中率统计用于监控。
+租户隔离：缓存按 TenantId 分区，防止数据串用。
+异步队列与重试
+分片规则：当文本长度 > 5k 字符时，拆分为句子或段落片段，生成任务列表；每个任务含文本片段、顺序号和重试计数；入队后异步翻译。
+并行翻译：队列工作者根据模型并发限制拉取任务并处理；翻译完成后在任务合并器中按顺序拼接译文。
+失败重试：每个任务支持 3 次重试；失败原因记录在审计日志中；当重试用尽时，将任务标记为失败并通知用户。
+长文本回调：网关通过 WebSocket 或 Teams Notification 卡片向用户推送完成通知；用户可在草稿列表查看并发送译文。
+MCP Server 与 Agent 扩展预留
+MCP（Model Context Protocol）允许外部智能体以结构化方式调用 TLA 能力，使得 Copilot 等 Agent 能够协同翻译任务。
+MCP 高层设计
+MCP Server：托管在 TLA 网关内，暴露一组工具方法供 Agent 调用；根据智能体请求安全地代理到实际功能。
+Agent 扩展：在 Copilot 或第三方 Agent 中注册 TLA 工具，使智能体可以使用 translate、detectLanguage、applyGlossary、replyInThread 等能力。
+安全模型：每个工具调用包含 tenantId、channelId、userId 等标识，通过 token 交换和权限裁剪确保仅在授权范围内执行。外部 Agent 只能使用只读工具（如检测语言、获取成本）或在授权的消息线程中使用可写工具（如 replyInThread）。
+MCP Tools 规范（示例 JSON Schema）
+{  "$schema": "http://json-schema.org/draft-07/schema#",  "title": "tla.translate",  "type": "object",  "properties": {    "sourceText": { "type": "string", "description": "待翻译的原文" },    "sourceLang": { "type": "string", "description": "可选的源语言代码" },    "targetLang": { "type": "string", "description": "目标语言代码" },    "tone": { "type": "string", "enum": ["polite", "casual", "business", "technical"], "description": "语气模板" },    "glossaryPolicy": { "type": "string", "enum": ["apply", "bypass", "askOnConflict"], "description": "术语应用策略" },    "modelHints": { "type": "object", "description": "模型路由提示，如优先模型列表" }  },  "required": ["sourceText", "targetLang"]}
+同样的结构可用于其他工具：
+{  "title": "tla.detectLanguage",  "type": "object",  "properties": { "text": { "type": "string" } },  "required": ["text"]}{  "title": "tla.applyGlossary",  "type": "object",  "properties": {    "text": { "type": "string" },    "glossaryIds": { "type": "array", "items": { "type": "string" } },    "policy": { "type": "string", "enum": ["strict", "fallback"] }  },  "required": ["text", "glossaryIds"]}{  "title": "tla.replyInThread",  "type": "object",  "properties": {    "threadId": { "type": "string" },    "replyText": { "type": "string" },    "languagePolicy": { "type": "object", "description": "包含目标语言、语气模板等信息" }  },  "required": ["threadId", "replyText"]}{  "title": "tla.getCostLatency",  "type": "object",  "properties": {    "payloadSize": { "type": "integer" },    "modelId": { "type": "string" }  },  "required": ["payloadSize", "modelId"]}
+事件流
+MessageSelected：用户在消息或撰写区选中文本时触发；可供 Agent 获取上下文。
+BeforeSend：在用户发送译文前触发；可进行术语检查、合规校验。
+AfterTranslate：翻译完成事件；返回译文、成本、延迟等信息。
+PolicyViolation：当检测到敏感词或违背合规策略时触发；包含违规详情和建议处理方式。
+Agent 协作
+仲裁/投票翻译：多个 Agent 可同时调用 tla.translate 提供备选译文；插件根据规则（投票或质量评分）选择最佳结果并呈现给用户。
+链式优化：Agent 可以按顺序调用 detectLanguage → translate → applyGlossary → rewrite → replyInThread，每一步获取前一阶段结果并进行改进。
+数据模型
+核心实体
+实体
+说明
+主键与索引
+TranslationJob
+描述一次翻译任务，包括原文、译文、状态、成本、延迟、模型 ID、片段列表
+主键 JobId；索引 TenantId + CreatedAt；状态字段 Pending/Processing/Completed/Failed；支持子表存储分片任务。
+MessageContext
+保存消息信息：ThreadId、ChannelId、UserId、Timestamp、首选语言等；用于翻译上下文和权限检查
+主键 ContextId；索引 ThreadId；包含外键到用户与频道。
+GlossaryEntry
+术语库条目：源词、目标词、语言对、优先级、备注；可属于特定租户/频道/用户
+主键 EntryId；复合键 TenantId + SourceTerm + TargetLang；索引 GlossaryId。
+Policy
+存储租户配置，包括模型路由、预算、禁译库、RAG 开关、语气模板等
+主键 TenantId；包含 JSON 配置；支持版本控制。
+ProviderConfig
+每个模型提供商的配置：API Key、Endpoint、优先级、费用估算等
+主键 ProviderId；索引 TenantId（多租户各自配置）。
+AuditTrail
+审计记录：JobId、UserId、Action、Timestamp、HashDigest、ModelId、Parameters、ResultStatus
+主键 AuditId；索引 TenantId + Timestamp；存储指纹和敏感字段加密。
+多租户隔离
+TenantId + Partition Key：所有表均以 TenantId 为分区键；数据按租户隔离，保障安全。
+ChannelId & UserId：细粒度标识上下文；在权限层面与 Teams 的授权模型对齐。
+接口契约
+端点与方法
+以 REST 形式示例，亦可通过 Graph 或 WebSocket 实现；所有请求需携带 OAuth Bearer Token。错误码按 HTTP 状态码和业务码组合。
+POST /translate
+请求参数：
+{  "sourceText": "string",  "sourceLang": "string(optional)",  "targetLang": "string",  "tone": "polite|casual|business|technical(optional)",  "glossaryPolicy": "apply|bypass|askOnConflict(optional)",  "modelHints": { "primary": "gpt-4o", "fallback": ["gpt-35-turbo", "ollama:mixtral"] }}
+响应示例：
+{  "jobId": "uuid",  "translatedText": "译文内容",  "modelId": "gpt-4o",  "sourceLang": "en",  "targetLang": "zh",  "toneApplied": "business",  "cost": 0.0023,  "latencyMs": 312}
+错误码：400（参数错误）、402（超出预算）、503（模型不可用）、504（超时）。
+幂等性：通过 jobId 去重；同样的 sourceText + targetLang 若参数相同，则返回缓存结果。
+速率限制：按租户限制请求频率，默认 60 QPS；大于限额返回 429。
+POST /detect
+请求：{ "text": "string" }
+响应：{ "language": "code", "confidence": 0.93 }
+限额：单次请求不得超过 50k 字符[5]；超出返回 413。
+POST /rewrite
+请求：{ "text": "译文", "tone": "business" }
+响应：{ "rewrittenText": "调整后的译文" }
+用于用户编辑译文后，通过模型微调语气。
+POST /summarize
+请求：{ "context": "多条消息文本" }
+响应：{ "summary": "简短摘要" }
+用于质量增强时提供上下文摘要。
+POST /applyGlossary
+请求：{ "text": "string", "glossaryIds": ["g1","g2"], "policy": "strict|fallback" }
+响应：{ "processedText": "已替换术语的文本", "matches": [ {"term":"CPU","translation":"中央处理器"} ] }
+如果 policy 为 fallback，当未匹配到术语时直接返回原文。
+POST /replyInThread
+请求：{ "threadId": "id", "replyText": "译文内容", "languagePolicy": {"targetLang": "zh", "tone": "business"} }
+响应：{ "messageId": "id", "status": "sent" }
+通过 Bot 调用 Teams API 发送 Adaptive Card。错误码 403 表示无权限写入线程。
+GET /getCostLatency
+请求参数：payloadSize（整数），modelId（字符串）。
+响应：估算的成本和延迟，例如：{ "cost": 0.0015, "latencyMs": 250 }。
+根据模型定价和服务限制预估；用以 UI 提前提示用户。
+鉴权
+使用 Azure AD OAuth2，采用 SSO 流程，当用户已在 Teams 中登录时无需再次登录[11]。
+后端 API 使用 OBO 流程将用户令牌换取访问下游服务的令牌[3]，确保调用采用用户的委托权限。
+租户管理员可在 Tab 页面配置应用权限，指定哪些频道或用户可以调用写操作；超出范围时返回 403。
+错误码
+代码
+描述
+处理建议
+400
+请求参数无效，如缺失必填字段
+检查参数格式并重试
+401
+未授权或 token 过期
+重新登录或刷新 token
+402
+超出成本预算
+等待下一日或联系管理员增额
+403
+无权限执行操作，如在未授权的频道发送
+检查租户策略或申请权限
+413
+请求体过大，超过字符限制 50k[5]
+将文本分片或使用离线草稿
+429
+速率限制触发
+稍后重试或降低并发
+503
+模型提供商不可用
+系统将自动回退，建议稍后重试
+504
+模型调用超时（>15 秒）[7]
+系统已自动回退，若仍失败则通知用户
+安全与合规
+数据主权：所有数据处理均遵循 {RegionPolicy}。用户数据在所在地区处理，不跨境传输。模型提供商必须在相应地区部署。
+PII/PHI 保护：在翻译请求中识别个人身份信息和健康信息，除非用户显式授权，不将其发送到公有模型。敏感场景（金融、医疗）通过禁译库确保不翻译敏感词。
+密钥托管：租户管理员在 Tab 中配置模型 API 密钥，存储于 Azure Key Vault；网关通过托管身份访问密钥，杜绝明文传输。
+日志与留痕：审计日志包含指纹和时间线，审计员可追溯；使用不可逆哈希保护原文[1]。
+误译纠错与人工复核：为高风险场景提供“人工复核模式”，译文先生成草稿，由专业译者复核后方可发送；管理员可配置触发场景（例如包含医疗术语或检测到低置信度）。
+性能与容量
+指标
+目标
+说明
+端到端 P95 延迟
+≤ 2 秒（短文本）；≤ 5 秒（中等文本）
+包括网络、检测、翻译、回贴时延
+端到端 P99 延迟
+≤ 5 秒（短文本）；≤ 10 秒（中等文本）
+针对异常情况；超过阈值触发重试或回退
+最大并发请求
+≥ 1000 RPS
+通过横向扩展网关和模型适配层保证
+长文本分片上限
+每条翻译请求拆分的片段数 ≤ 10
+避免合并过多片段造成性能下降
+缓存命中率
+≥ 40 %（MVP）
+通过向量索引提升命中率
+监控与告警
+可观测性指标：成功率、超时率、平均/95/99 延迟、每模型成本、缓存命中率、术语冲突率、RAG 检索耗时等。
+日志采集：使用集中式日志服务收集网关、模型适配层、队列等组件日志；日志以结构化格式存储。
+告警策略：
+当失败率 > 5 % 或延迟 > 3 秒持续 5 分钟触发告警。
+当某个模型成本急剧上升（超出预算 50 %）时提醒管理员切换模型。
+当缓存命中率低于 20 % 时提示优化术语库或查询策略。
+验收标准与测试用例
+测试用例按功能、兼容、无障碍、安全、恢复力、多租户和回归分类。以下示例：
+功能测试
+Given
+When
+Then
+用户查看外语消息
+点击“翻译”按钮
+系统自动检测语言并在原文下方显示译文；用户可切换目标语言
+用户选中文本
+点击“翻译并回复”
+弹出对话框显示原文与译文，允许编辑，并显示发送按钮
+用户开启术语库
+翻译文本包含术语
+提示术语匹配并提供遵循/保留/折衷选项；译文中应用术语
+模型 A 不可用
+翻译请求发生超时 > 15 秒
+系统自动回退到模型 B，记录回退原因并返回译文
+翻译字符 > 50k
+发送翻译请求
+API 返回错误码 413，提示用户拆分或离线草稿
+达到每日成本上限
+用户继续发送翻译
+API 返回 402，提示预算耗尽，不再处理
+审计员查询记录
+提供时间范围过滤
+返回符合条件的翻译记录，包含原文指纹、译文、操作者等；敏感内容可遮蔽
+兼容性测试
+在 Windows、macOS、iOS、Android 客户端测试插件界面和交互，确保布局响应式；
+使用深色、高对比度主题检查 UI 是否遵循 Teams 颜色令牌[12]。
+无障碍测试
+所有控件支持键盘导航，提供清晰的焦点状态；
+插件文本可被屏幕阅读器读出；
+颜色对比符合 WCAG 标准；提供“Alt”文本和 ARIA 标签。
+安全测试
+检查 OAuth 流程，确保 access token 不被泄露；
+注入测试：验证恶意输入不会被注入到下游模型或数据库；
+权限测试：普通用户无权访问审计接口；租户之间数据隔离。
+恢复力测试
+模拟模型服务不可用，验证系统自动回退并提供提示；
+模拟网络中断，验证离线草稿保存与恢复；
+重试逻辑：对 transient error 重试 3 次并记录。
+多租户测试
+在两个租户分别配置不同模型和术语库，确保数据互不影响；
+在租户 A 的频道发送翻译请求，租户 B 无法获取结果或日志。
+回归测试
+每次版本迭代后执行完整测试集，确保新增功能不影响原有流程。
+里程碑与发布策略
+阶段
+时间
+内容
+MVP 私有预览
+第 0–2 个月
+完成基础翻译、术语库、双向回复、成本控制、审计日志；在选定租户内试点；收集反馈和故障记录。
+公测 Beta
+第 3–5 个月
+扩展到更多租户；加入多模型路由与回退；支持离线草稿和移动端优化；完善监控与告警；开放 MCP Server。
+正式版 GA
+第 6 个月
+根据反馈优化 UI 和性能；支持 RAG 与风格锁定；发布术语上传管理；通过合规审核。
+vNext
+第 6 个月之后
+开发多语广播、仲裁翻译、智能 Agent 协同、人机共译等高级功能；持续迭代。
+发布策略采用灰度发布：先在小部分租户启用新功能，监控指标稳定后逐步扩大；支持一键回滚到前一版本，确保风险可控。
+风险清单与对策
+风险
+影响
+对策
+API 限流或停用
+第三方模型限额导致翻译失败
+提前设置多模型路由；监控各模型配额；在预算耗尽前切换到备用模型
+模型不可用或质量波动
+翻译质量下降
+实施 A/B 对比和回退策略；允许管理员手动禁用模型；多提供商冗余
+术语冲突
+译文不符合规范或含有歧义
+提示用户选择处理方式；记录冲突率；持续优化术语库管理
+长文本卡顿
+性能下降和用户体验差
+实施分片和异步队列；提供离线草稿；限制单次翻译长度
+合规审计要求突增
+日志存储压力与响应性能
+优化日志存储结构，增加索引；使用分区存储；扩展审计服务容量
+数据泄露风险
+可能违反隐私法规
+加强密钥管理；使用加密传输和不可逆哈希；定期安全审计
+附录
+术语与缩写
+缩写
+含义
+PII
+Personally Identifiable Information，个人身份信息
+PHI
+Protected Health Information，受保护的健康信息
+RAG
+Retrieval Augmented Generation[2]
+OBO
+On-behalf-of 授权[3]
+LLM
+Large Language Model
+示例术语库条目
+源词,目标词,源语言,目标语言,备注CPU,中央处理器,en,zh,技术术语请保留完整翻译compliance,合规,en,zh,金融行业专用Connected,Connected,en,es,品牌名禁止翻译
+消息卡片 JSON 示例
+{  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",  "type": "AdaptiveCard",  "version": "1.5",  "body": [    {      "type": "TextBlock",      "text": "译文",      "wrap": true,      "size": "Medium",      "weight": "Bolder"    },    {      "type": "TextBlock",      "text": "原文: ...",      "wrap": true,      "isSubtle": true,      "spacing": "None"    }  ],  "actions": [    {      "type": "Action.ShowCard",      "title": "查看原文",      "card": {        "type": "AdaptiveCard",        "body": [          { "type": "TextBlock", "text": "原文内容", "wrap": true }        ],        "actions": [],        "version": "1.5"      }    },    {      "type": "Action.Submit",      "title": "切换译文语言",      "data": { "action": "changeLanguage" }    }  ]}
+配置清单
+配置项
+说明
+{RegionPolicy}
+数据主权策略，如“欧盟优先”，“中国境内”等
+{ModelAllowList}
+允许使用的大模型及优先级列表，如 ["azureOpenAI:gpt-4o", "anthropic:claude-3", "ollama:llama3"]
+{DailyBudget}
+每个租户每日成本上限，例如 10 USD
+{ComplianceRefs}
+遵循的安全与合规框架，如 ISMAP、SOC2、ISO27001
+{GlossarySources}
+术语库来源，如 CSV 文件、TermBase 格式或外部词典 API
+本说明书结合 Teams 插件的设计原则和翻译服务的最佳实践编写，并使用最新文档提供的权威信息，如消息扩展应避免将用户带离对话、集成单点登录[4]、翻译服务字符和延迟限制[5][7]、术语库重要性[1]、RAG 优势[2][10]和 OBO 授权模型[3]等，为研发团队提供可执行的方案。在执行过程中，请始终遵守用户数据保护和合规要求，同时根据实际草图调整 UI 尺寸与布局。
+[1] A Detailed Guide to Machine Translation Glossaries | Phrase
+https://phrase.com/blog/posts/machine-translation-glossaries/
+[2] [10] Retrieval Augmented Generation (RAG): A Complete Guide - WEKA
+https://www.weka.io/learn/guide/ai-ml/retrieval-augmented-generation/
+[3] Microsoft identity platform and OAuth2.0 On-Behalf-Of flow - Microsoft identity platform | Microsoft Learn
+https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-on-behalf-of-flow
+[4] [6] [11] [12] Designing your message extension - Teams | Microsoft Learn
+https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/design/messaging-extension-design
+[5] [7] [8] [9] Service limits - Translator Service - Azure AI services | Microsoft Learn
+https://learn.microsoft.com/en-us/azure/ai-services/translator/service-limits

--- a/src/TlaPlugin/Configuration/PluginOptions.cs
+++ b/src/TlaPlugin/Configuration/PluginOptions.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+
+namespace TlaPlugin.Configuration;
+
+/// <summary>
+/// 描述插件核心配置的选项。
+/// </summary>
+public class PluginOptions
+{
+    public int MaxCharactersPerRequest { get; set; } = 50000;
+    public decimal DailyBudgetUsd { get; set; } = 25m;
+    public TimeSpan DraftRetention { get; set; } = TimeSpan.FromDays(7);
+    public TimeSpan CacheTtl { get; set; } = TimeSpan.FromHours(24);
+    public int MaxConcurrentTranslations { get; set; } = 4;
+    public int RequestsPerMinute { get; set; } = 120;
+    public string OfflineDraftConnectionString { get; set; } = "Data Source=tla-offline.db";
+    public IList<string> SupportedLanguages { get; set; } = new List<string>
+    {
+        "ja-JP",
+        "en-US",
+        "zh-CN",
+        "zh-TW",
+        "ko-KR",
+        "fr-FR"
+    };
+    public IList<string> DefaultTargetLanguages { get; set; } = new List<string>
+    {
+        "ja-JP",
+        "en-US"
+    };
+    public IList<ModelProviderOptions> Providers { get; set; } = new List<ModelProviderOptions>();
+    public CompliancePolicyOptions Compliance { get; set; } = new();
+    public SecurityOptions Security { get; set; } = new();
+}
+
+/// <summary>
+/// 用于说明模型提供方配置的结构。
+/// </summary>
+public class ModelProviderOptions
+{
+    public string Id { get; set; } = "mock";
+    public ModelProviderKind Kind { get; set; } = ModelProviderKind.Mock;
+    public decimal CostPerCharUsd { get; set; } = 0.00002m;
+    public int LatencyTargetMs { get; set; } = 300;
+    public double Reliability { get; set; } = 0.99;
+    public IList<string> Regions { get; set; } = new List<string> { "global" };
+    public IList<string> Certifications { get; set; } = new List<string>();
+    public int SimulatedFailures { get; set; }
+        = 0;
+    public string TranslationPrefix { get; set; } = string.Empty;
+    public string Endpoint { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public string ApiKeySecretName { get; set; } = string.Empty;
+    public string Organization { get; set; } = string.Empty;
+    public IDictionary<string, string> DefaultHeaders { get; set; } = new Dictionary<string, string>();
+}
+
+/// <summary>
+/// 标识模型提供方类型的枚举。
+/// </summary>
+public enum ModelProviderKind
+{
+    Mock,
+    OpenAi,
+    Anthropic,
+    Groq,
+    OpenWebUi,
+    Ollama,
+    Custom
+}
+
+/// <summary>
+/// 合规策略的配置值。
+/// </summary>
+public class CompliancePolicyOptions
+{
+    public IList<string> RequiredRegionTags { get; set; } = new List<string>();
+    public IList<string> AllowedRegionFallbacks { get; set; } = new List<string>();
+    public IList<string> RequiredCertifications { get; set; } = new List<string>();
+    public IList<string> BannedPhrases { get; set; } = new List<string>();
+    public IDictionary<string, string> PiiPatterns { get; set; } = new Dictionary<string, string>
+    {
+        ["email"] = @"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}",
+        ["phone"] = @"\\+?[0-9]{8,15}",
+        ["creditCard"] = @"[0-9]{13,16}"
+    };
+}
+
+/// <summary>
+/// 管理密钥与 OBO 认证的配置。
+/// </summary>
+public class SecurityOptions
+{
+    public string KeyVaultUri { get; set; } = "https://localhost.vault.azure.net/";
+    public string ClientId { get; set; } = "00000000-0000-0000-0000-000000000000";
+    public string ClientSecretName { get; set; } = "tla-client-secret";
+    public string UserAssertionAudience { get; set; } = "api://tla-plugin";
+    public TimeSpan AccessTokenLifetime { get; set; } = TimeSpan.FromMinutes(30);
+    public TimeSpan SecretCacheTtl { get; set; } = TimeSpan.FromMinutes(10);
+    public IDictionary<string, string> SeedSecrets { get; set; } = new Dictionary<string, string>
+    {
+        ["tla-client-secret"] = "local-dev-secret"
+    };
+}

--- a/src/TlaPlugin/Models/ConfigurationSummary.cs
+++ b/src/TlaPlugin/Models/ConfigurationSummary.cs
@@ -1,0 +1,27 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 提供给前端的配置摘要。
+/// </summary>
+public record ConfigurationSummary(
+    int MaxCharactersPerRequest,
+    decimal DailyBudgetUsd,
+    int RequestsPerMinute,
+    int MaxConcurrentTranslations,
+    IReadOnlyList<string> SupportedLanguages,
+    IReadOnlyList<string> DefaultTargetLanguages,
+    IReadOnlyDictionary<string, string> ToneTemplates,
+    IReadOnlyList<ModelProviderSummary> Providers,
+    int GlossaryEntryCount);
+
+/// <summary>
+/// 面向前端的模型提供方概要信息。
+/// </summary>
+public record ModelProviderSummary(
+    string Id,
+    ModelProviderKind Kind,
+    double Reliability,
+    decimal CostPerCharUsd,
+    int LatencyTargetMs,
+    IReadOnlyList<string> Regions,
+    IReadOnlyList<string> Certifications);

--- a/src/TlaPlugin/Models/DetectionResult.cs
+++ b/src/TlaPlugin/Models/DetectionResult.cs
@@ -1,0 +1,6 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 表示语言识别结果的值对象。
+/// </summary>
+public record DetectionResult(string Language, double Confidence);

--- a/src/TlaPlugin/Models/GlossaryEntry.cs
+++ b/src/TlaPlugin/Models/GlossaryEntry.cs
@@ -1,0 +1,6 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 表示需求文档三层术语整合的条目。
+/// </summary>
+public record GlossaryEntry(string Source, string Target, string Scope, IDictionary<string, string>? Metadata = null);

--- a/src/TlaPlugin/Models/OfflineDraftRecord.cs
+++ b/src/TlaPlugin/Models/OfflineDraftRecord.cs
@@ -1,0 +1,17 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 存储在 SQLite 中的草稿记录。
+/// </summary>
+public class OfflineDraftRecord
+{
+    public long Id { get; set; }
+        = 0;
+    public string UserId { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string OriginalText { get; set; } = string.Empty;
+    public string TargetLanguage { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+        = DateTimeOffset.UtcNow;
+    public string Status { get; set; } = "PENDING";
+}

--- a/src/TlaPlugin/Models/OfflineDraftRequest.cs
+++ b/src/TlaPlugin/Models/OfflineDraftRequest.cs
@@ -1,0 +1,12 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 离线草稿的保存请求。
+/// </summary>
+public class OfflineDraftRequest
+{
+    public string OriginalText { get; set; } = string.Empty;
+    public string TargetLanguage { get; set; } = "ja";
+    public string TenantId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+}

--- a/src/TlaPlugin/Models/ProjectStatusSnapshot.cs
+++ b/src/TlaPlugin/Models/ProjectStatusSnapshot.cs
@@ -1,0 +1,29 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 展示项目整体进度的快照。
+/// </summary>
+public record ProjectStatusSnapshot(
+    string CurrentStageId,
+    IReadOnlyList<StageStatus> Stages,
+    IReadOnlyList<string> NextSteps,
+    int OverallCompletionPercent,
+    FrontendProgress Frontend);
+
+/// <summary>
+/// 各开发阶段的状态。
+/// </summary>
+public record StageStatus(
+    string Id,
+    string Name,
+    string Description,
+    bool Completed);
+
+/// <summary>
+/// 前端准备度的详细指标。
+/// </summary>
+public record FrontendProgress(
+    int CompletionPercent,
+    bool DataPlaneReady,
+    bool UiImplemented,
+    bool IntegrationReady);

--- a/src/TlaPlugin/Models/TranslationRequest.cs
+++ b/src/TlaPlugin/Models/TranslationRequest.cs
@@ -1,0 +1,21 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 表达翻译输入的请求 DTO。
+/// </summary>
+public class TranslationRequest
+{
+    public const string DefaultTone = "polite";
+
+    public string Text { get; set; } = string.Empty;
+    public string? SourceLanguage { get; set; }
+        = null;
+    public string TargetLanguage { get; set; } = "ja";
+    public string TenantId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string? ChannelId { get; set; }
+        = null;
+    public string Tone { get; set; } = DefaultTone;
+    public bool UseGlossary { get; set; } = true;
+    public IList<string> AdditionalTargetLanguages { get; set; } = new List<string>();
+}

--- a/src/TlaPlugin/Models/TranslationResult.cs
+++ b/src/TlaPlugin/Models/TranslationResult.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Nodes;
+
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 保存翻译结果的模型。
+/// </summary>
+public class TranslationResult
+{
+    public string TranslatedText { get; set; } = string.Empty;
+    public string SourceLanguage { get; set; } = string.Empty;
+    public string TargetLanguage { get; set; } = string.Empty;
+    public string ModelId { get; set; } = string.Empty;
+    public double Confidence { get; set; }
+        = 0.0;
+    public decimal CostUsd { get; set; }
+        = 0m;
+    public int LatencyMs { get; set; }
+        = 0;
+    public JsonObject AdaptiveCard { get; set; } = new();
+    public IDictionary<string, string> AdditionalTranslations { get; set; } = new Dictionary<string, string>();
+}

--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+using TlaPlugin.Teams;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Configuration.AddJsonFile("appsettings.json", optional: true);
+
+builder.Services.Configure<PluginOptions>(builder.Configuration.GetSection("Plugin"));
+
+builder.Services.AddMemoryCache();
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton(provider =>
+{
+    var glossary = new GlossaryService();
+    glossary.LoadEntries(new[]
+    {
+        new GlossaryEntry("CPU", "中央处理器", "tenant:contoso"),
+        new GlossaryEntry("compliance", "合规性", "tenant:contoso"),
+        new GlossaryEntry("budget", "预算", "channel:finance"),
+        new GlossaryEntry("reply", "回复", "user:admin")
+    });
+    return glossary;
+});
+
+builder.Services.AddSingleton<ToneTemplateService>();
+builder.Services.AddSingleton<LanguageDetector>();
+builder.Services.AddSingleton(provider => new ComplianceGateway(provider.GetService<IOptions<PluginOptions>>()));
+builder.Services.AddSingleton(provider => new BudgetGuard(provider.GetService<IOptions<PluginOptions>>()?.Value));
+builder.Services.AddSingleton<AuditLogger>();
+builder.Services.AddSingleton(provider => new OfflineDraftStore(provider.GetService<IOptions<PluginOptions>>()));
+builder.Services.AddSingleton<TranslationCache>();
+builder.Services.AddSingleton<TranslationThrottle>();
+builder.Services.AddSingleton<KeyVaultSecretResolver>();
+builder.Services.AddSingleton<ITokenBroker, TokenBroker>();
+builder.Services.AddSingleton<ModelProviderFactory>();
+builder.Services.AddSingleton<TranslationRouter>();
+builder.Services.AddSingleton<TranslationPipeline>();
+builder.Services.AddSingleton<MessageExtensionHandler>();
+builder.Services.AddSingleton<ConfigurationSummaryService>();
+builder.Services.AddSingleton<ProjectStatusService>();
+
+var app = builder.Build();
+
+app.MapPost("/api/translate", async (TranslationRequest request, MessageExtensionHandler handler) =>
+{
+    var result = await handler.HandleTranslateAsync(request);
+    return Results.Json(result, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+});
+
+app.MapPost("/api/offline-draft", async (OfflineDraftRequest request, MessageExtensionHandler handler) =>
+{
+    var result = await handler.HandleOfflineDraftAsync(request);
+    return Results.Json(result, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+});
+
+app.MapGet("/api/configuration", (ConfigurationSummaryService service) =>
+{
+    var summary = service.CreateSummary();
+    return Results.Json(summary, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+});
+
+app.MapGet("/api/glossary", (GlossaryService glossary) =>
+{
+    return Results.Json(glossary.GetEntries(), options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+});
+
+app.MapGet("/api/audit", (AuditLogger auditLogger) =>
+{
+    return Results.Json(auditLogger.Export(), options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+});
+
+app.MapGet("/api/status", (ProjectStatusService statusService) =>
+{
+    var snapshot = statusService.GetSnapshot();
+    return Results.Json(snapshot, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+});
+
+app.Run();

--- a/src/TlaPlugin/Providers/ConfigurableChatModelProvider.cs
+++ b/src/TlaPlugin/Providers/ConfigurableChatModelProvider.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+
+namespace TlaPlugin.Providers;
+
+/// <summary>
+/// 为 OpenAI、Anthropic、Groq、OpenWebUI、Ollama 等聊天补全 API 提供统一封装的模型提供方。
+/// 当未配置实际 API 时会回退到 <see cref="MockModelProvider"/>。
+/// </summary>
+public class ConfigurableChatModelProvider : IModelProvider
+{
+    private readonly IHttpClientFactory? _httpClientFactory;
+    private readonly KeyVaultSecretResolver? _secretResolver;
+    private readonly LanguageDetector _detector = new();
+    private readonly MockModelProvider _fallback;
+
+    public ConfigurableChatModelProvider(ModelProviderOptions options, IHttpClientFactory? httpClientFactory, KeyVaultSecretResolver? secretResolver)
+    {
+        Options = options;
+        _httpClientFactory = httpClientFactory;
+        _secretResolver = secretResolver;
+        _fallback = new MockModelProvider(options);
+    }
+
+    public ModelProviderOptions Options { get; }
+
+    public Task<DetectionResult> DetectAsync(string text, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_detector.Detect(text));
+    }
+
+    public async Task<ModelTranslationResult> TranslateAsync(string text, string sourceLanguage, string targetLanguage, string promptPrefix, CancellationToken cancellationToken)
+    {
+        if (!CanInvokeExternalEndpoint)
+        {
+            return await _fallback.TranslateAsync(text, sourceLanguage, targetLanguage, promptPrefix, cancellationToken);
+        }
+
+        var instructions = $"{promptPrefix} 源语言: {sourceLanguage} / 目标语言: {targetLanguage}";
+        var messages = new List<(string role, string content)>
+        {
+            ("user", text)
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var content = await InvokeChatCompletionAsync(instructions, messages, cancellationToken);
+            stopwatch.Stop();
+            return new ModelTranslationResult(content, Options.Id, Options.Reliability, (int)stopwatch.ElapsedMilliseconds);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            throw new InvalidOperationException($"模型 {Options.Id} 调用失败。", ex);
+        }
+    }
+
+    public async Task<string> RewriteAsync(string translatedText, string tone, CancellationToken cancellationToken)
+    {
+        if (!CanInvokeExternalEndpoint)
+        {
+            return await _fallback.RewriteAsync(translatedText, tone, cancellationToken);
+        }
+
+        var instructions = tone switch
+        {
+            ToneTemplateService.Business => "请将译文润色为正式商务语气。",
+            ToneTemplateService.Technical => "请将译文润色为技术文档所需的严谨表达。",
+            ToneTemplateService.Casual => "请将译文调整为亲切随和的语气。",
+            _ => "请将译文润色为礼貌的敬语。"
+        };
+
+        var messages = new List<(string role, string content)>
+        {
+            ("user", translatedText)
+        };
+
+        try
+        {
+            var content = await InvokeChatCompletionAsync(instructions, messages, cancellationToken);
+            return EnsureToneSuffix(content, tone);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            throw new InvalidOperationException($"模型 {Options.Id} 重写处理失败。", ex);
+        }
+    }
+
+    private bool CanInvokeExternalEndpoint =>
+        _httpClientFactory != null && _secretResolver != null &&
+        !string.IsNullOrWhiteSpace(Options.Endpoint) &&
+        Options.Kind != ModelProviderKind.Mock &&
+        (Options.Kind == ModelProviderKind.Ollama || !string.IsNullOrWhiteSpace(Options.ApiKeySecretName) || Options.DefaultHeaders.Count > 0);
+
+    private async Task<string> InvokeChatCompletionAsync(string instructions, IList<(string role, string content)> messages, CancellationToken cancellationToken)
+    {
+        var client = _httpClientFactory!.CreateClient($"provider-{Options.Id}");
+        using var request = new HttpRequestMessage(HttpMethod.Post, Options.Endpoint);
+
+        AppendHeaders(request.Headers);
+        await AppendAuthorizationAsync(request.Headers, cancellationToken);
+
+        request.Content = new StringContent(BuildRequestPayload(instructions, messages), Encoding.UTF8, "application/json");
+        using var response = await client.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        return ExtractContent(JsonNode.Parse(json));
+    }
+
+    private void AppendHeaders(HttpRequestHeaders headers)
+    {
+        foreach (var kv in Options.DefaultHeaders)
+        {
+            headers.TryAddWithoutValidation(kv.Key, kv.Value);
+        }
+
+        if (!string.IsNullOrEmpty(Options.Organization) && Options.Kind is ModelProviderKind.OpenAi or ModelProviderKind.Groq)
+        {
+            headers.TryAddWithoutValidation("OpenAI-Organization", Options.Organization);
+        }
+
+        if (Options.Kind == ModelProviderKind.Anthropic)
+        {
+            headers.TryAddWithoutValidation("anthropic-version", "2023-06-01");
+        }
+    }
+
+    private async Task AppendAuthorizationAsync(HttpRequestHeaders headers, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(Options.ApiKeySecretName))
+        {
+            return;
+        }
+
+        var secret = await _secretResolver!.GetSecretAsync(Options.ApiKeySecretName, cancellationToken);
+        if (string.IsNullOrWhiteSpace(secret))
+        {
+            return;
+        }
+
+        switch (Options.Kind)
+        {
+            case ModelProviderKind.Anthropic:
+                headers.TryAddWithoutValidation("x-api-key", secret);
+                break;
+            case ModelProviderKind.Ollama:
+                // Ollama 默认无需鉴权，但若配置了 API Key 则以自定义头发送。
+                headers.TryAddWithoutValidation("Authorization", secret);
+                break;
+            default:
+                headers.Authorization = new AuthenticationHeaderValue("Bearer", secret);
+                break;
+        }
+    }
+
+    private string BuildRequestPayload(string instructions, IList<(string role, string content)> messages)
+    {
+        return Options.Kind switch
+        {
+            ModelProviderKind.Anthropic => BuildAnthropicPayload(instructions, messages),
+            ModelProviderKind.Ollama => BuildOllamaPayload(instructions, messages),
+            _ => BuildOpenAiCompatiblePayload(instructions, messages)
+        };
+    }
+
+    private string BuildOpenAiCompatiblePayload(string instructions, IList<(string role, string content)> messages)
+    {
+        var node = new JsonObject
+        {
+            ["model"] = string.IsNullOrWhiteSpace(Options.Model) ? "gpt-3.5-turbo" : Options.Model,
+            ["temperature"] = 0.3,
+            ["messages"] = new JsonArray
+            {
+                new JsonObject { ["role"] = "system", ["content"] = instructions }
+            }
+        };
+
+        var messageArray = node["messages"]!.AsArray();
+        foreach (var message in messages)
+        {
+            messageArray.Add(new JsonObject
+            {
+                ["role"] = message.role,
+                ["content"] = message.content
+            });
+        }
+
+        return node.ToJsonString();
+    }
+
+    private string BuildAnthropicPayload(string instructions, IList<(string role, string content)> messages)
+    {
+        var node = new JsonObject
+        {
+            ["model"] = string.IsNullOrWhiteSpace(Options.Model) ? "claude-3-sonnet-20240229" : Options.Model,
+            ["max_tokens"] = 2048,
+            ["messages"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["role"] = "user",
+                    ["content"] = new JsonArray
+                    {
+                        new JsonObject
+                        {
+                            ["type"] = "text",
+                            ["text"] = instructions + "\n" + string.Join("\n\n", messages.Select(m => m.content))
+                        }
+                    }
+                }
+            }
+        };
+
+        return node.ToJsonString();
+    }
+
+    private string BuildOllamaPayload(string instructions, IList<(string role, string content)> messages)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(instructions);
+        foreach (var message in messages)
+        {
+            builder.AppendLine(message.content);
+        }
+
+        var node = new JsonObject
+        {
+            ["model"] = string.IsNullOrWhiteSpace(Options.Model) ? "llama3" : Options.Model,
+            ["prompt"] = builder.ToString(),
+            ["stream"] = false
+        };
+
+        return node.ToJsonString();
+    }
+
+    private string ExtractContent(JsonNode? node)
+    {
+        if (node is null)
+        {
+            throw new InvalidOperationException("解析模型响应失败。");
+        }
+
+        return Options.Kind switch
+        {
+            ModelProviderKind.Anthropic => node["content"]?.AsArray().FirstOrDefault()?.AsObject()["text"]?.GetValue<string>()
+                ?? throw new InvalidOperationException("Anthropic 响应未包含文本。"),
+            ModelProviderKind.Ollama => node["response"]?.GetValue<string>()
+                ?? throw new InvalidOperationException("Ollama 响应未包含文本。"),
+            _ => node["choices"]?.AsArray().FirstOrDefault()?.AsObject()["message"]?.AsObject()["content"]?.GetValue<string>()
+                ?? throw new InvalidOperationException("OpenAI 兼容响应未包含文本。")
+        };
+    }
+
+    private static string EnsureToneSuffix(string text, string tone)
+    {
+        var suffix = tone switch
+        {
+            ToneTemplateService.Business => "※已调整为商务语气",
+            ToneTemplateService.Technical => "※已调整为技术语气",
+            ToneTemplateService.Casual => "※已调整为亲切语气",
+            _ => "※已调整为敬语"
+        };
+
+        return text.EndsWith(suffix, StringComparison.Ordinal) ? text : $"{text} {suffix}";
+    }
+}

--- a/src/TlaPlugin/Providers/IModelProvider.cs
+++ b/src/TlaPlugin/Providers/IModelProvider.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+
+namespace TlaPlugin.Providers;
+
+/// <summary>
+/// 翻译模型提供方的通用接口。
+/// </summary>
+public interface IModelProvider
+{
+    Task<DetectionResult> DetectAsync(string text, CancellationToken cancellationToken);
+    Task<ModelTranslationResult> TranslateAsync(string text, string sourceLanguage, string targetLanguage, string promptPrefix, CancellationToken cancellationToken);
+    Task<string> RewriteAsync(string translatedText, string tone, CancellationToken cancellationToken);
+    ModelProviderOptions Options { get; }
+}
+
+/// <summary>
+/// 用于在内部保存模型调用结果。
+/// </summary>
+public record ModelTranslationResult(string Text, string ModelId, double Confidence, int LatencyMs);

--- a/src/TlaPlugin/Providers/MockModelProvider.cs
+++ b/src/TlaPlugin/Providers/MockModelProvider.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+
+namespace TlaPlugin.Providers;
+
+/// <summary>
+/// 面向单元测试的模拟模型。
+/// </summary>
+public class MockModelProvider : IModelProvider
+{
+    private int _remainingFailures;
+
+    public MockModelProvider(ModelProviderOptions options)
+    {
+        Options = options;
+        _remainingFailures = options.SimulatedFailures;
+    }
+
+    public ModelProviderOptions Options { get; }
+
+    public Task<DetectionResult> DetectAsync(string text, CancellationToken cancellationToken)
+    {
+        // 使用非常轻量的启发式检测。
+        var detector = new LanguageDetector();
+        return Task.FromResult(detector.Detect(text));
+    }
+
+    public async Task<ModelTranslationResult> TranslateAsync(string text, string sourceLanguage, string targetLanguage, string promptPrefix, CancellationToken cancellationToken)
+    {
+        if (_remainingFailures > 0)
+        {
+            _remainingFailures--;
+            throw new InvalidOperationException($"模型 {Options.Id} 的模拟调用失败");
+        }
+
+        var sw = Stopwatch.StartNew();
+        await Task.Delay(TimeSpan.FromMilliseconds(Math.Min(Options.LatencyTargetMs, 500)), cancellationToken);
+        sw.Stop();
+
+        var prefix = string.IsNullOrEmpty(Options.TranslationPrefix) ? $"[{Options.Id}]" : Options.TranslationPrefix;
+        var output = $"{prefix} {promptPrefix} {text} ({targetLanguage})";
+        return new ModelTranslationResult(output, Options.Id, Options.Reliability, (int)sw.ElapsedMilliseconds);
+    }
+
+    public Task<string> RewriteAsync(string translatedText, string tone, CancellationToken cancellationToken)
+    {
+        // 在此仅对重写逻辑做简单模拟。
+        var suffix = tone switch
+        {
+            ToneTemplateService.Business => "※已调整为商务语气",
+            ToneTemplateService.Technical => "※已调整为技术语气",
+            ToneTemplateService.Casual => "※已调整为亲切语气",
+            _ => "※已调整为敬语"
+        };
+        return Task.FromResult($"{translatedText} {suffix}");
+    }
+}

--- a/src/TlaPlugin/Services/AuditLogger.cs
+++ b/src/TlaPlugin/Services/AuditLogger.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 持久化审计日志以提供合规追溯。
+/// </summary>
+public class AuditLogger
+{
+    private readonly IList<JsonObject> _logs = new List<JsonObject>();
+
+    public void Record(string tenantId, string userId, string modelId, string text, string translation, decimal cost, int latencyMs, string? audience = null, IReadOnlyDictionary<string, string>? additionalTranslations = null)
+    {
+        var hashed = HashText(text);
+        var entry = new JsonObject
+        {
+            ["tenantId"] = tenantId,
+            ["userId"] = userId,
+            ["modelId"] = modelId,
+            ["originalHash"] = hashed,
+            ["translation"] = translation,
+            ["costUsd"] = cost,
+            ["latencyMs"] = latencyMs,
+            ["timestamp"] = DateTimeOffset.UtcNow.ToString("O")
+        };
+        if (!string.IsNullOrEmpty(audience))
+        {
+            entry["audience"] = audience;
+        }
+        if (additionalTranslations is { Count: > 0 })
+        {
+            var extras = new JsonObject();
+            foreach (var kvp in additionalTranslations)
+            {
+                extras[kvp.Key] = kvp.Value;
+            }
+            entry["additionalTranslations"] = extras;
+        }
+        _logs.Add(entry);
+    }
+
+    private static string HashText(string text)
+    {
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(text));
+        return Convert.ToHexString(bytes);
+    }
+
+    public IReadOnlyList<JsonObject> Export() => _logs.ToList();
+}

--- a/src/TlaPlugin/Services/BudgetGuard.cs
+++ b/src/TlaPlugin/Services/BudgetGuard.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Concurrent;
+using TlaPlugin.Configuration;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 追踪成本并确保每日预算不被超额。
+/// </summary>
+public class BudgetGuard
+{
+    private readonly PluginOptions _options;
+    private readonly ConcurrentDictionary<string, decimal> _dailyCosts = new();
+
+    public BudgetGuard(PluginOptions? options = null)
+    {
+        _options = options ?? new PluginOptions();
+    }
+
+    public bool TryReserve(string tenantId, decimal cost)
+    {
+        var key = $"{tenantId}:{DateTime.UtcNow:yyyyMMdd}";
+        var total = _dailyCosts.AddOrUpdate(key, cost, (_, existing) => existing + cost);
+        if (total > _options.DailyBudgetUsd)
+        {
+            _dailyCosts.AddOrUpdate(key, 0, (_, existing) => existing - cost);
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/TlaPlugin/Services/ComplianceGateway.cs
+++ b/src/TlaPlugin/Services/ComplianceGateway.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 负责评估地域、认证与 PII 检测的合规网关。
+/// </summary>
+public class ComplianceGateway
+{
+    private readonly CompliancePolicyOptions _policy;
+    private readonly IDictionary<string, Regex> _piiPatterns;
+
+    public ComplianceGateway(IOptions<PluginOptions>? options = null)
+    {
+        _policy = options?.Value.Compliance ?? new CompliancePolicyOptions();
+        _piiPatterns = _policy.PiiPatterns.ToDictionary(kvp => kvp.Key, kvp => new Regex(kvp.Value, RegexOptions.Compiled));
+    }
+
+    public ComplianceReport Evaluate(string text, ModelProviderOptions provider)
+    {
+        var violations = new List<string>();
+
+        if (!IsRegionAllowed(provider))
+        {
+            violations.Add($"模型提供区域 {string.Join(',', provider.Regions)} 不在允许列表中。");
+        }
+
+        if (!HasRequiredCertifications(provider))
+        {
+            violations.Add("未满足所需的合规认证。");
+        }
+
+        var pii = DetectPii(text).ToList();
+        if (pii.Any())
+        {
+            violations.Add($"检测到敏感信息: {string.Join(',', pii.Select(p => p.Type))}");
+        }
+
+        if (_policy.BannedPhrases.Any(b => text.Contains(b, StringComparison.OrdinalIgnoreCase)))
+        {
+            violations.Add("文本中包含禁止词。");
+        }
+
+        return new ComplianceReport(violations.Count == 0, violations);
+    }
+
+    private bool IsRegionAllowed(ModelProviderOptions provider)
+    {
+        if (_policy.RequiredRegionTags.Count == 0)
+        {
+            return true;
+        }
+        if (provider.Regions.Any(r => _policy.RequiredRegionTags.Contains(r)))
+        {
+            return true;
+        }
+        return provider.Regions.Any(r => _policy.AllowedRegionFallbacks.Contains(r));
+    }
+
+    private bool HasRequiredCertifications(ModelProviderOptions provider)
+    {
+        if (_policy.RequiredCertifications.Count == 0)
+        {
+            return true;
+        }
+        return _policy.RequiredCertifications.All(c => provider.Certifications.Contains(c));
+    }
+
+    private IEnumerable<PiiFinding> DetectPii(string text)
+    {
+        foreach (var pair in _piiPatterns)
+        {
+            if (pair.Value.IsMatch(text))
+            {
+                yield return new PiiFinding(pair.Key);
+            }
+        }
+    }
+}
+
+public record ComplianceReport(bool Allowed, IList<string> Violations);
+public record PiiFinding(string Type);

--- a/src/TlaPlugin/Services/ConfigurationSummaryService.cs
+++ b/src/TlaPlugin/Services/ConfigurationSummaryService.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 生成提供给前端的配置概要信息。
+/// </summary>
+public class ConfigurationSummaryService
+{
+    private readonly IOptions<PluginOptions> _options;
+    private readonly ToneTemplateService _toneTemplates;
+    private readonly GlossaryService _glossary;
+
+    public ConfigurationSummaryService(
+        IOptions<PluginOptions> options,
+        ToneTemplateService toneTemplates,
+        GlossaryService glossary)
+    {
+        _options = options;
+        _toneTemplates = toneTemplates;
+        _glossary = glossary;
+    }
+
+    /// <summary>
+    /// 构建可供 UI 使用的配置信息摘要。
+    /// </summary>
+    public ConfigurationSummary CreateSummary()
+    {
+        var options = _options.Value;
+        var providers = options.Providers
+            .Select(p => new ModelProviderSummary(
+                p.Id,
+                p.Kind,
+                p.Reliability,
+                p.CostPerCharUsd,
+                p.LatencyTargetMs,
+                p.Regions.ToList(),
+                p.Certifications.ToList()))
+            .ToList();
+
+        return new ConfigurationSummary(
+            options.MaxCharactersPerRequest,
+            options.DailyBudgetUsd,
+            options.RequestsPerMinute,
+            options.MaxConcurrentTranslations,
+            options.SupportedLanguages.ToList(),
+            options.DefaultTargetLanguages.ToList(),
+            _toneTemplates.GetAvailableTones(),
+            providers,
+            _glossary.GetEntries().Count);
+    }
+}

--- a/src/TlaPlugin/Services/GlossaryService.cs
+++ b/src/TlaPlugin/Services/GlossaryService.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 负责整合三层术语表与禁用词列表的服务。
+/// </summary>
+public class GlossaryService
+{
+    private readonly IList<GlossaryEntry> _entries = new List<GlossaryEntry>();
+
+    public void LoadEntries(IEnumerable<GlossaryEntry> entries)
+    {
+        foreach (var entry in entries)
+        {
+            _entries.Add(entry);
+        }
+    }
+
+    /// <summary>
+    /// 按优先级顺序应用术语表。
+    /// </summary>
+    public string Apply(string text, string tenantId, string? channelId, string userId)
+    {
+        var ordered = _entries
+            .Where(e => e.Scope == $"tenant:{tenantId}" || e.Scope == $"channel:{channelId}" || e.Scope == $"user:{userId}")
+            .OrderBy(e => Priority(e.Scope, tenantId, channelId, userId))
+            .ToList();
+
+        var result = text;
+        foreach (var entry in ordered)
+        {
+            var pattern = Regex.Escape(entry.Source);
+            result = Regex.Replace(result, pattern, entry.Target, RegexOptions.IgnoreCase);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// 返回当前登记的术语条目。
+    /// </summary>
+    public IReadOnlyList<GlossaryEntry> GetEntries()
+    {
+        return _entries.ToList();
+    }
+
+    private static int Priority(string scope, string tenantId, string? channelId, string userId)
+    {
+        if (scope == $"user:{userId}")
+        {
+            return 0;
+        }
+        if (!string.IsNullOrEmpty(channelId) && scope == $"channel:{channelId}")
+        {
+            return 1;
+        }
+        if (scope == $"tenant:{tenantId}")
+        {
+            return 2;
+        }
+        return 3;
+    }
+}

--- a/src/TlaPlugin/Services/KeyVaultSecretResolver.cs
+++ b/src/TlaPlugin/Services/KeyVaultSecretResolver.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 从 Key Vault 拉取机密的轻量级解析器。
+/// </summary>
+public class KeyVaultSecretResolver
+{
+    private readonly PluginOptions _options;
+    private readonly ConcurrentDictionary<string, CachedSecret> _cache = new();
+
+    public KeyVaultSecretResolver(IOptions<PluginOptions>? options = null)
+    {
+        _options = options?.Value ?? new PluginOptions();
+    }
+
+    public Task<string> GetSecretAsync(string secretName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(secretName))
+        {
+            return Task.FromResult(string.Empty);
+        }
+
+        if (_cache.TryGetValue(secretName, out var cached) && cached.Expiry > DateTimeOffset.UtcNow)
+        {
+            return Task.FromResult(cached.Value);
+        }
+
+        if (!_options.Security.SeedSecrets.TryGetValue(secretName, out var value))
+        {
+            throw new InvalidOperationException($"KeyVault 中不存在名为 {secretName} 的机密。");
+        }
+
+        var ttl = _options.Security.SecretCacheTtl <= TimeSpan.Zero
+            ? TimeSpan.FromMinutes(1)
+            : _options.Security.SecretCacheTtl;
+        var expiry = DateTimeOffset.UtcNow.Add(ttl);
+        _cache[secretName] = new CachedSecret(value, expiry);
+        return Task.FromResult(value);
+    }
+
+    public void Invalidate(string secretName)
+    {
+        _cache.TryRemove(secretName, out _);
+    }
+
+    private readonly record struct CachedSecret(string Value, DateTimeOffset Expiry);
+}

--- a/src/TlaPlugin/Services/LanguageDetector.cs
+++ b/src/TlaPlugin/Services/LanguageDetector.cs
@@ -1,0 +1,33 @@
+using System.Text.RegularExpressions;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 支撑 R1 要求的简易语言检测器。
+/// </summary>
+public class LanguageDetector
+{
+    private static readonly Regex Japanese = new("[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff]", RegexOptions.Compiled);
+    private static readonly Regex Spanish = new("[áéíóúñü]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public DetectionResult Detect(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return new DetectionResult("unknown", 0);
+        }
+
+        if (Japanese.IsMatch(text))
+        {
+            return new DetectionResult("ja", 0.92);
+        }
+
+        if (Spanish.IsMatch(text))
+        {
+            return new DetectionResult("es", 0.75);
+        }
+
+        return new DetectionResult("en", 0.6);
+    }
+}

--- a/src/TlaPlugin/Services/ModelProviderFactory.cs
+++ b/src/TlaPlugin/Services/ModelProviderFactory.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Providers;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 根据配置组装模型提供方的工厂。
+/// </summary>
+public class ModelProviderFactory
+{
+    private readonly PluginOptions _options;
+    private readonly IHttpClientFactory? _httpClientFactory;
+    private readonly KeyVaultSecretResolver? _secretResolver;
+
+    public ModelProviderFactory(IOptions<PluginOptions>? options = null, IHttpClientFactory? httpClientFactory = null, KeyVaultSecretResolver? secretResolver = null)
+    {
+        _options = options?.Value ?? new PluginOptions();
+        _httpClientFactory = httpClientFactory;
+        _secretResolver = secretResolver;
+    }
+
+    public IReadOnlyList<IModelProvider> CreateProviders()
+    {
+        if (_options.Providers.Count == 0)
+        {
+            _options.Providers.Add(new ModelProviderOptions { Id = "mock-primary", TranslationPrefix = "[Mock]" });
+            _options.Providers.Add(new ModelProviderOptions { Id = "mock-backup", TranslationPrefix = "[Backup]", SimulatedFailures = 1 });
+        }
+
+        var providers = new List<IModelProvider>();
+        foreach (var opt in _options.Providers)
+        {
+            providers.Add(CreateProvider(opt));
+        }
+
+        return providers;
+    }
+
+    private IModelProvider CreateProvider(ModelProviderOptions options)
+    {
+        return options.Kind switch
+        {
+            ModelProviderKind.Mock => new MockModelProvider(options),
+            ModelProviderKind.OpenAi or ModelProviderKind.Anthropic or ModelProviderKind.Groq or ModelProviderKind.OpenWebUi or ModelProviderKind.Ollama or ModelProviderKind.Custom
+                => new ConfigurableChatModelProvider(options, _httpClientFactory, _secretResolver),
+            _ => new MockModelProvider(options)
+        };
+    }
+}

--- a/src/TlaPlugin/Services/OfflineDraftStore.cs
+++ b/src/TlaPlugin/Services/OfflineDraftStore.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 基于 SQLite 的草稿存储。
+/// </summary>
+public class OfflineDraftStore
+{
+    private readonly PluginOptions _options;
+
+    public OfflineDraftStore(IOptions<PluginOptions>? options = null)
+    {
+        _options = options?.Value ?? new PluginOptions();
+        EnsureSchema();
+    }
+
+    public OfflineDraftRecord SaveDraft(OfflineDraftRequest request)
+    {
+        using var connection = new SqliteConnection(_options.OfflineDraftConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            @"INSERT INTO Drafts(UserId, TenantId, OriginalText, TargetLanguage, CreatedAt, Status)
+              VALUES ($userId, $tenantId, $text, $target, $createdAt, 'PENDING');
+              SELECT last_insert_rowid();";
+        command.Parameters.AddWithValue("$userId", request.UserId);
+        command.Parameters.AddWithValue("$tenantId", request.TenantId);
+        command.Parameters.AddWithValue("$text", request.OriginalText);
+        command.Parameters.AddWithValue("$target", request.TargetLanguage);
+        command.Parameters.AddWithValue("$createdAt", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+
+        var id = (long)(command.ExecuteScalar() ?? 0);
+        return new OfflineDraftRecord
+        {
+            Id = id,
+            UserId = request.UserId,
+            TenantId = request.TenantId,
+            OriginalText = request.OriginalText,
+            TargetLanguage = request.TargetLanguage,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Status = "PENDING"
+        };
+    }
+
+    public IReadOnlyList<OfflineDraftRecord> ListDrafts(string userId)
+    {
+        var results = new List<OfflineDraftRecord>();
+        using var connection = new SqliteConnection(_options.OfflineDraftConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT Id, UserId, TenantId, OriginalText, TargetLanguage, CreatedAt, Status FROM Drafts WHERE UserId = $user";
+        command.Parameters.AddWithValue("$user", userId);
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            results.Add(new OfflineDraftRecord
+            {
+                Id = reader.GetInt64(0),
+                UserId = reader.GetString(1),
+                TenantId = reader.GetString(2),
+                OriginalText = reader.GetString(3),
+                TargetLanguage = reader.GetString(4),
+                CreatedAt = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64(5)),
+                Status = reader.GetString(6)
+            });
+        }
+        return results;
+    }
+
+    public void Cleanup()
+    {
+        using var connection = new SqliteConnection(_options.OfflineDraftConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM Drafts WHERE CreatedAt < $cutoff";
+        var cutoff = DateTimeOffset.UtcNow.Subtract(_options.DraftRetention).ToUnixTimeSeconds();
+        command.Parameters.AddWithValue("$cutoff", cutoff);
+        command.ExecuteNonQuery();
+    }
+
+    private void EnsureSchema()
+    {
+        using var connection = new SqliteConnection(_options.OfflineDraftConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            @"CREATE TABLE IF NOT EXISTS Drafts (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                UserId TEXT NOT NULL,
+                TenantId TEXT NOT NULL,
+                OriginalText TEXT NOT NULL,
+                TargetLanguage TEXT NOT NULL,
+                CreatedAt INTEGER NOT NULL,
+                Status TEXT NOT NULL
+            );";
+        command.ExecuteNonQuery();
+    }
+}

--- a/src/TlaPlugin/Services/ProjectStatusService.cs
+++ b/src/TlaPlugin/Services/ProjectStatusService.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 提供开发进度快照以加速前端规划的服务。
+/// </summary>
+public class ProjectStatusService
+{
+    private static readonly IReadOnlyList<StageStatus> Stages = new List<StageStatus>
+    {
+        new("stage0", "阶段 0：需求吸收", "完成需求说明书解读与技术选型。", true),
+        new("stage1", "阶段 1：服务编排", "交付多模型路由、预算守卫与术语融合能力。", true),
+        new("stage2", "阶段 2：Teams 适配", "实现消息扩展与 Adaptive Card 响应。", true),
+        new("stage3", "阶段 3：持久化与测试", "落地 SQLite 草稿存储并建立 xUnit 覆盖。", true),
+        new("stage4", "阶段 4：合规加固", "引入区域、认证与禁译语校验。", true),
+        new("stage5", "阶段 5：性能护栏", "提供翻译缓存与速率控制。", true),
+        new("stage6", "阶段 6：密钥与 OBO", "完成 Key Vault 机密缓存与 OBO 代理。", true),
+        new("stage7", "阶段 7：多语广播", "交付额外语言批量翻译与卡片呈现。", true),
+        new("stage8", "阶段 8：多模型互联", "通过 ConfigurableChatModelProvider 统一外部 API。", true),
+        new("stage9", "阶段 9：前端体验", "构建 Teams Tab、设置界面与联调测试。", false)
+    };
+
+    private static readonly IReadOnlyList<string> NextSteps = new List<string>
+    {
+        "完成真实模型联通与延迟监控",
+        "替换 Key Vault/OBO 模拟为生产 SDK",
+        "实现 Teams Tab 设置页与术语管理前端",
+        "启动前后端联调与端到端测试"
+    };
+
+    /// <summary>
+    /// 返回当前的进度快照。
+    /// </summary>
+    public ProjectStatusSnapshot GetSnapshot()
+    {
+        var current = Stages.Last(s => s.Completed);
+        var overallPercent = CalculateOverallPercent();
+        var frontend = new FrontendProgress(
+            CompletionPercent: 0,
+            DataPlaneReady: true,
+            UiImplemented: false,
+            IntegrationReady: false);
+
+        return new ProjectStatusSnapshot(current.Id, Stages, NextSteps, overallPercent, frontend);
+    }
+
+    private static int CalculateOverallPercent()
+    {
+        var completed = Stages.Count(stage => stage.Completed);
+        var percent = (double)completed / Stages.Count * 100;
+        return (int)Math.Round(percent, MidpointRounding.AwayFromZero);
+    }
+}

--- a/src/TlaPlugin/Services/TokenBroker.cs
+++ b/src/TlaPlugin/Services/TokenBroker.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Concurrent;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 模拟 OBO 流程并颁发访问令牌的代理。
+/// </summary>
+public class TokenBroker : ITokenBroker
+{
+    private readonly KeyVaultSecretResolver _resolver;
+    private readonly PluginOptions _options;
+    private readonly ConcurrentDictionary<string, AccessToken> _cache = new();
+
+    public TokenBroker(KeyVaultSecretResolver resolver, IOptions<PluginOptions>? options = null)
+    {
+        _resolver = resolver;
+        _options = options?.Value ?? new PluginOptions();
+    }
+
+    public async Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
+    {
+        var cacheKey = $"{tenantId}:{userId}";
+        if (_cache.TryGetValue(cacheKey, out var cached) && cached.ExpiresOn > DateTimeOffset.UtcNow.AddMinutes(-1))
+        {
+            return cached;
+        }
+
+        var clientSecret = await _resolver.GetSecretAsync(_options.Security.ClientSecretName, cancellationToken);
+        if (string.IsNullOrEmpty(clientSecret))
+        {
+            throw new AuthenticationException("无法获取客户端机密。");
+        }
+
+        var lifetime = _options.Security.AccessTokenLifetime <= TimeSpan.Zero
+            ? TimeSpan.FromMinutes(30)
+            : _options.Security.AccessTokenLifetime;
+        var expiresOn = DateTimeOffset.UtcNow.Add(lifetime);
+        var value = GenerateToken(tenantId, userId, clientSecret, expiresOn);
+        var token = new AccessToken(value, expiresOn, _options.Security.UserAssertionAudience);
+        _cache[cacheKey] = token;
+        return token;
+    }
+
+    private static string GenerateToken(string tenantId, string userId, string secret, DateTimeOffset expiresOn)
+    {
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var payload = $"{tenantId}:{userId}:{expiresOn.ToUnixTimeSeconds()}";
+        var signature = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(payload)));
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes($"{payload}:{signature}"));
+    }
+}
+
+public interface ITokenBroker
+{
+    Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken);
+}
+
+public record AccessToken(string Value, DateTimeOffset ExpiresOn, string Audience);

--- a/src/TlaPlugin/Services/ToneTemplateService.cs
+++ b/src/TlaPlugin/Services/ToneTemplateService.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 提供不同语气模板的工具类。
+/// </summary>
+public class ToneTemplateService
+{
+    public const string Polite = "polite";
+    public const string Casual = "casual";
+    public const string Business = "business";
+    public const string Technical = "technical";
+    public const string DefaultTone = Polite;
+
+    private static readonly IDictionary<string, string> Templates = new Dictionary<string, string>
+    {
+        [Polite] = "请将以下内容翻译成礼貌且正式的语气。",
+        [Casual] = "请将以下内容翻译成轻松随和的口吻。",
+        [Business] = "请将以下内容翻译成适合商务场景的正式语气。",
+        [Technical] = "请将以下内容翻译成技术文档需要的严谨语气。"
+    };
+
+    /// <summary>
+    /// 获取指定语气的提示词。
+    /// </summary>
+    public string GetPromptPrefix(string tone)
+    {
+        if (string.IsNullOrWhiteSpace(tone))
+        {
+            return Templates[DefaultTone];
+        }
+
+        if (Templates.TryGetValue(tone, out var template))
+        {
+            return template;
+        }
+
+        return Templates[DefaultTone];
+    }
+
+    /// <summary>
+    /// 返回可用的语气模板列表。
+    /// </summary>
+    public IReadOnlyDictionary<string, string> GetAvailableTones()
+    {
+        return new Dictionary<string, string>(Templates);
+    }
+}

--- a/src/TlaPlugin/Services/TranslationCache.cs
+++ b/src/TlaPlugin/Services/TranslationCache.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using System.Text.Json.Nodes;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 用于避免重复翻译的内存缓存。
+/// </summary>
+public class TranslationCache : IDisposable
+{
+    private readonly IMemoryCache _cache;
+    private readonly PluginOptions _options;
+    private readonly bool _ownsCache;
+
+    public TranslationCache(IMemoryCache cache, IOptions<PluginOptions>? options = null)
+    {
+        _cache = cache;
+        _options = options?.Value ?? new PluginOptions();
+    }
+
+    public TranslationCache(IOptions<PluginOptions>? options = null)
+    {
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _options = options?.Value ?? new PluginOptions();
+        _ownsCache = true;
+    }
+
+    public bool TryGet(TranslationRequest request, out TranslationResult result)
+    {
+        if (_cache.TryGetValue(BuildKey(request), out TranslationResult cached))
+        {
+            result = Clone(cached);
+            return true;
+        }
+
+        result = null!;
+        return false;
+    }
+
+    public void Set(TranslationRequest request, TranslationResult result)
+    {
+        _cache.Set(BuildKey(request), Clone(result), _options.CacheTtl);
+    }
+
+    private static string BuildKey(TranslationRequest request)
+    {
+        var extras = string.Join(',', request.AdditionalTargetLanguages.OrderBy(l => l));
+        return string.Join('|', new[]
+        {
+            request.TenantId,
+            request.SourceLanguage ?? string.Empty,
+            request.TargetLanguage,
+            request.Tone,
+            request.UseGlossary.ToString(),
+            request.Text,
+            extras
+        });
+    }
+
+    private static TranslationResult Clone(TranslationResult source)
+    {
+        return new TranslationResult
+        {
+            TranslatedText = source.TranslatedText,
+            SourceLanguage = source.SourceLanguage,
+            TargetLanguage = source.TargetLanguage,
+            ModelId = source.ModelId,
+            Confidence = source.Confidence,
+            CostUsd = source.CostUsd,
+            LatencyMs = source.LatencyMs,
+            AdaptiveCard = (JsonObject?)(source.AdaptiveCard?.DeepClone()) ?? new JsonObject(),
+            AdditionalTranslations = new Dictionary<string, string>(source.AdditionalTranslations)
+        };
+    }
+
+    public void Dispose()
+    {
+        if (_ownsCache && _cache is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+}

--- a/src/TlaPlugin/Services/TranslationPipeline.cs
+++ b/src/TlaPlugin/Services/TranslationPipeline.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 负责调度翻译并生成 Teams 响应的管线。
+/// </summary>
+public class TranslationPipeline
+{
+    private readonly TranslationRouter _router;
+    private readonly GlossaryService _glossary;
+    private readonly OfflineDraftStore _drafts;
+    private readonly LanguageDetector _detector;
+    private readonly TranslationCache _cache;
+    private readonly TranslationThrottle _throttle;
+    private readonly PluginOptions _options;
+
+    public TranslationPipeline(TranslationRouter router, GlossaryService glossary, OfflineDraftStore drafts, LanguageDetector detector, TranslationCache cache, TranslationThrottle throttle, IOptions<PluginOptions>? options = null)
+    {
+        _router = router;
+        _glossary = glossary;
+        _drafts = drafts;
+        _detector = detector;
+        _cache = cache;
+        _throttle = throttle;
+        _options = options?.Value ?? new PluginOptions();
+    }
+
+    public async Task<TranslationResult> ExecuteAsync(TranslationRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Text))
+        {
+            throw new TranslationException("翻译内容为空。");
+        }
+
+        if (request.Text.Length > _options.MaxCharactersPerRequest)
+        {
+            throw new TranslationException("文本长度超过上限。");
+        }
+
+        var resolvedRequest = new TranslationRequest
+        {
+            Text = request.UseGlossary ? _glossary.Apply(request.Text, request.TenantId, request.ChannelId, request.UserId) : request.Text,
+            SourceLanguage = request.SourceLanguage,
+            TargetLanguage = request.TargetLanguage,
+            TenantId = request.TenantId,
+            UserId = request.UserId,
+            ChannelId = request.ChannelId,
+            Tone = request.Tone,
+            AdditionalTargetLanguages = new List<string>(request.AdditionalTargetLanguages),
+            UseGlossary = request.UseGlossary
+        };
+
+        if (string.IsNullOrEmpty(resolvedRequest.SourceLanguage))
+        {
+            var detection = _detector.Detect(resolvedRequest.Text);
+            if (detection.Confidence < 0.7)
+            {
+                throw new TranslationException("无法识别语言，请手动指定。");
+            }
+            resolvedRequest.SourceLanguage = detection.Language;
+        }
+
+        if (_cache.TryGet(resolvedRequest, out var cached))
+        {
+            return cached;
+        }
+
+        using var lease = await _throttle.AcquireAsync(resolvedRequest.TenantId, cancellationToken);
+        var result = await _router.TranslateAsync(resolvedRequest, cancellationToken);
+        _cache.Set(resolvedRequest, result);
+        return result;
+    }
+
+    public OfflineDraftRecord SaveDraft(OfflineDraftRequest request)
+    {
+        return _drafts.SaveDraft(request);
+    }
+}

--- a/src/TlaPlugin/Services/TranslationRouter.cs
+++ b/src/TlaPlugin/Services/TranslationRouter.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Authentication;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Providers;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 负责评估多个模型并执行回退的路由器。
+/// </summary>
+public class TranslationRouter
+{
+    private readonly IReadOnlyList<IModelProvider> _providers;
+    private readonly ComplianceGateway _compliance;
+    private readonly BudgetGuard _budget;
+    private readonly AuditLogger _audit;
+    private readonly ToneTemplateService _tones;
+    private readonly ITokenBroker _tokenBroker;
+
+    public TranslationRouter(ModelProviderFactory providerFactory, ComplianceGateway compliance, BudgetGuard budget, AuditLogger audit, ToneTemplateService tones, ITokenBroker tokenBroker, IOptions<PluginOptions>? options = null)
+    {
+        _providers = providerFactory.CreateProviders();
+        _compliance = compliance;
+        _budget = budget;
+        _audit = audit;
+        _tones = tones;
+        _tokenBroker = tokenBroker;
+        Options = options?.Value ?? new PluginOptions();
+    }
+
+    public PluginOptions Options { get; }
+
+    public async Task<TranslationResult> TranslateAsync(TranslationRequest request, CancellationToken cancellationToken)
+    {
+        var sourceLanguage = request.SourceLanguage;
+        DetectionResult? detection = null;
+        if (string.IsNullOrEmpty(sourceLanguage))
+        {
+            detection = await _providers.First().DetectAsync(request.Text, cancellationToken);
+            sourceLanguage = detection.Language;
+        }
+
+        if (string.IsNullOrEmpty(request.UserId))
+        {
+            throw new AuthenticationException("用户 ID 为空，无法获取令牌。");
+        }
+
+        var token = await _tokenBroker.ExchangeOnBehalfOfAsync(request.TenantId, request.UserId, cancellationToken);
+        if (token.ExpiresOn <= DateTimeOffset.UtcNow)
+        {
+            throw new AuthenticationException("获取的令牌已失效。");
+        }
+
+        var promptPrefix = _tones.GetPromptPrefix(request.Tone);
+
+        foreach (var provider in _providers)
+        {
+            var report = _compliance.Evaluate(request.Text, provider.Options);
+            if (!report.Allowed)
+            {
+                continue;
+            }
+
+            var translationCount = 1 + request.AdditionalTargetLanguages.Count;
+            var estimatedCost = request.Text.Length * provider.Options.CostPerCharUsd * translationCount;
+            if (!_budget.TryReserve(request.TenantId, estimatedCost))
+            {
+                throw new BudgetExceededException("已超出今日翻译预算。");
+            }
+
+            try
+            {
+                var result = await provider.TranslateAsync(request.Text, sourceLanguage!, request.TargetLanguage, promptPrefix, cancellationToken);
+                var rewritten = await provider.RewriteAsync(result.Text, request.Tone, cancellationToken);
+
+                var additional = new Dictionary<string, string>();
+                foreach (var extraLanguage in request.AdditionalTargetLanguages)
+                {
+                    var extraResult = await provider.TranslateAsync(request.Text, sourceLanguage!, extraLanguage, promptPrefix, cancellationToken);
+                    var extraRewritten = await provider.RewriteAsync(extraResult.Text, request.Tone, cancellationToken);
+                    additional[extraLanguage] = extraRewritten;
+                }
+
+                _audit.Record(request.TenantId, request.UserId, result.ModelId, request.Text, rewritten, estimatedCost, result.LatencyMs, token.Audience, additional);
+
+                return new TranslationResult
+                {
+                    TranslatedText = rewritten,
+                    SourceLanguage = sourceLanguage!,
+                    TargetLanguage = request.TargetLanguage,
+                    ModelId = result.ModelId,
+                    Confidence = result.Confidence,
+                    LatencyMs = result.LatencyMs,
+                    CostUsd = estimatedCost,
+                    AdditionalTranslations = additional,
+                    AdaptiveCard = BuildAdaptiveCard(rewritten, sourceLanguage!, request.TargetLanguage, result.ModelId, estimatedCost, result.LatencyMs, additional)
+                };
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or TaskCanceledException)
+            {
+                // 继续尝试其他模型。
+            }
+        }
+
+        throw new TranslationException("未找到可用的模型。");
+    }
+
+    private static JsonObject BuildAdaptiveCard(string translatedText, string sourceLanguage, string targetLanguage, string modelId, decimal cost, int latency, IReadOnlyDictionary<string, string> additionalTranslations)
+    {
+        var body = new JsonArray
+        {
+            new JsonObject
+            {
+                ["type"] = "TextBlock",
+                ["text"] = "翻译结果",
+                ["wrap"] = true,
+                ["weight"] = "Bolder",
+                ["size"] = "Medium"
+            },
+            new JsonObject
+            {
+                ["type"] = "TextBlock",
+                ["text"] = translatedText,
+                ["wrap"] = true
+            },
+            new JsonObject
+            {
+                ["type"] = "TextBlock",
+                ["text"] = $"{sourceLanguage} → {targetLanguage} | 模型: {modelId}",
+                ["wrap"] = true,
+                ["isSubtle"] = true
+            },
+            new JsonObject
+            {
+                ["type"] = "TextBlock",
+                ["text"] = $"成本: ${cost:F4} | 延迟: {latency}ms",
+                ["wrap"] = true,
+                ["spacing"] = "None",
+                ["isSubtle"] = true
+            }
+        };
+
+        if (additionalTranslations.Count > 0)
+        {
+            body.Add(new JsonObject
+            {
+                ["type"] = "TextBlock",
+                ["text"] = "额外翻译",
+                ["wrap"] = true,
+                ["weight"] = "Bolder",
+                ["spacing"] = "Medium"
+            });
+
+            foreach (var kvp in additionalTranslations)
+            {
+                body.Add(new JsonObject
+                {
+                    ["type"] = "TextBlock",
+                    ["text"] = $"{kvp.Key}: {kvp.Value}",
+                    ["wrap"] = true
+                });
+            }
+        }
+
+        var actions = new JsonArray
+        {
+            CreateInsertAction("插入到聊天", translatedText, targetLanguage)
+        };
+
+        foreach (var kvp in additionalTranslations)
+        {
+            actions.Add(CreateInsertAction($"插入 {kvp.Key}", kvp.Value, kvp.Key));
+        }
+
+        actions.Add(new JsonObject
+        {
+            ["type"] = "Action.Submit",
+            ["title"] = "查看原文",
+            ["data"] = new JsonObject { ["action"] = "showOriginal" }
+        });
+
+        actions.Add(new JsonObject
+        {
+            ["type"] = "Action.Submit",
+            ["title"] = "选择其他语言",
+            ["data"] = new JsonObject { ["action"] = "changeLanguage" }
+        });
+
+        return new JsonObject
+        {
+            ["type"] = "AdaptiveCard",
+            ["version"] = "1.5",
+            ["body"] = body,
+            ["actions"] = actions
+        };
+    }
+
+    private static JsonObject CreateInsertAction(string title, string text, string language)
+    {
+        return new JsonObject
+        {
+            ["type"] = "Action.Submit",
+            ["title"] = title,
+            ["data"] = new JsonObject
+            {
+                ["action"] = "insertTranslation",
+                ["text"] = text,
+                ["language"] = language
+            },
+            ["msteams"] = new JsonObject
+            {
+                ["type"] = "messageBack",
+                ["text"] = text,
+                ["displayText"] = text,
+                ["language"] = language
+            }
+        };
+    }
+}
+
+public class TranslationException : Exception
+{
+    public TranslationException(string message) : base(message) { }
+}
+
+public class BudgetExceededException : Exception
+{
+    public BudgetExceededException(string message) : base(message) { }
+}

--- a/src/TlaPlugin/Services/TranslationThrottle.cs
+++ b/src/TlaPlugin/Services/TranslationThrottle.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 统一管理并发与速率限制的节流器。
+/// </summary>
+public class TranslationThrottle
+{
+    private readonly SemaphoreSlim _semaphore;
+    private readonly int _requestsPerMinute;
+    private readonly ConcurrentDictionary<string, RateWindow> _rateWindows = new();
+
+    public TranslationThrottle(IOptions<PluginOptions>? options = null)
+    {
+        var resolved = options?.Value ?? new PluginOptions();
+        var concurrency = Math.Max(1, resolved.MaxConcurrentTranslations);
+        _requestsPerMinute = resolved.RequestsPerMinute <= 0 ? int.MaxValue : resolved.RequestsPerMinute;
+        _semaphore = new SemaphoreSlim(concurrency, concurrency);
+    }
+
+    public async Task<IDisposable> AcquireAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+
+        if (!TryIncrement(tenantId))
+        {
+            _semaphore.Release();
+            throw new RateLimitExceededException("已超出每分钟请求上限。");
+        }
+
+        return new Lease(this);
+    }
+
+    private bool TryIncrement(string tenantId)
+    {
+        if (_requestsPerMinute == int.MaxValue)
+        {
+            return true;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+
+        while (true)
+        {
+            if (!_rateWindows.TryGetValue(tenantId, out var window))
+            {
+                if (_rateWindows.TryAdd(tenantId, new RateWindow(now, 1)))
+                {
+                    return true;
+                }
+                continue;
+            }
+
+            if (now - window.WindowStart >= TimeSpan.FromMinutes(1))
+            {
+                if (_rateWindows.TryUpdate(tenantId, new RateWindow(now, 1), window))
+                {
+                    return true;
+                }
+                continue;
+            }
+
+            if (window.Count >= _requestsPerMinute)
+            {
+                return false;
+            }
+
+            if (_rateWindows.TryUpdate(tenantId, window with { Count = window.Count + 1 }, window))
+            {
+                return true;
+            }
+        }
+    }
+
+    private void Release()
+    {
+        _semaphore.Release();
+    }
+
+    private sealed class Lease : IDisposable
+    {
+        private readonly TranslationThrottle _owner;
+        private bool _disposed;
+
+        public Lease(TranslationThrottle owner)
+        {
+            _owner = owner;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _owner.Release();
+        }
+    }
+
+    private record struct RateWindow(DateTimeOffset WindowStart, int Count);
+}
+
+public class RateLimitExceededException : Exception
+{
+    public RateLimitExceededException(string message) : base(message)
+    {
+    }
+}

--- a/src/TlaPlugin/Teams/MessageExtensionHandler.cs
+++ b/src/TlaPlugin/Teams/MessageExtensionHandler.cs
@@ -1,0 +1,100 @@
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+
+namespace TlaPlugin.Teams;
+
+/// <summary>
+/// 承载 Teams 消息扩展业务逻辑的处理器。
+/// </summary>
+public class MessageExtensionHandler
+{
+    private readonly TranslationPipeline _pipeline;
+
+    public MessageExtensionHandler(TranslationPipeline pipeline)
+    {
+        _pipeline = pipeline;
+    }
+
+    public async Task<JsonObject> HandleTranslateAsync(TranslationRequest request)
+    {
+        try
+        {
+            var result = await _pipeline.ExecuteAsync(request, CancellationToken.None);
+            return new JsonObject
+            {
+                ["type"] = "message",
+                ["attachments"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["contentType"] = "application/vnd.microsoft.card.adaptive",
+                        ["content"] = result.AdaptiveCard
+                    }
+                }
+            };
+        }
+        catch (BudgetExceededException ex)
+        {
+            return BuildErrorCard("预算限制", ex.Message);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            return BuildErrorCard("速率限制", ex.Message);
+        }
+        catch (TranslationException ex)
+        {
+            return BuildErrorCard("翻译错误", ex.Message);
+        }
+    }
+
+    public Task<JsonObject> HandleOfflineDraftAsync(OfflineDraftRequest request)
+    {
+        var record = _pipeline.SaveDraft(request);
+        return Task.FromResult(new JsonObject
+        {
+            ["type"] = "offlineDraftSaved",
+            ["draftId"] = record.Id,
+            ["status"] = record.Status,
+            ["createdAt"] = record.CreatedAt.ToString("O")
+        });
+    }
+
+    private static JsonObject BuildErrorCard(string title, string message)
+    {
+        return new JsonObject
+        {
+            ["type"] = "message",
+            ["attachments"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["contentType"] = "application/vnd.microsoft.card.adaptive",
+                    ["content"] = new JsonObject
+                    {
+                        ["type"] = "AdaptiveCard",
+                        ["version"] = "1.5",
+                        ["body"] = new JsonArray
+                        {
+                            new JsonObject
+                            {
+                                ["type"] = "TextBlock",
+                                ["text"] = title,
+                                ["wrap"] = true,
+                                ["weight"] = "Bolder"
+                            },
+                            new JsonObject
+                            {
+                                ["type"] = "TextBlock",
+                                ["text"] = message,
+                                ["wrap"] = true
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+}

--- a/src/TlaPlugin/TlaPlugin.csproj
+++ b/src/TlaPlugin/TlaPlugin.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.20" />
+  </ItemGroup>
+</Project>

--- a/src/TlaPlugin/appsettings.json
+++ b/src/TlaPlugin/appsettings.json
@@ -1,0 +1,53 @@
+{
+  "Plugin": {
+    "MaxCharactersPerRequest": 50000,
+    "DailyBudgetUsd": 30,
+    "DraftRetention": "7.00:00:00",
+    "CacheTtl": "1.00:00:00",
+    "MaxConcurrentTranslations": 4,
+    "RequestsPerMinute": 120,
+    "OfflineDraftConnectionString": "Data Source=tla-offline.db",
+    "SupportedLanguages": ["ja-JP", "en-US", "zh-CN", "zh-TW", "ko-KR", "fr-FR"],
+    "DefaultTargetLanguages": ["ja-JP", "en-US"],
+    "Providers": [
+      {
+        "Id": "mock-primary",
+        "Kind": "Mock",
+        "CostPerCharUsd": 0.00002,
+        "LatencyTargetMs": 250,
+        "Reliability": 0.98,
+        "Regions": ["japan", "global"],
+        "Certifications": ["iso27001"],
+        "TranslationPrefix": "[MockJP]"
+      },
+      {
+        "Id": "mock-backup",
+        "Kind": "Mock",
+        "CostPerCharUsd": 0.000015,
+        "LatencyTargetMs": 400,
+        "Reliability": 0.95,
+        "Regions": ["global"],
+        "Certifications": [],
+        "TranslationPrefix": "[MockBackup]",
+        "SimulatedFailures": 1
+      }
+    ],
+    "Compliance": {
+      "RequiredRegionTags": ["japan"],
+      "AllowedRegionFallbacks": ["global"],
+      "RequiredCertifications": ["iso27001"],
+      "BannedPhrases": ["secret", "forbidden"]
+    },
+    "Security": {
+      "KeyVaultUri": "https://localhost.vault.azure.net/",
+      "ClientId": "11111111-1111-1111-1111-111111111111",
+      "ClientSecretName": "tla-client-secret",
+      "UserAssertionAudience": "api://tla-plugin",
+      "AccessTokenLifetime": "00:30:00",
+      "SecretCacheTtl": "00:05:00",
+      "SeedSecrets": {
+        "tla-client-secret": "local-dev-secret"
+      }
+    }
+  }
+}

--- a/tests/TlaPlugin.Tests/ComplianceGatewayTests.cs
+++ b/tests/TlaPlugin.Tests/ComplianceGatewayTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class ComplianceGatewayTests
+{
+    [Fact]
+    public void BlocksBannedPhrases()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Compliance = new CompliancePolicyOptions
+            {
+                BannedPhrases = new List<string> { "forbidden" }
+            }
+        });
+
+        var gateway = new ComplianceGateway(options);
+        var report = gateway.Evaluate("this contains forbidden term", new ModelProviderOptions { Regions = new List<string> { "global" } });
+
+        Assert.False(report.Allowed);
+        Assert.Contains(report.Violations, v => v.Contains("禁則語"));
+    }
+
+    [Fact]
+    public void AllowsCertifiedRegion()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var gateway = new ComplianceGateway(options);
+        var report = gateway.Evaluate("hello", new ModelProviderOptions
+        {
+            Regions = new List<string> { "japan" },
+            Certifications = new List<string> { "iso" }
+        });
+
+        Assert.True(report.Allowed);
+    }
+}

--- a/tests/TlaPlugin.Tests/ConfigurationSummaryServiceTests.cs
+++ b/tests/TlaPlugin.Tests/ConfigurationSummaryServiceTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class ConfigurationSummaryServiceTests
+{
+    [Fact]
+    public void CreateSummary_Returns_Providers_And_Tone_Info()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            MaxCharactersPerRequest = 1234,
+            DailyBudgetUsd = 55m,
+            RequestsPerMinute = 80,
+            MaxConcurrentTranslations = 3,
+            SupportedLanguages = { "ja-JP", "en-US" },
+            DefaultTargetLanguages = { "ja-JP" },
+            Providers =
+            {
+                new ModelProviderOptions
+                {
+                    Id = "openai",
+                    Kind = ModelProviderKind.OpenAi,
+                    Reliability = 0.97,
+                    CostPerCharUsd = 0.00003m,
+                    LatencyTargetMs = 500,
+                    Regions = { "global" },
+                    Certifications = { "iso27001" }
+                }
+            }
+        });
+
+        var toneService = new ToneTemplateService();
+        var glossary = new GlossaryService();
+        glossary.LoadEntries(new[]
+        {
+            new GlossaryEntry("CPU", "中央処理装置", "tenant:contoso")
+        });
+
+        var service = new ConfigurationSummaryService(options, toneService, glossary);
+
+        var summary = service.CreateSummary();
+
+        Assert.Equal(1234, summary.MaxCharactersPerRequest);
+        Assert.Equal(55m, summary.DailyBudgetUsd);
+        Assert.Equal(80, summary.RequestsPerMinute);
+        Assert.Equal(3, summary.MaxConcurrentTranslations);
+        Assert.Contains("ja-JP", summary.SupportedLanguages);
+        Assert.Single(summary.DefaultTargetLanguages);
+        Assert.Single(summary.Providers);
+        Assert.Equal(ModelProviderKind.OpenAi, summary.Providers[0].Kind);
+        Assert.Equal(1, summary.GlossaryEntryCount);
+        Assert.Contains(ToneTemplateService.Business, summary.ToneTemplates.Keys);
+    }
+}

--- a/tests/TlaPlugin.Tests/KeyVaultSecretResolverTests.cs
+++ b/tests/TlaPlugin.Tests/KeyVaultSecretResolverTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class KeyVaultSecretResolverTests
+{
+    [Fact]
+    public async Task ReturnsSeedSecret()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Security = new SecurityOptions
+            {
+                SeedSecrets = new Dictionary<string, string> { ["custom-secret"] = "value" }
+            }
+        });
+
+        var resolver = new KeyVaultSecretResolver(options);
+        var value = await resolver.GetSecretAsync("custom-secret", CancellationToken.None);
+
+        Assert.Equal("value", value);
+    }
+
+    [Fact]
+    public async Task UsesCacheUntilInvalidated()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Security = new SecurityOptions
+            {
+                SeedSecrets = new Dictionary<string, string> { ["custom-secret"] = "value" },
+                SecretCacheTtl = TimeSpan.FromMinutes(5)
+            }
+        });
+
+        var resolver = new KeyVaultSecretResolver(options);
+        var first = await resolver.GetSecretAsync("custom-secret", CancellationToken.None);
+        options.Value.Security.SeedSecrets["custom-secret"] = "updated";
+        var cached = await resolver.GetSecretAsync("custom-secret", CancellationToken.None);
+
+        Assert.Equal(first, cached);
+
+        resolver.Invalidate("custom-secret");
+        var refreshed = await resolver.GetSecretAsync("custom-secret", CancellationToken.None);
+        Assert.Equal("updated", refreshed);
+    }
+
+    [Fact]
+    public async Task ThrowsWhenSecretMissing()
+    {
+        var resolver = new KeyVaultSecretResolver();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => resolver.GetSecretAsync("missing", CancellationToken.None));
+    }
+}

--- a/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
+++ b/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
@@ -1,0 +1,179 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+using TlaPlugin.Teams;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class MessageExtensionHandlerTests
+{
+    [Fact]
+    public async Task ReturnsAdaptiveCardResponse()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var handler = BuildHandler(options);
+        var response = await handler.HandleTranslateAsync(new TranslationRequest
+        {
+            Text = "hello",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en"
+        });
+
+        Assert.Equal("message", response["type"]?.GetValue<string>());
+        var attachment = response["attachments"]!.AsArray().First().AsObject();
+        Assert.Equal("application/vnd.microsoft.card.adaptive", attachment["contentType"]?.GetValue<string>());
+        var card = attachment["content"]!.AsObject();
+        var body = card["body"]!.AsArray();
+        var translated = body[1]!.AsObject()["text"]!.GetValue<string>();
+        var actions = card["actions"]!.AsArray();
+        var insertAction = actions.First()!.AsObject();
+        Assert.Equal("Action.Submit", insertAction["type"]!.GetValue<string>());
+        var teams = insertAction["msteams"]!.AsObject();
+        Assert.Equal("messageBack", teams["type"]!.GetValue<string>());
+        Assert.Equal(translated, teams["text"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task RendersAdditionalTranslationsInAdaptiveCard()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var handler = BuildHandler(options);
+        var response = await handler.HandleTranslateAsync(new TranslationRequest
+        {
+            Text = "hello",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en",
+            AdditionalTargetLanguages = new List<string> { "fr" }
+        });
+
+        var card = response["attachments"]!.AsArray().First()["content"]!.AsObject();
+        var texts = card["body"]!.AsArray().Select(node => node!.AsObject()["text"]?.GetValue<string>()).ToList();
+        Assert.Contains("额外翻译", texts);
+        Assert.Contains(texts, text => text?.StartsWith("fr:") == true);
+        var actions = card["actions"]!.AsArray();
+        Assert.Contains(actions.Select(a => a!.AsObject()["data"]!.AsObject()["language"]!.GetValue<string>()), value => value == "fr");
+    }
+
+    [Fact]
+    public async Task ReturnsErrorCardWhenBudgetExceeded()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            DailyBudgetUsd = 0.00001m,
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", CostPerCharUsd = 0.1m, Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var handler = BuildHandler(options);
+        var response = await handler.HandleTranslateAsync(new TranslationRequest
+        {
+            Text = new string('a', 200),
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en"
+        });
+
+        Assert.Equal("message", response["type"]?.GetValue<string>());
+        var body = response["attachments"]!.AsArray().First()["content"]!.AsObject();
+        var title = body["body"]!.AsArray().First().AsObject();
+        Assert.Contains("预算", title["text"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task ReturnsErrorCardWhenRateLimited()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            RequestsPerMinute = 1,
+            MaxConcurrentTranslations = 1,
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var handler = BuildHandler(options);
+
+        await handler.HandleTranslateAsync(new TranslationRequest
+        {
+            Text = "first",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en"
+        });
+
+        var response = await handler.HandleTranslateAsync(new TranslationRequest
+        {
+            Text = "second",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en"
+        });
+
+        var body = response["attachments"]!.AsArray().First()["content"]!.AsObject();
+        var title = body["body"]!.AsArray().First().AsObject();
+        Assert.Contains("速率", title["text"]!.GetValue<string>());
+    }
+
+    private static MessageExtensionHandler BuildHandler(IOptions<PluginOptions> options)
+    {
+        var glossary = new GlossaryService();
+        glossary.LoadEntries(new[] { new GlossaryEntry("hello", "你好", "tenant:contoso") });
+        var compliance = new ComplianceGateway(options);
+        var resolver = new KeyVaultSecretResolver(options);
+        var router = new TranslationRouter(new ModelProviderFactory(options), compliance, new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new TokenBroker(resolver, options), options);
+        var cache = new TranslationCache(options);
+        var throttle = new TranslationThrottle(options);
+        var pipeline = new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, options);
+        return new MessageExtensionHandler(pipeline);
+    }
+}

--- a/tests/TlaPlugin.Tests/ModelProviderFactoryTests.cs
+++ b/tests/TlaPlugin.Tests/ModelProviderFactoryTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Providers;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class ModelProviderFactoryTests
+{
+    [Fact]
+    public void CreatesConfigurableProviderForOpenAi()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new()
+                {
+                    Id = "openai",
+                    Kind = ModelProviderKind.OpenAi,
+                    Endpoint = "https://api.openai.com/v1/chat/completions",
+                    ApiKeySecretName = "openai-api-key",
+                    Model = "gpt-4o-mini"
+                }
+            },
+            Security = new SecurityOptions
+            {
+                SeedSecrets = new Dictionary<string, string>
+                {
+                    ["openai-api-key"] = "test"
+                }
+            }
+        });
+
+        var factory = new ModelProviderFactory(options, new StubHttpClientFactory(), new KeyVaultSecretResolver(options));
+        var providers = factory.CreateProviders();
+        Assert.IsType<ConfigurableChatModelProvider>(providers.Single());
+    }
+
+    private sealed class StubHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name)
+        {
+            return new HttpClient(new StubHandler());
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}")
+                };
+                return Task.FromResult(response);
+            }
+        }
+    }
+}

--- a/tests/TlaPlugin.Tests/OfflineDraftStoreTests.cs
+++ b/tests/TlaPlugin.Tests/OfflineDraftStoreTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class OfflineDraftStoreTests
+{
+    [Fact]
+    public void PersistsDraftsToSqlite()
+    {
+        var dbPath = Path.GetTempFileName();
+        var options = Options.Create(new PluginOptions
+        {
+            OfflineDraftConnectionString = $"Data Source={dbPath}",
+            DraftRetention = TimeSpan.FromDays(1)
+        });
+
+        var store = new OfflineDraftStore(options);
+        var record = store.SaveDraft(new OfflineDraftRequest
+        {
+            OriginalText = "test",
+            TargetLanguage = "ja",
+            TenantId = "contoso",
+            UserId = "alice"
+        });
+
+        Assert.True(record.Id > 0);
+        var drafts = store.ListDrafts("alice");
+        Assert.Single(drafts);
+        Assert.Equal("test", drafts[0].OriginalText);
+
+        store.Cleanup();
+    }
+}

--- a/tests/TlaPlugin.Tests/ProjectStatusServiceTests.cs
+++ b/tests/TlaPlugin.Tests/ProjectStatusServiceTests.cs
@@ -1,0 +1,25 @@
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class ProjectStatusServiceTests
+{
+    [Fact]
+    public void GetSnapshot_Returns_CurrentStage_And_NextSteps()
+    {
+        var service = new ProjectStatusService();
+
+        var snapshot = service.GetSnapshot();
+
+        Assert.Equal("stage8", snapshot.CurrentStageId);
+        Assert.Contains(snapshot.Stages, stage => stage.Id == "stage9" && !stage.Completed);
+        Assert.Equal(4, snapshot.NextSteps.Count);
+        Assert.Contains(snapshot.NextSteps, step => step.Contains("前端"));
+        Assert.Equal(80, snapshot.OverallCompletionPercent);
+        Assert.True(snapshot.Frontend.DataPlaneReady);
+        Assert.False(snapshot.Frontend.UiImplemented);
+        Assert.False(snapshot.Frontend.IntegrationReady);
+        Assert.Equal(0, snapshot.Frontend.CompletionPercent);
+    }
+}

--- a/tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj
+++ b/tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/TlaPlugin/TlaPlugin.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/TlaPlugin.Tests/TokenBrokerTests.cs
+++ b/tests/TlaPlugin.Tests/TokenBrokerTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class TokenBrokerTests
+{
+    [Fact]
+    public async Task CachesTokensUntilNearExpiry()
+    {
+        var options = Options.Create(new PluginOptions());
+        var resolver = new KeyVaultSecretResolver(options);
+        var broker = new TokenBroker(resolver, options);
+
+        var first = await broker.ExchangeOnBehalfOfAsync("contoso", "user", CancellationToken.None);
+        var second = await broker.ExchangeOnBehalfOfAsync("contoso", "user", CancellationToken.None);
+
+        Assert.Equal(first.Value, second.Value);
+    }
+
+    [Fact]
+    public async Task RefreshesExpiredTokens()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Security = new SecurityOptions
+            {
+                AccessTokenLifetime = TimeSpan.FromMilliseconds(50)
+            }
+        });
+        var resolver = new KeyVaultSecretResolver(options);
+        var broker = new TokenBroker(resolver, options);
+
+        var first = await broker.ExchangeOnBehalfOfAsync("contoso", "user", CancellationToken.None);
+        await Task.Delay(100);
+        var second = await broker.ExchangeOnBehalfOfAsync("contoso", "user", CancellationToken.None);
+
+        Assert.NotEqual(first.Value, second.Value);
+    }
+}

--- a/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class TranslationPipelineTests
+{
+    [Fact]
+    public async Task ReturnsCachedResultForDuplicateRequest()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            DailyBudgetUsd = 0.2m,
+            CacheTtl = TimeSpan.FromHours(1),
+            RequestsPerMinute = 10,
+            MaxConcurrentTranslations = 2,
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", CostPerCharUsd = 0.1m, Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var pipeline = BuildPipeline(options);
+
+        var request = new TranslationRequest
+        {
+            Text = "hi",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en"
+        };
+
+        var first = await pipeline.ExecuteAsync(request, CancellationToken.None);
+        var second = await pipeline.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.Equal(first.TranslatedText, second.TranslatedText);
+    }
+
+    [Fact]
+    public async Task ThrowsWhenRateLimitExceeded()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            RequestsPerMinute = 1,
+            MaxConcurrentTranslations = 1,
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var pipeline = BuildPipeline(options);
+
+        await pipeline.ExecuteAsync(new TranslationRequest
+        {
+            Text = "first",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en"
+        }, CancellationToken.None);
+
+        await Assert.ThrowsAsync<RateLimitExceededException>(() => pipeline.ExecuteAsync(new TranslationRequest
+        {
+            Text = "second",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en"
+        }, CancellationToken.None));
+    }
+
+    private static TranslationPipeline BuildPipeline(IOptions<PluginOptions> options)
+    {
+        var glossary = new GlossaryService();
+        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new TokenBroker(new KeyVaultSecretResolver(options), options), options);
+        var cache = new TranslationCache(options);
+        var throttle = new TranslationThrottle(options);
+        return new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, options);
+    }
+}

--- a/tests/TlaPlugin.Tests/TranslationRouterTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationRouterTests.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class TranslationRouterTests
+{
+    [Fact]
+    public async Task UsesFallbackProviderWhenPrimaryFails()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", SimulatedFailures = 2, CostPerCharUsd = 0.00002m, Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso27001"} },
+                new() { Id = "backup", SimulatedFailures = 0, CostPerCharUsd = 0.00002m, Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso27001"}, TranslationPrefix = "[Backup]" }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso27001" }
+            }
+        });
+
+        var tokenBroker = new RecordingTokenBroker();
+        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), tokenBroker, options);
+        var request = new TranslationRequest
+        {
+            Text = "hello world",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en",
+            AdditionalTargetLanguages = new List<string> { "fr" }
+        };
+
+        var result = await router.TranslateAsync(request, CancellationToken.None);
+
+        Assert.Equal(1, tokenBroker.Calls);
+        Assert.Equal("backup", result.ModelId);
+        Assert.Equal("ja", result.TargetLanguage);
+        Assert.True(result.AdditionalTranslations.ContainsKey("fr"));
+        Assert.EndsWith("※已调整为敬语", result.AdditionalTranslations["fr"]);
+        var expectedCost = request.Text.Length * 0.00002m * 2;
+        Assert.Equal(expectedCost, result.CostUsd);
+    }
+
+    [Fact]
+    public async Task ThrowsWhenBudgetExceeded()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            DailyBudgetUsd = 0.00001m,
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", SimulatedFailures = 0, CostPerCharUsd = 0.1m, Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso27001"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso27001" }
+            }
+        });
+
+        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new RecordingTokenBroker(), options);
+        var request = new TranslationRequest
+        {
+            Text = new string('a', 200),
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en"
+        };
+
+        await Assert.ThrowsAsync<BudgetExceededException>(() => router.TranslateAsync(request, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ThrowsWhenTokenBrokerFails()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso27001"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso27001" }
+            }
+        });
+
+        var broker = new RecordingTokenBroker { ShouldThrow = true };
+        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), broker, options);
+
+        await Assert.ThrowsAsync<AuthenticationException>(() => router.TranslateAsync(new TranslationRequest
+        {
+            Text = "hello",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en"
+        }, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RequiresUserIdForTokenExchange()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso27001"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso27001" }
+            }
+        });
+
+        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new RecordingTokenBroker(), options);
+
+        await Assert.ThrowsAsync<AuthenticationException>(() => router.TranslateAsync(new TranslationRequest
+        {
+            Text = "hello",
+            TenantId = "contoso",
+            UserId = string.Empty,
+            TargetLanguage = "ja",
+            SourceLanguage = "en"
+        }, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task AppendsAdditionalTranslationsToCardAndAudit()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso27001"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso27001" }
+            }
+        });
+
+        var audit = new AuditLogger();
+        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), audit, new ToneTemplateService(), new RecordingTokenBroker(), options);
+        var request = new TranslationRequest
+        {
+            Text = "hello world",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja",
+            SourceLanguage = "en",
+            AdditionalTargetLanguages = new List<string> { "fr", "de" }
+        };
+
+        var result = await router.TranslateAsync(request, CancellationToken.None);
+
+        var body = result.AdaptiveCard["body"]!.AsArray().Select(node => node!.AsObject()).ToList();
+        Assert.Contains(body, block => block["text"]?.GetValue<string>() == "额外翻译");
+        Assert.Contains(body, block => block["text"]?.GetValue<string>()?.StartsWith("fr:") == true);
+        Assert.Contains(body, block => block["text"]?.GetValue<string>()?.StartsWith("de:") == true);
+        var actions = result.AdaptiveCard["actions"]!.AsArray();
+        Assert.Contains(actions.Select(a => a!.AsObject()["data"]!.AsObject()["language"]!.GetValue<string>()), language => language == "fr");
+        Assert.Contains(actions.Select(a => a!.AsObject()["data"]!.AsObject()["language"]!.GetValue<string>()), language => language == "de");
+
+        var log = audit.Export().Single();
+        var extras = log["additionalTranslations"]!.AsObject();
+        Assert.Equal(2, extras.Count);
+        Assert.True(extras.ContainsKey("fr"));
+        Assert.True(extras.ContainsKey("de"));
+    }
+
+    private sealed class RecordingTokenBroker : ITokenBroker
+    {
+        public bool ShouldThrow { get; set; }
+        public int Calls { get; private set; }
+
+        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
+        {
+            Calls++;
+            if (ShouldThrow)
+            {
+                throw new AuthenticationException("OBO 流程失败");
+            }
+
+            return Task.FromResult(new AccessToken("token", DateTimeOffset.UtcNow.AddMinutes(5), "api://audience"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- rewrite backend prompts, error messages, and adaptive card strings in simplified Chinese to eliminate mixed-language output
- refresh glossary seeds, documentation, and status descriptions so README and comments consistently describe the Chinese UX
- align unit tests with the updated copy to keep coverage validating the new card sections and error messaging

## Testing
- dotnet test *(fails: dotnet CLI is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da03d99c54832fb27da4682b9312c1