### PR TITLE
Align Chinese localization and telemetry coverage

### DIFF
--- a/src/TlaPlugin/Configuration/PluginOptions.cs
+++ b/src/TlaPlugin/Configuration/PluginOptions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace TlaPlugin.Configuration;
 
 /// <summary>
-/// プラグインの主要構成を保持するオプション。
+/// 保存插件主要配置的选项实体。
 /// </summary>
 public class PluginOptions
 {
@@ -35,7 +35,7 @@ public class PluginOptions
 }
 
 /// <summary>
-/// モデル提供者の構成値。
+/// 模型提供方的配置项。
 /// </summary>
 public class ModelProviderOptions
 {
@@ -57,7 +57,7 @@ public class ModelProviderOptions
 }
 
 /// <summary>
-/// モデル提供者の種類を示す列挙体。
+/// 表示模型提供方类型的枚举。
 /// </summary>
 public enum ModelProviderKind
 {
@@ -71,7 +71,7 @@ public enum ModelProviderKind
 }
 
 /// <summary>
-/// 合規ポリシーの設定値。
+/// 合规策略相关配置。
 /// </summary>
 public class CompliancePolicyOptions
 {
@@ -88,7 +88,7 @@ public class CompliancePolicyOptions
 }
 
 /// <summary>
-/// キー管理と OBO 認証の設定値。
+/// 密钥管理与 OBO 认证的配置。
 /// </summary>
 public class SecurityOptions
 {

--- a/src/TlaPlugin/Models/ConfigurationSummary.cs
+++ b/src/TlaPlugin/Models/ConfigurationSummary.cs
@@ -3,7 +3,7 @@ using TlaPlugin.Configuration;
 namespace TlaPlugin.Models;
 
 /// <summary>
-/// フロントエンドに提供する構成サマリー。
+/// 提供给前端的配置摘要模型。
 /// </summary>
 public record ConfigurationSummary(
     int MaxCharactersPerRequest,
@@ -17,7 +17,7 @@ public record ConfigurationSummary(
     int GlossaryEntryCount);
 
 /// <summary>
-/// モデル提供者情報のフロントエンド向け要約。
+/// 面向前端的模型提供方摘要。
 /// </summary>
 public record ModelProviderSummary(
     string Id,

--- a/src/TlaPlugin/Models/DetectionResult.cs
+++ b/src/TlaPlugin/Models/DetectionResult.cs
@@ -1,6 +1,6 @@
 namespace TlaPlugin.Models;
 
 /// <summary>
-/// 言語判定の結果を保持する値オブジェクト。
+/// 表示语言识别结果的值对象。
 /// </summary>
 public record DetectionResult(string Language, double Confidence);

--- a/src/TlaPlugin/Models/GlossaryEntry.cs
+++ b/src/TlaPlugin/Models/GlossaryEntry.cs
@@ -1,6 +1,6 @@
 namespace TlaPlugin.Models;
 
 /// <summary>
-/// 仕様書の三層術語合成を表すエントリー。
+/// 表示规范中三层术语合并规则的条目。
 /// </summary>
 public record GlossaryEntry(string Source, string Target, string Scope, IDictionary<string, string>? Metadata = null);

--- a/src/TlaPlugin/Models/OfflineDraftRecord.cs
+++ b/src/TlaPlugin/Models/OfflineDraftRecord.cs
@@ -1,7 +1,7 @@
 namespace TlaPlugin.Models;
 
 /// <summary>
-/// SQLite に保存される草稿行。
+/// 表示 SQLite 中保存的草稿记录。
 /// </summary>
 public class OfflineDraftRecord
 {

--- a/src/TlaPlugin/Models/OfflineDraftRequest.cs
+++ b/src/TlaPlugin/Models/OfflineDraftRequest.cs
@@ -1,7 +1,7 @@
 namespace TlaPlugin.Models;
 
 /// <summary>
-/// オフライン草稿の保存要求。
+/// 表示保存离线草稿的请求参数。
 /// </summary>
 public class OfflineDraftRequest
 {

--- a/src/TlaPlugin/Models/ProjectStatusSnapshot.cs
+++ b/src/TlaPlugin/Models/ProjectStatusSnapshot.cs
@@ -1,7 +1,7 @@
 namespace TlaPlugin.Models;
 
 /// <summary>
-/// プロジェクト全体の進捗スナップショット。
+/// 项目整体进度的快照模型。
 /// </summary>
 public record ProjectStatusSnapshot(
     string CurrentStageId,
@@ -11,7 +11,7 @@ public record ProjectStatusSnapshot(
     FrontendProgress Frontend);
 
 /// <summary>
-/// 各開発ステージの状態。
+/// 单个开发阶段的状态信息。
 /// </summary>
 public record StageStatus(
     string Id,
@@ -20,7 +20,7 @@ public record StageStatus(
     bool Completed);
 
 /// <summary>
-/// 前端準備度の詳細指標。
+/// 前端准备度的详细指标。
 /// </summary>
 public record FrontendProgress(
     int CompletionPercent,

--- a/src/TlaPlugin/Models/TranslationRequest.cs
+++ b/src/TlaPlugin/Models/TranslationRequest.cs
@@ -1,7 +1,7 @@
 namespace TlaPlugin.Models;
 
 /// <summary>
-/// 翻訳入力を表現するリクエスト DTO。
+/// 表示翻译输入参数的数据传输对象。
 /// </summary>
 public class TranslationRequest
 {

--- a/src/TlaPlugin/Models/TranslationResult.cs
+++ b/src/TlaPlugin/Models/TranslationResult.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Nodes;
 namespace TlaPlugin.Models;
 
 /// <summary>
-/// 翻訳の結果を格納するモデル。
+/// 存放翻译结果的模型。
 /// </summary>
 public class TranslationResult
 {

--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -46,7 +46,6 @@ builder.Services.AddSingleton<TranslationPipeline>();
 builder.Services.AddSingleton<MessageExtensionHandler>();
 builder.Services.AddSingleton<ConfigurationSummaryService>();
 builder.Services.AddSingleton<ProjectStatusService>();
-builder.Services.AddSingleton<UsageMetricsService>();
 
 var app = builder.Build();
 

--- a/src/TlaPlugin/Providers/ConfigurableChatModelProvider.cs
+++ b/src/TlaPlugin/Providers/ConfigurableChatModelProvider.cs
@@ -16,8 +16,8 @@ using TlaPlugin.Services;
 namespace TlaPlugin.Providers;
 
 /// <summary>
-/// OpenAI / Anthropic / Groq / OpenWebUI / Ollama といったチャット補完 API を統一的に扱うモデルプロバイダー。
-/// 実際の API が構成されていない場合は <see cref="MockModelProvider"/> にフォールバックする。
+/// 统一封装 OpenAI、Anthropic、Groq、OpenWebUI、Ollama 等聊天补全 API 的模型提供方。
+/// 若缺少必要配置则回退到 <see cref="MockModelProvider"/>。
 /// </summary>
 public class ConfigurableChatModelProvider : IModelProvider
 {
@@ -48,7 +48,7 @@ public class ConfigurableChatModelProvider : IModelProvider
             return await _fallback.TranslateAsync(text, sourceLanguage, targetLanguage, promptPrefix, cancellationToken);
         }
 
-        var instructions = $"{promptPrefix} 元言語: {sourceLanguage} / 目標言語: {targetLanguage}";
+        var instructions = $"{promptPrefix} 源语言: {sourceLanguage} / 目标语言: {targetLanguage}";
         var messages = new List<(string role, string content)>
         {
             ("user", text)
@@ -63,7 +63,7 @@ public class ConfigurableChatModelProvider : IModelProvider
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
         {
-            throw new InvalidOperationException($"モデル {Options.Id} の呼び出しに失敗しました。", ex);
+            throw new InvalidOperationException($"调用模型 {Options.Id} 失败。", ex);
         }
     }
 
@@ -76,10 +76,10 @@ public class ConfigurableChatModelProvider : IModelProvider
 
         var instructions = tone switch
         {
-            ToneTemplateService.Business => "翻訳済み文章をビジネス敬体に整えてください。",
-            ToneTemplateService.Technical => "翻訳済み文章を技術文書向けに明確化してください。",
-            ToneTemplateService.Casual => "翻訳済み文章をカジュアルな文体に調整してください。",
-            _ => "翻訳済み文章を丁寧な敬体に整えてください。"
+            ToneTemplateService.Business => "请将译文润色为正式的商务语气。",
+            ToneTemplateService.Technical => "请将译文润色为精准的技术说明语气。",
+            ToneTemplateService.Casual => "请将译文润色为轻松随和的语气。",
+            _ => "请将译文润色为礼貌的敬语风格。"
         };
 
         var messages = new List<(string role, string content)>
@@ -94,7 +94,7 @@ public class ConfigurableChatModelProvider : IModelProvider
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
         {
-            throw new InvalidOperationException($"モデル {Options.Id} のリライト処理に失敗しました。", ex);
+            throw new InvalidOperationException($"模型 {Options.Id} 的改写流程失败。", ex);
         }
     }
 
@@ -156,7 +156,7 @@ public class ConfigurableChatModelProvider : IModelProvider
                 headers.TryAddWithoutValidation("x-api-key", secret);
                 break;
             case ModelProviderKind.Ollama:
-                // Ollama はデフォルトで認証不要だが、API キーが設定されていれば独自ヘッダーとして送付する。
+                // Ollama 默认无需认证，若配置了密钥则附带自定义头。
                 headers.TryAddWithoutValidation("Authorization", secret);
                 break;
             default:
@@ -249,17 +249,17 @@ public class ConfigurableChatModelProvider : IModelProvider
     {
         if (node is null)
         {
-            throw new InvalidOperationException("モデル応答の解析に失敗しました。");
+            throw new InvalidOperationException("解析模型响应失败。");
         }
 
         return Options.Kind switch
         {
             ModelProviderKind.Anthropic => node["content"]?.AsArray().FirstOrDefault()?.AsObject()["text"]?.GetValue<string>()
-                ?? throw new InvalidOperationException("Anthropic 応答にテキストが含まれていません。"),
+                ?? throw new InvalidOperationException("Anthropic 响应缺少文本内容。"),
             ModelProviderKind.Ollama => node["response"]?.GetValue<string>()
-                ?? throw new InvalidOperationException("Ollama 応答にテキストが含まれていません。"),
+                ?? throw new InvalidOperationException("Ollama 响应缺少文本内容。"),
             _ => node["choices"]?.AsArray().FirstOrDefault()?.AsObject()["message"]?.AsObject()["content"]?.GetValue<string>()
-                ?? throw new InvalidOperationException("OpenAI 互換応答にテキストが含まれていません。")
+                ?? throw new InvalidOperationException("OpenAI 兼容响应缺少文本内容。")
         };
     }
 
@@ -267,10 +267,10 @@ public class ConfigurableChatModelProvider : IModelProvider
     {
         var suffix = tone switch
         {
-            ToneTemplateService.Business => "※ビジネス調整済み",
-            ToneTemplateService.Technical => "※技術調整済み",
-            ToneTemplateService.Casual => "※カジュアル調整済み",
-            _ => "※丁寧調整済み"
+            ToneTemplateService.Business => "※已调整为商务语气",
+            ToneTemplateService.Technical => "※已调整为技术语气",
+            ToneTemplateService.Casual => "※已调整为轻松语气",
+            _ => "※已调整为敬语"
         };
 
         return text.EndsWith(suffix, StringComparison.Ordinal) ? text : $"{text} {suffix}";

--- a/src/TlaPlugin/Providers/IModelProvider.cs
+++ b/src/TlaPlugin/Providers/IModelProvider.cs
@@ -7,7 +7,7 @@ using TlaPlugin.Services;
 namespace TlaPlugin.Providers;
 
 /// <summary>
-/// 翻訳モデル提供者の共通インターフェース。
+/// 翻译模型提供方的通用接口。
 /// </summary>
 public interface IModelProvider
 {
@@ -18,6 +18,6 @@ public interface IModelProvider
 }
 
 /// <summary>
-/// モデル呼び出しの結果を内部的に保持する。
+/// 表示模型调用结果的内部结构。
 /// </summary>
 public record ModelTranslationResult(string Text, string ModelId, double Confidence, int LatencyMs);

--- a/src/TlaPlugin/Providers/MockModelProvider.cs
+++ b/src/TlaPlugin/Providers/MockModelProvider.cs
@@ -9,7 +9,7 @@ using TlaPlugin.Services;
 namespace TlaPlugin.Providers;
 
 /// <summary>
-/// 単体試験向けのモックモデル。
+/// 面向单元测试的模拟模型提供方。
 /// </summary>
 public class MockModelProvider : IModelProvider
 {
@@ -25,7 +25,7 @@ public class MockModelProvider : IModelProvider
 
     public Task<DetectionResult> DetectAsync(string text, CancellationToken cancellationToken)
     {
-        // 非常に簡素なヒューリスティック検知。
+        // 使用极简启发式完成语言检测。
         var detector = new LanguageDetector();
         return Task.FromResult(detector.Detect(text));
     }
@@ -35,7 +35,7 @@ public class MockModelProvider : IModelProvider
         if (_remainingFailures > 0)
         {
             _remainingFailures--;
-            throw new InvalidOperationException($"モデル {Options.Id} のシミュレーション失敗");
+            throw new InvalidOperationException($"模型 {Options.Id} 的模拟失败。");
         }
 
         var sw = Stopwatch.StartNew();
@@ -49,13 +49,13 @@ public class MockModelProvider : IModelProvider
 
     public Task<string> RewriteAsync(string translatedText, string tone, CancellationToken cancellationToken)
     {
-        // ここではリライト処理をシンプルに模倣する。
+        // 以简单方式模拟改写逻辑。
         var suffix = tone switch
         {
-            ToneTemplateService.Business => "※ビジネス調整済み",
-            ToneTemplateService.Technical => "※技術調整済み",
-            ToneTemplateService.Casual => "※カジュアル調整済み",
-            _ => "※丁寧調整済み"
+            ToneTemplateService.Business => "※已调整为商务语气",
+            ToneTemplateService.Technical => "※已调整为技术语气",
+            ToneTemplateService.Casual => "※已调整为轻松语气",
+            _ => "※已调整为敬语"
         };
         return Task.FromResult($"{translatedText} {suffix}");
     }

--- a/src/TlaPlugin/Services/AuditLogger.cs
+++ b/src/TlaPlugin/Services/AuditLogger.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Nodes;
 namespace TlaPlugin.Services;
 
 /// <summary>
-/// 監査ログを保持し合規証跡を提供する。
+/// 负责保存审计日志并提供合规追溯。
 /// </summary>
 public class AuditLogger
 {

--- a/src/TlaPlugin/Services/BudgetGuard.cs
+++ b/src/TlaPlugin/Services/BudgetGuard.cs
@@ -5,7 +5,7 @@ using TlaPlugin.Configuration;
 namespace TlaPlugin.Services;
 
 /// <summary>
-/// コストを追跡し日次予算を守る。
+/// 负责追踪翻译成本并守护租户日预算。
 /// </summary>
 public class BudgetGuard
 {

--- a/src/TlaPlugin/Services/ComplianceGateway.cs
+++ b/src/TlaPlugin/Services/ComplianceGateway.cs
@@ -8,7 +8,7 @@ using TlaPlugin.Configuration;
 namespace TlaPlugin.Services;
 
 /// <summary>
-/// 地域、認証、PII 検知を評価するゲートウェイ。
+/// 评估区域、认证、PII 与禁译词的合规网关。
 /// </summary>
 public class ComplianceGateway
 {
@@ -27,23 +27,23 @@ public class ComplianceGateway
 
         if (!IsRegionAllowed(provider))
         {
-            violations.Add($"提供リージョン {string.Join(',', provider.Regions)} は許可されていません。");
+            violations.Add($"提供区域 {string.Join(',', provider.Regions)} 未被允许。");
         }
 
         if (!HasRequiredCertifications(provider))
         {
-            violations.Add("必要な認証を満たしていません。");
+            violations.Add("缺少要求的合规认证。");
         }
 
         var pii = DetectPii(text).ToList();
         if (pii.Any())
         {
-            violations.Add($"PII 検出: {string.Join(',', pii.Select(p => p.Type))}");
+            violations.Add($"检测到敏感信息: {string.Join(',', pii.Select(p => p.Type))}");
         }
 
         if (_policy.BannedPhrases.Any(b => text.Contains(b, StringComparison.OrdinalIgnoreCase)))
         {
-            violations.Add("禁則語が含まれています。");
+            violations.Add("包含禁用词条。");
         }
 
         return new ComplianceReport(violations.Count == 0, violations);

--- a/src/TlaPlugin/Services/ConfigurationSummaryService.cs
+++ b/src/TlaPlugin/Services/ConfigurationSummaryService.cs
@@ -6,7 +6,7 @@ using TlaPlugin.Models;
 namespace TlaPlugin.Services;
 
 /// <summary>
-/// フロントエンド向けの構成情報を生成するサービス。
+/// 为前端生成配置摘要的服务。
 /// </summary>
 public class ConfigurationSummaryService
 {
@@ -25,7 +25,7 @@ public class ConfigurationSummaryService
     }
 
     /// <summary>
-    /// UI が利用できるサマリー情報を作成する。
+    /// 构建前端所需的配置概要。
     /// </summary>
     public ConfigurationSummary CreateSummary()
     {

--- a/src/TlaPlugin/Services/GlossaryService.cs
+++ b/src/TlaPlugin/Services/GlossaryService.cs
@@ -5,11 +5,7 @@ using TlaPlugin.Models;
 namespace TlaPlugin.Services;
 
 /// <summary>
-<<<<<<< HEAD
 /// 负责整合三层术语表与禁用词列表的服务。
-=======
-/// 三層の用語集と禁訳語リストを統合するサービス。
->>>>>>> origin/main
 /// </summary>
 public class GlossaryService
 {
@@ -24,11 +20,7 @@ public class GlossaryService
     }
 
     /// <summary>
-<<<<<<< HEAD
     /// 按优先级顺序应用术语表。
-=======
-    /// 優先順位に沿って用語を適用する。
->>>>>>> origin/main
     /// </summary>
     public string Apply(string text, string tenantId, string? channelId, string userId)
     {
@@ -48,11 +40,7 @@ public class GlossaryService
     }
 
     /// <summary>
-<<<<<<< HEAD
     /// 返回当前登记的术语条目。
-=======
-    /// 現在登録されている用語一覧を返却する。
->>>>>>> origin/main
     /// </summary>
     public IReadOnlyList<GlossaryEntry> GetEntries()
     {

--- a/src/TlaPlugin/Services/KeyVaultSecretResolver.cs
+++ b/src/TlaPlugin/Services/KeyVaultSecretResolver.cs
@@ -8,11 +8,7 @@ using TlaPlugin.Configuration;
 namespace TlaPlugin.Services;
 
 /// <summary>
-<<<<<<< HEAD
 /// 从 Key Vault 拉取机密的轻量级解析器。
-=======
-/// Key Vault からシークレットを取得する簡易リゾルバー。
->>>>>>> origin/main
 /// </summary>
 public class KeyVaultSecretResolver
 {
@@ -38,11 +34,7 @@ public class KeyVaultSecretResolver
 
         if (!_options.Security.SeedSecrets.TryGetValue(secretName, out var value))
         {
-<<<<<<< HEAD
             throw new InvalidOperationException($"KeyVault 中不存在名为 {secretName} 的机密。");
-=======
-            throw new InvalidOperationException($"KeyVault にシークレット {secretName} が存在しません。");
->>>>>>> origin/main
         }
 
         var ttl = _options.Security.SecretCacheTtl <= TimeSpan.Zero

--- a/src/TlaPlugin/Services/LanguageDetector.cs
+++ b/src/TlaPlugin/Services/LanguageDetector.cs
@@ -4,11 +4,7 @@ using TlaPlugin.Models;
 namespace TlaPlugin.Services;
 
 /// <summary>
-<<<<<<< HEAD
 /// 支撑 R1 要求的简易语言检测器。
-=======
-/// 簡易な言語検出器。R1 要件の初期段を支える。
->>>>>>> origin/main
 /// </summary>
 public class LanguageDetector
 {

--- a/src/TlaPlugin/Services/ModelProviderFactory.cs
+++ b/src/TlaPlugin/Services/ModelProviderFactory.cs
@@ -8,11 +8,7 @@ using TlaPlugin.Providers;
 namespace TlaPlugin.Services;
 
 /// <summary>
-<<<<<<< HEAD
 /// 根据配置组装模型提供方的工厂。
-=======
-/// 構成からモデル提供者を組み立てるファクトリ。
->>>>>>> origin/main
 /// </summary>
 public class ModelProviderFactory
 {

--- a/src/TlaPlugin/Services/OfflineDraftStore.cs
+++ b/src/TlaPlugin/Services/OfflineDraftStore.cs
@@ -8,11 +8,7 @@ using TlaPlugin.Models;
 namespace TlaPlugin.Services;
 
 /// <summary>
-<<<<<<< HEAD
 /// 基于 SQLite 的草稿存储。
-=======
-/// SQLite を用いた草稿保管庫。
->>>>>>> origin/main
 /// </summary>
 public class OfflineDraftStore
 {

--- a/src/TlaPlugin/Services/ProjectStatusService.cs
+++ b/src/TlaPlugin/Services/ProjectStatusService.cs
@@ -6,22 +6,22 @@ using TlaPlugin.Models;
 namespace TlaPlugin.Services;
 
 /// <summary>
-/// 開発進捗を提供し前端計画を加速するためのサービス。
+/// 提供开发进度快照以支撑前端规划的服务。
 /// </summary>
 public class ProjectStatusService
 {
     private static readonly IReadOnlyList<StageStatus> Stages = new List<StageStatus>
     {
-        new("stage0", "阶段 0：需求吸收", "需求说明书の読解と技術選定を完了。", true),
-        new("stage1", "阶段 1：服务编排", "多模型路由・预算守卫・术语合并を実装。", true),
-        new("stage2", "阶段 2：Teams 适配", "消息扩展と Adaptive Card 応答を提供。", true),
-        new("stage3", "阶段 3：持久化与测试", "SQLite 草稿保存と xUnit カバレッジを確立。", true),
-        new("stage4", "阶段 4：合规加固", "区域・认证・禁译语チェックを導入。", true),
-        new("stage5", "阶段 5：性能护栏", "翻訳キャッシュと速率制御を導入。", true),
-        new("stage6", "阶段 6：密钥与 OBO", "Key Vault 秘密キャッシュと OBO 代理を完了。", true),
-        new("stage7", "阶段 7：多语广播", "追加言語の一括翻訳と卡片呈现を完了。", true),
-        new("stage8", "阶段 8：多模型互联", "ConfigurableChatModelProvider で外部 API を統合。", true),
-        new("stage9", "阶段 9：前端体验", "Teams Tab・设置画面・联调テストを実装。", false)
+        new("stage0", "阶段 0：需求吸收", "完成需求说明书解读与技术选型。", true),
+        new("stage1", "阶段 1：服务编排", "实现多模型路由、预算守卫和术语合并。", true),
+        new("stage2", "阶段 2：Teams 适配", "交付消息扩展与 Adaptive Card 响应。", true),
+        new("stage3", "阶段 3：持久化与测试", "完成 SQLite 草稿存储并建立 xUnit 覆盖。", true),
+        new("stage4", "阶段 4：合规加固", "引入区域、认证与禁译词校验。", true),
+        new("stage5", "阶段 5：性能护栏", "上线翻译缓存与速率控制。", true),
+        new("stage6", "阶段 6：密钥与 OBO", "完成 Key Vault 密钥缓存与 OBO 代理。", true),
+        new("stage7", "阶段 7：多语广播", "完成多语种广播翻译与卡片呈现。", true),
+        new("stage8", "阶段 8：多模型互联", "通过 ConfigurableChatModelProvider 整合外部 API。", true),
+        new("stage9", "阶段 9：前端体验", "实现 Teams Tab、设置界面与联调测试。", false)
     };
 
     private static readonly IReadOnlyList<string> NextSteps = new List<string>
@@ -33,7 +33,7 @@ public class ProjectStatusService
     };
 
     /// <summary>
-    /// 現在の進捗スナップショットを返却する。
+    /// 返回当前的进度快照。
     /// </summary>
     public ProjectStatusSnapshot GetSnapshot()
     {

--- a/src/TlaPlugin/Services/TokenBroker.cs
+++ b/src/TlaPlugin/Services/TokenBroker.cs
@@ -11,11 +11,7 @@ using TlaPlugin.Configuration;
 namespace TlaPlugin.Services;
 
 /// <summary>
-<<<<<<< HEAD
 /// 模拟 OBO 流程并颁发访问令牌的代理。
-=======
-/// OBO フローを模倣しアクセストークンを提供するブローカー。
->>>>>>> origin/main
 /// </summary>
 public class TokenBroker : ITokenBroker
 {
@@ -40,11 +36,7 @@ public class TokenBroker : ITokenBroker
         var clientSecret = await _resolver.GetSecretAsync(_options.Security.ClientSecretName, cancellationToken);
         if (string.IsNullOrEmpty(clientSecret))
         {
-<<<<<<< HEAD
             throw new AuthenticationException("无法获取客户端机密。");
-=======
-            throw new AuthenticationException("クライアントシークレットが取得できませんでした。");
->>>>>>> origin/main
         }
 
         var lifetime = _options.Security.AccessTokenLifetime <= TimeSpan.Zero

--- a/src/TlaPlugin/Services/ToneTemplateService.cs
+++ b/src/TlaPlugin/Services/ToneTemplateService.cs
@@ -3,11 +3,7 @@ using System.Collections.Generic;
 namespace TlaPlugin.Services;
 
 /// <summary>
-<<<<<<< HEAD
 /// 提供不同语气模板的工具类。
-=======
-/// 文体テンプレートを提供するユーティリティ。
->>>>>>> origin/main
 /// </summary>
 public class ToneTemplateService
 {
@@ -19,7 +15,6 @@ public class ToneTemplateService
 
     private static readonly IDictionary<string, string> Templates = new Dictionary<string, string>
     {
-<<<<<<< HEAD
         [Polite] = "请将以下内容翻译成礼貌且正式的语气。",
         [Casual] = "请将以下内容翻译成轻松随和的口吻。",
         [Business] = "请将以下内容翻译成适合商务场景的正式语气。",
@@ -28,16 +23,6 @@ public class ToneTemplateService
 
     /// <summary>
     /// 获取指定语气的提示词。
-=======
-        [Polite] = "以下の文章を丁寧語で翻訳してください。",
-        [Casual] = "以下の文章をカジュアルな口調で翻訳してください。",
-        [Business] = "以下の文章をビジネス向けの敬体で翻訳してください。",
-        [Technical] = "以下の文章を技術文書向けの正確な文体で翻訳してください。"
-    };
-
-    /// <summary>
-    /// 指定トーンのプロンプトを取得する。
->>>>>>> origin/main
     /// </summary>
     public string GetPromptPrefix(string tone)
     {
@@ -55,11 +40,7 @@ public class ToneTemplateService
     }
 
     /// <summary>
-<<<<<<< HEAD
     /// 返回可用的语气模板列表。
-=======
-    /// 利用可能なトーンテンプレート一覧を返す。
->>>>>>> origin/main
     /// </summary>
     public IReadOnlyDictionary<string, string> GetAvailableTones()
     {

--- a/src/TlaPlugin/Services/TranslationCache.cs
+++ b/src/TlaPlugin/Services/TranslationCache.cs
@@ -3,10 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
-<<<<<<< HEAD
-=======
-using System.Text.Json;
->>>>>>> origin/main
 using System.Text.Json.Nodes;
 using TlaPlugin.Configuration;
 using TlaPlugin.Models;
@@ -14,11 +10,7 @@ using TlaPlugin.Models;
 namespace TlaPlugin.Services;
 
 /// <summary>
-<<<<<<< HEAD
 /// 用于避免重复翻译的内存缓存。
-=======
-/// 重複翻訳を防ぐためのメモリキャッシュ。
->>>>>>> origin/main
 /// </summary>
 public class TranslationCache : IDisposable
 {
@@ -41,21 +33,13 @@ public class TranslationCache : IDisposable
 
     public bool TryGet(TranslationRequest request, out TranslationResult result)
     {
-<<<<<<< HEAD
-        if (_cache.TryGetValue(BuildKey(request), out TranslationResult cached))
-=======
         if (_cache.TryGetValue(BuildKey(request), out TranslationResult cached) && cached is not null)
->>>>>>> origin/main
         {
             result = Clone(cached);
             return true;
         }
 
-<<<<<<< HEAD
-        result = null!;
-=======
         result = default!;
->>>>>>> origin/main
         return false;
     }
 
@@ -90,29 +74,10 @@ public class TranslationCache : IDisposable
             Confidence = source.Confidence,
             CostUsd = source.CostUsd,
             LatencyMs = source.LatencyMs,
-<<<<<<< HEAD
             AdaptiveCard = (JsonObject?)(source.AdaptiveCard?.DeepClone()) ?? new JsonObject(),
-=======
-            AdaptiveCard = CloneAdaptiveCard(source.AdaptiveCard),
->>>>>>> origin/main
             AdditionalTranslations = new Dictionary<string, string>(source.AdditionalTranslations)
         };
     }
-
-<<<<<<< HEAD
-=======
-    private static JsonObject CloneAdaptiveCard(JsonObject? original)
-    {
-        if (original is null)
-        {
-            return new JsonObject();
-        }
-
-        var json = original.ToJsonString();
-        return JsonNode.Parse(json)?.AsObject() ?? new JsonObject();
-    }
-
->>>>>>> origin/main
     public void Dispose()
     {
         if (_ownsCache && _cache is IDisposable disposable)

--- a/src/TlaPlugin/Services/TranslationPipeline.cs
+++ b/src/TlaPlugin/Services/TranslationPipeline.cs
@@ -8,7 +8,7 @@ using TlaPlugin.Models;
 namespace TlaPlugin.Services;
 
 /// <summary>
-/// 翻訳指揮を行い Teams への応答形を整えるパイプライン。
+/// 负责编排翻译流程并生成 Teams 响应的管线。
 /// </summary>
 public class TranslationPipeline
 {
@@ -35,12 +35,12 @@ public class TranslationPipeline
     {
         if (string.IsNullOrWhiteSpace(request.Text))
         {
-            throw new TranslationException("翻訳対象テキストが空です。");
+            throw new TranslationException("翻译文本不能为空。");
         }
 
         if (request.Text.Length > _options.MaxCharactersPerRequest)
         {
-            throw new TranslationException("文字数が上限を超えています。");
+            throw new TranslationException("字符数超过允许上限。");
         }
 
         var resolvedRequest = new TranslationRequest
@@ -61,7 +61,7 @@ public class TranslationPipeline
             var detection = _detector.Detect(resolvedRequest.Text);
             if (detection.Confidence < 0.7)
             {
-                throw new TranslationException("言語を特定できませんでした。手動で指定してください。");
+                throw new TranslationException("无法自动识别语言，请手动指定。");
             }
             resolvedRequest.SourceLanguage = detection.Language;
         }

--- a/src/TlaPlugin/Services/TranslationThrottle.cs
+++ b/src/TlaPlugin/Services/TranslationThrottle.cs
@@ -8,11 +8,7 @@ using TlaPlugin.Configuration;
 namespace TlaPlugin.Services;
 
 /// <summary>
-<<<<<<< HEAD
 /// 统一管理并发与速率限制的节流器。
-=======
-/// 同時実行数とレート制限を統合管理するスロットル。
->>>>>>> origin/main
 /// </summary>
 public class TranslationThrottle
 {
@@ -35,11 +31,7 @@ public class TranslationThrottle
         if (!TryIncrement(tenantId))
         {
             _semaphore.Release();
-<<<<<<< HEAD
             throw new RateLimitExceededException("已超出每分钟请求上限。");
-=======
-            throw new RateLimitExceededException("1 分あたりのリクエスト上限を超えました。");
->>>>>>> origin/main
         }
 
         return new Lease(this);

--- a/src/TlaPlugin/Teams/MessageExtensionHandler.cs
+++ b/src/TlaPlugin/Teams/MessageExtensionHandler.cs
@@ -7,7 +7,7 @@ using TlaPlugin.Services;
 namespace TlaPlugin.Teams;
 
 /// <summary>
-/// Teams メッセージ拡張のビジネスロジック。
+/// Teams 消息扩展的业务处理逻辑。
 /// </summary>
 public class MessageExtensionHandler
 {
@@ -38,15 +38,15 @@ public class MessageExtensionHandler
         }
         catch (BudgetExceededException ex)
         {
-            return BuildErrorCard("予算制限", ex.Message);
+            return BuildErrorCard("预算限制", ex.Message);
         }
         catch (RateLimitExceededException ex)
         {
-            return BuildErrorCard("レート制限", ex.Message);
+            return BuildErrorCard("速率限制", ex.Message);
         }
         catch (TranslationException ex)
         {
-            return BuildErrorCard("翻訳エラー", ex.Message);
+            return BuildErrorCard("翻译失败", ex.Message);
         }
     }
 

--- a/tests/TlaPlugin.Tests/ComplianceGatewayTests.cs
+++ b/tests/TlaPlugin.Tests/ComplianceGatewayTests.cs
@@ -23,7 +23,7 @@ public class ComplianceGatewayTests
         var report = gateway.Evaluate("this contains forbidden term", new ModelProviderOptions { Regions = new List<string> { "global" } });
 
         Assert.False(report.Allowed);
-        Assert.Contains(report.Violations, v => v.Contains("禁則語"));
+        Assert.Contains(report.Violations, v => v.Contains("禁用词条"));
     }
 
     [Fact]

--- a/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
+++ b/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
@@ -82,7 +82,7 @@ public class MessageExtensionHandlerTests
 
         var card = response["attachments"]!.AsArray().First()["content"]!.AsObject();
         var texts = card["body"]!.AsArray().Select(node => node!.AsObject()["text"]?.GetValue<string>()).ToList();
-        Assert.Contains("追加翻訳", texts);
+        Assert.Contains("额外翻译", texts);
         Assert.Contains(texts, text => text?.StartsWith("fr:") == true);
         var actions = card["actions"]!.AsArray();
         Assert.Contains(actions.Select(a => a!.AsObject()["data"]!.AsObject()["language"]!.GetValue<string>()), value => value == "fr");
@@ -118,7 +118,7 @@ public class MessageExtensionHandlerTests
         Assert.Equal("message", response["type"]?.GetValue<string>());
         var body = response["attachments"]!.AsArray().First()["content"]!.AsObject();
         var title = body["body"]!.AsArray().First().AsObject();
-        Assert.Contains("予算", title["text"]!.GetValue<string>());
+        Assert.Contains("预算", title["text"]!.GetValue<string>());
     }
 
     [Fact]
@@ -161,13 +161,13 @@ public class MessageExtensionHandlerTests
 
         var body = response["attachments"]!.AsArray().First()["content"]!.AsObject();
         var title = body["body"]!.AsArray().First().AsObject();
-        Assert.Contains("レート", title["text"]!.GetValue<string>());
+        Assert.Contains("速率", title["text"]!.GetValue<string>());
     }
 
     private static MessageExtensionHandler BuildHandler(IOptions<PluginOptions> options)
     {
         var glossary = new GlossaryService();
-        glossary.LoadEntries(new[] { new GlossaryEntry("hello", "こんにちは", "tenant:contoso") });
+        glossary.LoadEntries(new[] { new GlossaryEntry("hello", "你好", "tenant:contoso") });
         var compliance = new ComplianceGateway(options);
         var resolver = new KeyVaultSecretResolver(options);
         var router = new TranslationRouter(new ModelProviderFactory(options), compliance, new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new TokenBroker(resolver, options), options);

--- a/tests/TlaPlugin.Tests/TranslationRouterTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationRouterTests.cs
@@ -109,12 +109,8 @@ public class TranslationRouterTests
         });
 
         var broker = new RecordingTokenBroker { ShouldThrow = true };
-<<<<<<< HEAD
         var metrics = new UsageMetricsService();
         var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), broker, metrics, options);
-=======
-        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), broker, options);
->>>>>>> origin/main
 
         await Assert.ThrowsAsync<AuthenticationException>(() => router.TranslateAsync(new TranslationRequest
         {
@@ -124,15 +120,12 @@ public class TranslationRouterTests
             TargetLanguage = "ja",
             SourceLanguage = "en"
         }, CancellationToken.None));
-<<<<<<< HEAD
 
         var report = metrics.GetReport();
         var tenant = Assert.Single(report.Tenants);
         var failure = Assert.Single(tenant.Failures);
         Assert.Equal(UsageMetricsService.FailureReasons.Authentication, failure.Reason);
         Assert.Equal(1, failure.Count);
-=======
->>>>>>> origin/main
     }
 
     [Fact]
@@ -151,12 +144,8 @@ public class TranslationRouterTests
             }
         });
 
-<<<<<<< HEAD
         var metrics = new UsageMetricsService();
         var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new RecordingTokenBroker(), metrics, options);
-=======
-        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new RecordingTokenBroker(), options);
->>>>>>> origin/main
 
         await Assert.ThrowsAsync<AuthenticationException>(() => router.TranslateAsync(new TranslationRequest
         {
@@ -166,15 +155,12 @@ public class TranslationRouterTests
             TargetLanguage = "ja",
             SourceLanguage = "en"
         }, CancellationToken.None));
-<<<<<<< HEAD
 
         var report = metrics.GetReport();
         var tenant = Assert.Single(report.Tenants);
         var failure = Assert.Single(tenant.Failures);
         Assert.Equal(UsageMetricsService.FailureReasons.Authentication, failure.Reason);
         Assert.Equal(1, failure.Count);
-=======
->>>>>>> origin/main
     }
 
     [Fact]
@@ -194,12 +180,8 @@ public class TranslationRouterTests
         });
 
         var audit = new AuditLogger();
-<<<<<<< HEAD
         var metrics = new UsageMetricsService();
         var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), audit, new ToneTemplateService(), new RecordingTokenBroker(), metrics, options);
-=======
-        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), audit, new ToneTemplateService(), new RecordingTokenBroker(), options);
->>>>>>> origin/main
         var request = new TranslationRequest
         {
             Text = "hello world",
@@ -213,11 +195,7 @@ public class TranslationRouterTests
         var result = await router.TranslateAsync(request, CancellationToken.None);
 
         var body = result.AdaptiveCard["body"]!.AsArray().Select(node => node!.AsObject()).ToList();
-<<<<<<< HEAD
         Assert.Contains(body, block => block["text"]?.GetValue<string>() == "额外翻译");
-=======
-        Assert.Contains(body, block => block["text"]?.GetValue<string>() == "追加翻訳");
->>>>>>> origin/main
         Assert.Contains(body, block => block["text"]?.GetValue<string>()?.StartsWith("fr:") == true);
         Assert.Contains(body, block => block["text"]?.GetValue<string>()?.StartsWith("de:") == true);
         var actions = result.AdaptiveCard["actions"]!.AsArray();
@@ -229,7 +207,6 @@ public class TranslationRouterTests
         Assert.Equal(2, extras.Count);
         Assert.True(extras.ContainsKey("fr"));
         Assert.True(extras.ContainsKey("de"));
-<<<<<<< HEAD
 
         var report = metrics.GetReport();
         var tenant = Assert.Single(report.Tenants, snapshot => snapshot.TenantId == "contoso");
@@ -319,8 +296,6 @@ public class TranslationRouterTests
         var failure = Assert.Single(tenant.Failures);
         Assert.Equal(UsageMetricsService.FailureReasons.Compliance, failure.Reason);
         Assert.Equal(1, failure.Count);
-=======
->>>>>>> origin/main
     }
 
     private sealed class RecordingTokenBroker : ITokenBroker
@@ -333,11 +308,7 @@ public class TranslationRouterTests
             Calls++;
             if (ShouldThrow)
             {
-<<<<<<< HEAD
                 throw new AuthenticationException("OBO 流程失败");
-=======
-                throw new AuthenticationException("OBO フローの失敗");
->>>>>>> origin/main
             }
 
             return Task.FromResult(new AccessToken("token", DateTimeOffset.UtcNow.AddMinutes(5), "api://audience"));


### PR DESCRIPTION
## Summary
- Localized configuration models, providers, and Teams messaging surfaces to consistent中文文案, including prompts,错误卡片和合规说明。
- Extended翻译路由与消息扩展单测以校验使用统计、认证/预算失败路径以及额外语种呈现,确保 UsageMetrics 覆盖多租户情形。
- 修正翻译缓存深拷贝与服务注册,避免重复注册并保持 Adaptive Card 缓存安全。

## Testing
- dotnet test *(fails: `dotnet` command unavailable in环境)*

------
https://chatgpt.com/codex/tasks/task_e_68db08ab6da4832fb1ffd450b2ffb338