### PR TITLE
Add Teams surfaces for translation workflows

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,31 @@ import { TranslationPipeline } from "./services/translationPipeline.js";
 import { MessageExtensionHandler } from "./teams/messageExtension.js";
 import { DEFAULT_MODEL_ALLOW_LIST, compliancePolicy } from "./config.js";
 
+function buildMetadata() {
+  return {
+    models: DEFAULT_MODEL_ALLOW_LIST.map((model) => ({
+      id: model.id,
+      displayName: model.id,
+      costPerCharUsd: model.costPerCharUsd,
+      latencyTargetMs: model.latencyTargetMs
+    })),
+    languages: [
+      { id: "auto", name: "自动检测", isDefault: true },
+      { id: "en", name: "English" },
+      { id: "zh-Hans", name: "简体中文" },
+      { id: "ja", name: "日本語" },
+      { id: "fr", name: "Français" }
+    ],
+    features: {
+      terminologyToggle: true,
+      offlineDraft: true
+    },
+    pricing: {
+      currency: "USD"
+    }
+  };
+}
+
 function buildHandler() {
   const providers = DEFAULT_MODEL_ALLOW_LIST.map((config) =>
     new MockModelProvider({
@@ -44,8 +69,25 @@ function buildHandler() {
   return new MessageExtensionHandler({ pipeline });
 }
 
-export function createServer({ handler = buildHandler() } = {}) {
+export function createServer({ handler = buildHandler(), metadata = buildMetadata() } = {}) {
   return http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    if (req.method === "GET" && url.pathname === "/api/metadata") {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify(metadata));
+      return;
+    }
+    if (req.method === "POST" && url.pathname === "/api/draft") {
+      let body = "";
+      for await (const chunk of req) {
+        body += chunk;
+      }
+      const payload = JSON.parse(body || "{}");
+      const result = await handler.handleOfflineDraft(payload);
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify(result));
+      return;
+    }
     if (req.method !== "POST") {
       res.statusCode = 405;
       res.end("Method Not Allowed");

--- a/src/teams/botCommands.js
+++ b/src/teams/botCommands.js
@@ -1,0 +1,124 @@
+import { TranslationPipeline } from "../services/translationPipeline.js";
+
+export class BotCommandProcessor {
+  constructor({ pipeline }) {
+    if (!(pipeline instanceof TranslationPipeline)) {
+      throw new Error("pipeline must be an instance of TranslationPipeline");
+    }
+    this.pipeline = pipeline;
+  }
+
+  parseCommand(text = "") {
+    const trimmed = text.trim();
+    if (!trimmed.startsWith("/")) {
+      return null;
+    }
+    const [commandToken, ...rest] = trimmed.slice(1).split(/\s+/);
+    const command = commandToken?.toLowerCase();
+    const argsText = rest.join(" ").trim();
+    if (!command) {
+      return null;
+    }
+    if (command === "help") {
+      return { command };
+    }
+    if (command === "translate") {
+      const options = {};
+      const words = rest;
+      const remaining = [];
+      for (const word of words) {
+        const [key, value] = word.split("=");
+        if (value) {
+          options[key.toLowerCase()] = value;
+        } else {
+          remaining.push(word);
+        }
+      }
+      return {
+        command,
+        text: remaining.join(" ").trim(),
+        targetLanguage: options.to ?? options.lang ?? "en",
+        sourceLanguage: options.from,
+        modelId: options.model,
+        useTerminology: options.terminology !== "off"
+      };
+    }
+    if (command === "config") {
+      return { command, args: argsText };
+    }
+    return { command: "help" };
+  }
+
+  buildHelpCard() {
+    return {
+      type: "AdaptiveCard",
+      version: "1.5",
+      body: [
+        { type: "TextBlock", text: "翻译助手命令", weight: "Bolder", size: "Medium" },
+        { type: "TextBlock", text: "/translate to=ja 内容 — 翻译指定文本", wrap: true },
+        { type: "TextBlock", text: "/config — 查看租户配置", wrap: true },
+        { type: "TextBlock", text: "/help — 查看帮助", wrap: true }
+      ]
+    };
+  }
+
+  buildConfigCard(config = {}) {
+    return {
+      type: "AdaptiveCard",
+      version: "1.5",
+      body: [
+        { type: "TextBlock", text: "当前租户配置", weight: "Bolder" },
+        {
+          type: "FactSet",
+          facts: [
+            { title: "默认目标语言", value: config.defaultTargetLanguage ?? "未设置" },
+            { title: "启用术语库", value: config.features?.terminology ? "是" : "否" },
+            { title: "允许模型", value: (config.allowedModels ?? []).join(", ") || "无" }
+          ]
+        }
+      ]
+    };
+  }
+
+  async handleCommand({ text, tenantId, userId, channelId, context = {} }) {
+    const parsed = this.parseCommand(text);
+    if (!parsed) {
+      return this.buildHelpCard();
+    }
+    if (parsed.command === "help") {
+      return this.buildHelpCard();
+    }
+    if (parsed.command === "config") {
+      return this.buildConfigCard(context.configuration);
+    }
+    if (parsed.command === "translate") {
+      if (!parsed.text) {
+        return {
+          type: "AdaptiveCard",
+          version: "1.5",
+          body: [{ type: "TextBlock", text: "请提供要翻译的文本", wrap: true }]
+        };
+      }
+      const payload = {
+        text: parsed.text,
+        sourceLanguage: parsed.sourceLanguage,
+        targetLanguage: parsed.targetLanguage,
+        tenantId,
+        userId,
+        channelId,
+        metadata: {
+          origin: "botCommand",
+          modelId: parsed.modelId,
+          useTerminology: parsed.useTerminology
+        }
+      };
+      const result = await this.pipeline.translateAndReply(payload);
+      return result.replyPayload;
+    }
+    return this.buildHelpCard();
+  }
+}
+
+export default {
+  BotCommandProcessor
+};

--- a/src/webapp/apiClient.js
+++ b/src/webapp/apiClient.js
@@ -1,0 +1,68 @@
+const FALLBACK_METADATA = {
+  models: [
+    { id: "azureOpenAI:gpt-4o", displayName: "Azure OpenAI GPT-4o", costPerCharUsd: 0.00002, latencyTargetMs: 1800 },
+    { id: "anthropic:claude-3", displayName: "Anthropic Claude 3", costPerCharUsd: 0.000018, latencyTargetMs: 2200 },
+    { id: "ollama:llama3", displayName: "Ollama Llama 3", costPerCharUsd: 0.000005, latencyTargetMs: 2500 }
+  ],
+  languages: [
+    { id: "auto", name: "自动检测", isDefault: true },
+    { id: "en", name: "English" },
+    { id: "zh-Hans", name: "简体中文" },
+    { id: "ja", name: "日本語" },
+    { id: "fr", name: "Français" }
+  ],
+  features: {
+    terminologyToggle: true,
+    offlineDraft: true
+  },
+  pricing: {
+    currency: "USD",
+    dailyBudgetUsd: 20
+  }
+};
+
+export async function fetchMetadata(fetchImpl = fetch) {
+  try {
+    const response = await fetchImpl("/api/metadata", { method: "GET" });
+    if (!response.ok) {
+      throw new Error(`metadata request failed: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.warn("使用本地消息扩展元数据", error.message);
+    return FALLBACK_METADATA;
+  }
+}
+
+export async function translateText(payload, fetchImpl = fetch) {
+  const response = await fetchImpl("/api/translate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`翻译接口失败: ${response.status} ${text}`);
+  }
+  return await response.json();
+}
+
+export async function saveOfflineDraft(payload, fetchImpl = fetch) {
+  const response = await fetchImpl("/api/draft", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  if (!response.ok) {
+    throw new Error(`保存离线草稿失败: ${response.status}`);
+  }
+  return await response.json();
+}
+
+export { FALLBACK_METADATA };
+
+export default {
+  fetchMetadata,
+  translateText,
+  saveOfflineDraft
+};

--- a/src/webapp/compose.html
+++ b/src/webapp/compose.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BOBTLA Compose 插件</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body class="compose" data-compose-root>
+    <header class="compose__header">
+      <h1>内联翻译助手</h1>
+      <p>在撰写消息时快速生成译文预览。</p>
+    </header>
+    <main class="compose__main">
+      <label>
+        目标语言
+        <select data-compose-target aria-label="目标语言"></select>
+      </label>
+      <label class="toggle">
+        <input type="checkbox" data-terminology-toggle checked /> 使用术语表
+      </label>
+      <label class="compose__editor">
+        原文
+        <textarea rows="5" data-compose-input placeholder="输入要翻译的消息"></textarea>
+      </label>
+      <label class="compose__editor">
+        译文预览
+        <textarea rows="5" data-compose-preview readonly></textarea>
+      </label>
+    </main>
+    <footer class="compose__footer">
+      <button type="button" class="btn" data-compose-suggest>生成建议</button>
+      <button type="button" class="btn btn--primary" data-compose-apply>应用译文</button>
+    </footer>
+    <script type="module" src="./composePlugin.js"></script>
+  </body>
+</html>

--- a/src/webapp/composePlugin.js
+++ b/src/webapp/composePlugin.js
@@ -1,0 +1,119 @@
+import { ensureTeamsContext } from "./teamsContext.js";
+import { fetchMetadata, translateText } from "./apiClient.js";
+import { buildDialogState, buildTranslatePayload } from "./dialogState.js";
+
+function resolveComposeUi(root = typeof document !== "undefined" ? document : undefined) {
+  if (!root) {
+    return {};
+  }
+  return {
+    input: root.querySelector?.("[data-compose-input]"),
+    targetSelect: root.querySelector?.("[data-compose-target]") ?? root.querySelector?.("[data-target-select]"),
+    suggestButton: root.querySelector?.("[data-compose-suggest]"),
+    applyButton: root.querySelector?.("[data-compose-apply]"),
+    preview: root.querySelector?.("[data-compose-preview]"),
+    terminologyToggle: root.querySelector?.("[data-terminology-toggle]")
+  };
+}
+
+function setPreview(previewElement, text) {
+  if (!previewElement) {
+    return;
+  }
+  if ("value" in previewElement) {
+    previewElement.value = text;
+    return;
+  }
+  previewElement.textContent = text;
+}
+
+export async function initComposePlugin({ ui = resolveComposeUi(), teams, fetcher } = {}) {
+  const { teams: sdk, context } = await ensureTeamsContext({ teams });
+  const metadata = await fetchMetadata(fetcher);
+  const state = buildDialogState({ models: metadata.models, languages: metadata.languages, context });
+  state.text = "";
+  state.translation = "";
+
+  if (ui.targetSelect && typeof ui.targetSelect.replaceChildren === "function" && typeof document !== "undefined") {
+    const nodes = metadata.languages
+      .filter((lang) => lang.id !== "auto")
+      .map((lang) => {
+        const option = document.createElement("option");
+        option.value = lang.id;
+        option.textContent = lang.name;
+        return option;
+      });
+    ui.targetSelect.replaceChildren(...nodes);
+  } else if (ui.targetSelect) {
+    ui.targetSelect.optionsData = metadata.languages.filter((lang) => lang.id !== "auto");
+  }
+
+  if (ui.targetSelect) {
+    ui.targetSelect.value = state.targetLanguage;
+    ui.targetSelect.addEventListener?.("change", (event) => {
+      state.targetLanguage = event.target.value;
+    });
+  }
+
+  if (ui.terminologyToggle) {
+    ui.terminologyToggle.checked = state.useTerminology;
+    ui.terminologyToggle.addEventListener?.("change", (event) => {
+      state.useTerminology = Boolean(event.target.checked);
+    });
+  }
+
+  async function requestSuggestion() {
+    if (!ui.input) {
+      return;
+    }
+    state.text = ui.input.value ?? "";
+    if (!state.text.trim()) {
+      setPreview(ui.preview, "请输入要翻译的文本");
+      return;
+    }
+    const payload = buildTranslatePayload({ ...state }, context);
+    try {
+      const response = await translateText(payload, fetcher);
+      state.translation = response.text ?? "";
+      setPreview(ui.preview, state.translation);
+    } catch (error) {
+      setPreview(ui.preview, `翻译失败：${error.message}`);
+    }
+  }
+
+  ui.suggestButton?.addEventListener?.("click", () => {
+    return requestSuggestion();
+  });
+
+  ui.applyButton?.addEventListener?.("click", async () => {
+    if (!state.translation) {
+      await requestSuggestion();
+    }
+    if (state.translation) {
+      if (sdk.conversations?.sendMessageToConversation) {
+        await sdk.conversations.sendMessageToConversation({
+          conversationId: context?.channel?.id,
+          content: state.translation,
+          type: "text"
+        });
+      } else if (ui.input) {
+        ui.input.value = state.translation;
+      }
+    }
+  });
+
+  return { state, metadata, context };
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", () => {
+    const composeRoot = document.querySelector?.("[data-compose-root]");
+    if (composeRoot) {
+      initComposePlugin().catch((error) => console.error("初始化 Compose 插件失败", error));
+    }
+  });
+}
+
+export default {
+  initComposePlugin
+};

--- a/src/webapp/dialog.html
+++ b/src/webapp/dialog.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BOBTLA 消息扩展对话框</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body class="dialog" data-dialog-root>
+    <header class="dialog__header">
+      <h1>翻译助手</h1>
+      <p>选择模型、语言与术语策略，生成可编辑译文。</p>
+    </header>
+    <main class="dialog__main">
+      <section class="dialog__controls">
+        <label>
+          模型
+          <select data-model-select aria-label="模型选择"></select>
+        </label>
+        <label>
+          源语言
+          <select data-source-select aria-label="源语言选择"></select>
+        </label>
+        <label>
+          目标语言
+          <select data-target-select aria-label="目标语言选择"></select>
+        </label>
+        <label class="toggle">
+          <input type="checkbox" data-terminology-toggle checked /> 使用术语表
+        </label>
+        <p class="dialog__cost" data-cost-hint></p>
+      </section>
+      <section class="dialog__editor">
+        <label class="editor__label">
+          原文
+          <textarea rows="6" data-source-text placeholder="请输入要翻译的文本"></textarea>
+        </label>
+        <label class="editor__label">
+          译文（可编辑）
+          <textarea rows="6" data-translation-text placeholder="点击生成译文后可编辑"></textarea>
+        </label>
+      </section>
+      <p class="dialog__error" data-error-banner hidden></p>
+    </main>
+    <footer class="dialog__footer">
+      <button type="button" class="btn" data-preview-translation>生成译文</button>
+      <button type="button" class="btn btn--primary" data-submit-translation>插入消息</button>
+    </footer>
+    <script type="module" src="./dialog.js"></script>
+  </body>
+</html>

--- a/src/webapp/dialog.js
+++ b/src/webapp/dialog.js
@@ -1,0 +1,162 @@
+import { ensureTeamsContext } from "./teamsContext.js";
+import { fetchMetadata, translateText } from "./apiClient.js";
+import { buildDialogState, calculateCostHint, buildTranslatePayload, updateStateWithResponse } from "./dialogState.js";
+
+function resolveDialogUi(root = typeof document !== "undefined" ? document : undefined) {
+  if (!root) {
+    return {};
+  }
+  return {
+    modelSelect: root.querySelector?.("[data-model-select]"),
+    sourceSelect: root.querySelector?.("[data-source-select]"),
+    targetSelect: root.querySelector?.("[data-target-select]"),
+    terminologyToggle: root.querySelector?.("[data-terminology-toggle]"),
+    costHint: root.querySelector?.("[data-cost-hint]"),
+    input: root.querySelector?.("[data-source-text]"),
+    translation: root.querySelector?.("[data-translation-text]"),
+    previewButton: root.querySelector?.("[data-preview-translation]"),
+    submitButton: root.querySelector?.("[data-submit-translation]"),
+    errorBanner: root.querySelector?.("[data-error-banner]")
+  };
+}
+
+function applySelectOptions(element, options, { valueKey, labelKey }) {
+  if (!element || !Array.isArray(options)) {
+    return;
+  }
+  const entries = options.map((item) => ({ value: item[valueKey], label: item[labelKey] ?? item[valueKey] }));
+  if (typeof element.replaceChildren === "function" && typeof document !== "undefined" && document?.createElement) {
+    const nodes = entries.map((entry) => {
+      const option = document.createElement("option");
+      option.value = entry.value;
+      option.textContent = entry.label;
+      return option;
+    });
+    element.replaceChildren(...nodes);
+  } else {
+    element.optionsData = entries;
+  }
+  if (entries.length && element.value === undefined) {
+    element.value = entries[0].value;
+  }
+}
+
+function bindCostHint(ui, state, metadata) {
+  if (!ui.costHint) {
+    return;
+  }
+  ui.costHint.textContent = calculateCostHint(state, metadata.models, metadata.pricing);
+}
+
+function updateError(ui, message) {
+  if (!ui.errorBanner) {
+    return;
+  }
+  if (!message) {
+    ui.errorBanner.textContent = "";
+    ui.errorBanner.hidden = true;
+    return;
+  }
+  ui.errorBanner.hidden = false;
+  ui.errorBanner.textContent = message;
+}
+
+export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams, fetcher } = {}) {
+  const { teams: sdk, context } = await ensureTeamsContext({ teams });
+  const metadata = await fetchMetadata(fetcher);
+  const state = buildDialogState({ models: metadata.models, languages: metadata.languages, context });
+
+  applySelectOptions(ui.modelSelect, metadata.models, { valueKey: "id", labelKey: "displayName" });
+  applySelectOptions(ui.sourceSelect, metadata.languages, { valueKey: "id", labelKey: "name" });
+  applySelectOptions(ui.targetSelect, metadata.languages.filter((lang) => lang.id !== "auto"), {
+    valueKey: "id",
+    labelKey: "name"
+  });
+
+  if (ui.modelSelect) {
+    ui.modelSelect.value = state.modelId;
+    ui.modelSelect.addEventListener?.("change", (event) => {
+      state.modelId = event.target.value;
+      bindCostHint(ui, state, metadata);
+    });
+  }
+  if (ui.sourceSelect) {
+    ui.sourceSelect.value = state.sourceLanguage;
+    ui.sourceSelect.addEventListener?.("change", (event) => {
+      state.sourceLanguage = event.target.value;
+    });
+  }
+  if (ui.targetSelect) {
+    ui.targetSelect.value = state.targetLanguage;
+    ui.targetSelect.addEventListener?.("change", (event) => {
+      state.targetLanguage = event.target.value;
+    });
+  }
+  if (ui.terminologyToggle) {
+    ui.terminologyToggle.checked = state.useTerminology;
+    ui.terminologyToggle.addEventListener?.("change", (event) => {
+      state.useTerminology = Boolean(event.target.checked);
+    });
+  }
+
+  if (ui.input) {
+    ui.input.addEventListener?.("input", (event) => {
+      state.text = event.target.value ?? "";
+      state.charCount = state.text.length;
+      bindCostHint(ui, state, metadata);
+    });
+  }
+
+  bindCostHint(ui, state, metadata);
+
+  async function requestTranslation() {
+    try {
+      updateError(ui, "");
+      const payload = buildTranslatePayload(state, context);
+      const response = await translateText(payload, fetcher);
+      const nextState = updateStateWithResponse(state, response);
+      state.translation = nextState.translation;
+      state.modelId = nextState.modelId;
+      if (ui.translation) {
+        ui.translation.value = nextState.translation ?? "";
+      }
+      bindCostHint(ui, state, metadata);
+      return nextState;
+    } catch (error) {
+      updateError(ui, error.message);
+      throw error;
+    }
+  }
+
+  ui.previewButton?.addEventListener?.("click", () => {
+    return requestTranslation();
+  });
+
+  ui.submitButton?.addEventListener?.("click", async () => {
+    if (!state.translation && state.text) {
+      try {
+        await requestTranslation();
+      } catch (error) {
+        return;
+      }
+    }
+    sdk.dialog?.submit?.({
+      translation: state.translation,
+      targetLanguage: state.targetLanguage,
+      modelId: state.modelId,
+      useTerminology: state.useTerminology
+    });
+  });
+
+  return { state, metadata, context };
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", () => {
+    initMessageExtensionDialog().catch((error) => console.error("初始化消息扩展对话框失败", error));
+  });
+}
+
+export default {
+  initMessageExtensionDialog
+};

--- a/src/webapp/dialogState.js
+++ b/src/webapp/dialogState.js
@@ -1,0 +1,95 @@
+import { FALLBACK_METADATA } from "./apiClient.js";
+
+function resolveDefaultTargetLanguage(languages = [], locale = "") {
+  if (!Array.isArray(languages) || languages.length === 0) {
+    return "en";
+  }
+  const exactLocale = languages.find((lang) => lang.id === locale);
+  if (exactLocale) {
+    return exactLocale.id;
+  }
+  const normalized = locale?.split?.("-")?.[0];
+  if (normalized) {
+    const match = languages.find((lang) => lang.id === normalized);
+    if (match) {
+      return match.id;
+    }
+  }
+  const defaultLocale = languages.find((lang) => lang.isDefault);
+  if (defaultLocale) {
+    return defaultLocale.id;
+  }
+  return languages[0].id;
+}
+
+export function buildDialogState({ models, languages, context } = {}) {
+  const metadata = {
+    models: models?.length ? models : FALLBACK_METADATA.models,
+    languages: languages?.length ? languages : FALLBACK_METADATA.languages
+  };
+  const defaultModel = metadata.models[0];
+  const targetLanguage = resolveDefaultTargetLanguage(metadata.languages, context?.app?.locale ?? "");
+  return {
+    text: "",
+    translation: "",
+    modelId: defaultModel?.id ?? "",
+    sourceLanguage: metadata.languages[0]?.id ?? "auto",
+    targetLanguage,
+    useTerminology: true,
+    charCount: 0
+  };
+}
+
+export function calculateCostHint({ charCount, modelId }, models = [], pricing = {}) {
+  const model = models.find((item) => item.id === modelId);
+  if (!model) {
+    return "";
+  }
+  const cost = Number(model.costPerCharUsd ?? 0) * (charCount ?? 0);
+  const currency = pricing.currency ?? "USD";
+  const formatted = cost ? cost.toFixed(6) : "0";
+  return `预计成本：${currency} ${formatted}（${charCount ?? 0} 字符 @ ${model.id}）`;
+}
+
+export function buildTranslatePayload(state, context) {
+  if (!state?.text) {
+    throw new Error("缺少要翻译的文本");
+  }
+  if (!state.targetLanguage) {
+    throw new Error("缺少目标语言");
+  }
+  return {
+    text: state.text,
+    sourceLanguage: state.sourceLanguage === "auto" ? undefined : state.sourceLanguage,
+    targetLanguage: state.targetLanguage,
+    tenantId: context?.tenant?.id,
+    userId: context?.user?.id,
+    channelId: context?.channel?.id,
+    metadata: {
+      origin: "messageExtension",
+      modelId: state.modelId,
+      useTerminology: Boolean(state.useTerminology)
+    }
+  };
+}
+
+export function updateStateWithResponse(state, response) {
+  if (!state || !response) {
+    return state;
+  }
+  const next = { ...state };
+  if (typeof response.text === "string") {
+    next.translation = response.text;
+  }
+  if (response.metadata?.modelId) {
+    next.modelId = response.metadata.modelId;
+  }
+  return next;
+}
+
+export default {
+  buildDialogState,
+  calculateCostHint,
+  buildTranslatePayload,
+  updateStateWithResponse
+};

--- a/src/webapp/settings.html
+++ b/src/webapp/settings.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BOBTLA 设置页</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body class="settings" data-settings-root>
+    <header class="settings__header">
+      <h1>租户配置</h1>
+      <p>管理允许的模型、默认目标语言与术语策略。</p>
+    </header>
+    <main class="settings__main">
+      <section>
+        <h2>允许模型</h2>
+        <div class="settings__models" data-model-list></div>
+      </section>
+      <section>
+        <h2>默认目标语言</h2>
+        <select data-default-language aria-label="默认目标语言"></select>
+      </section>
+      <section>
+        <label class="toggle">
+          <input type="checkbox" data-terminology-toggle checked /> 启用术语库
+        </label>
+      </section>
+      <p class="settings__status" data-settings-status></p>
+    </main>
+    <footer class="settings__footer">
+      <button type="button" class="btn btn--primary" data-settings-save>保存配置</button>
+    </footer>
+    <script type="module" src="./settingsTab.js"></script>
+  </body>
+</html>

--- a/src/webapp/settingsTab.js
+++ b/src/webapp/settingsTab.js
@@ -1,0 +1,141 @@
+import { ensureTeamsContext } from "./teamsContext.js";
+import { fetchMetadata } from "./apiClient.js";
+import { buildDialogState } from "./dialogState.js";
+
+function resolveSettingsUi(root = typeof document !== "undefined" ? document : undefined) {
+  if (!root) {
+    return {};
+  }
+  return {
+    modelContainer: root.querySelector?.("[data-model-list]"),
+    defaultLanguageSelect: root.querySelector?.("[data-default-language]"),
+    terminologyToggle: root.querySelector?.("[data-terminology-toggle]"),
+    statusLabel: root.querySelector?.("[data-settings-status]"),
+    saveButton: root.querySelector?.("[data-settings-save]")
+  };
+}
+
+function renderModelList(container, models, state) {
+  if (!container) {
+    return;
+  }
+  if (typeof container.replaceChildren === "function" && typeof document !== "undefined") {
+    const nodes = models.map((model) => {
+      const label = document.createElement("label");
+      label.className = "model-item";
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.value = model.id;
+      checkbox.checked = state.allowedModels.has(model.id);
+      checkbox.addEventListener("change", (event) => {
+        if (event.target.checked) {
+          state.allowedModels.add(model.id);
+        } else {
+          state.allowedModels.delete(model.id);
+        }
+      });
+      const span = document.createElement("span");
+      span.textContent = `${model.displayName ?? model.id}（${model.costPerCharUsd} USD/char）`;
+      label.append(checkbox, span);
+      return label;
+    });
+    container.replaceChildren(...nodes);
+  } else {
+    container.items = models;
+  }
+}
+
+function renderDefaultLanguage(select, languages, state) {
+  if (!select) {
+    return;
+  }
+  const candidates = languages.filter((lang) => lang.id !== "auto");
+  if (typeof select.replaceChildren === "function" && typeof document !== "undefined") {
+    const options = candidates.map((lang) => {
+      const option = document.createElement("option");
+      option.value = lang.id;
+      option.textContent = lang.name;
+      return option;
+    });
+    select.replaceChildren(...options);
+  } else {
+    select.optionsData = candidates;
+  }
+  select.value = state.targetLanguage;
+  select.addEventListener?.("change", (event) => {
+    state.targetLanguage = event.target.value;
+  });
+}
+
+export function buildTenantConfig(state, context) {
+  return {
+    tenantId: context?.tenant?.id,
+    defaultTargetLanguage: state.targetLanguage,
+    allowedModels: Array.from(state.allowedModels),
+    features: {
+      terminology: Boolean(state.useTerminology)
+    }
+  };
+}
+
+export async function initSettingsTab({ ui = resolveSettingsUi(), teams, fetcher } = {}) {
+  const { teams: sdk, context } = await ensureTeamsContext({ teams });
+  const metadata = await fetchMetadata(fetcher);
+  const baseState = buildDialogState({ models: metadata.models, languages: metadata.languages, context });
+  const state = {
+    targetLanguage: baseState.targetLanguage,
+    allowedModels: new Set(metadata.models.map((model) => model.id)),
+    useTerminology: true
+  };
+
+  renderModelList(ui.modelContainer, metadata.models, state);
+  renderDefaultLanguage(ui.defaultLanguageSelect, metadata.languages, state);
+
+  if (ui.terminologyToggle) {
+    ui.terminologyToggle.checked = state.useTerminology;
+    ui.terminologyToggle.addEventListener?.("change", (event) => {
+      state.useTerminology = Boolean(event.target.checked);
+    });
+  }
+
+  sdk.pages?.config?.setValidityState?.(true);
+  let saveHandler;
+  sdk.pages?.config?.registerOnSaveHandler?.((event) => {
+    saveHandler = event;
+  });
+
+  async function persistSettings() {
+    const config = buildTenantConfig(state, context);
+    const currentUrl = typeof window !== "undefined" ? window.location?.href : "";
+    await sdk.pages?.config?.setConfig?.({
+      entityId: "bobtla-settings",
+      contentUrl: config.contentUrl ?? currentUrl ?? "",
+      suggestedDisplayName: "BOBTLA 设置",
+      state: JSON.stringify(config)
+    });
+    saveHandler?.notifySuccess?.();
+    if (ui.statusLabel) {
+      ui.statusLabel.textContent = "已保存";
+    }
+  }
+
+  ui.saveButton?.addEventListener?.("click", () => {
+    return persistSettings();
+  });
+
+  return { state, metadata, context };
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", () => {
+    const settingsRoot = document.querySelector?.("[data-settings-root]");
+    if (settingsRoot) {
+      initSettingsTab().catch((error) => console.error("初始化设置页失败", error));
+    }
+  });
+}
+
+export default {
+  initSettingsTab,
+  buildTenantConfig
+};

--- a/src/webapp/styles.css
+++ b/src/webapp/styles.css
@@ -212,3 +212,98 @@ body {
     grid-template-columns: 1fr;
   }
 }
+
+.dialog,
+.compose,
+.settings {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+  display: grid;
+  gap: 24px;
+}
+
+.dialog__controls,
+.dialog__editor,
+.compose__main,
+.settings__main {
+  display: grid;
+  gap: 16px;
+}
+
+.dialog__controls label,
+.compose__main label,
+.settings__main label {
+  display: grid;
+  gap: 6px;
+  font-weight: 500;
+}
+
+.dialog__editor,
+.compose__editor {
+  display: grid;
+  gap: 8px;
+}
+
+textarea,
+select,
+input[type="text"] {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--text-primary);
+  padding: 12px;
+  font: inherit;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dialog__footer,
+.compose__footer,
+.settings__footer {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.btn {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  padding: 10px 18px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.btn--primary {
+  background: var(--accent);
+  color: #021a35;
+  border-color: transparent;
+}
+
+.dialog__error {
+  margin: 0;
+  padding: 12px;
+  border-radius: 10px;
+  background: rgba(255, 77, 79, 0.15);
+  color: #ffb3b5;
+}
+
+.dialog__cost {
+  color: var(--text-secondary);
+}
+
+.settings__models {
+  display: grid;
+  gap: 10px;
+}
+
+.settings__status {
+  color: var(--text-secondary);
+  min-height: 24px;
+}

--- a/src/webapp/teamsContext.js
+++ b/src/webapp/teamsContext.js
@@ -1,0 +1,71 @@
+const DEFAULT_CONTEXT = {
+  user: { id: "local-user" },
+  tenant: { id: "local-tenant" },
+  channel: { id: "local-channel" },
+  app: { locale: "en-US" }
+};
+
+function createLocalFallbackSdk() {
+  return {
+    app: {
+      async initialize() {
+        return undefined;
+      },
+      async getContext() {
+        return DEFAULT_CONTEXT;
+      }
+    },
+    dialog: {
+      submit() {
+        return undefined;
+      }
+    },
+    pages: {
+      config: {
+        registerOnSaveHandler() {
+          return undefined;
+        },
+        async setConfig() {
+          return undefined;
+        },
+        setValidityState() {
+          return undefined;
+        }
+      }
+    },
+    conversations: {
+      async sendMessageToConversation() {
+        return undefined;
+      }
+    }
+  };
+}
+
+export function resolveTeamsSdk(override) {
+  if (override) {
+    return override;
+  }
+  if (typeof window !== "undefined" && window.microsoftTeams) {
+    return window.microsoftTeams;
+  }
+  if (typeof globalThis !== "undefined" && globalThis.microsoftTeams) {
+    return globalThis.microsoftTeams;
+  }
+  return createLocalFallbackSdk();
+}
+
+export async function ensureTeamsContext({ teams } = {}) {
+  const sdk = resolveTeamsSdk(teams);
+  if (sdk?.app?.initialize) {
+    await sdk.app.initialize();
+  }
+  const context = (await sdk?.app?.getContext?.()) ?? DEFAULT_CONTEXT;
+  return { teams: sdk ?? createLocalFallbackSdk(), context };
+}
+
+export { DEFAULT_CONTEXT };
+
+export default {
+  resolveTeamsSdk,
+  ensureTeamsContext
+};

--- a/tests/botCommandProcessor.test.js
+++ b/tests/botCommandProcessor.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { BotCommandProcessor } from "../src/teams/botCommands.js";
+import { TranslationPipeline } from "../src/services/translationPipeline.js";
+
+test("translate command delegates to pipeline", async () => {
+  const pipeline = new TranslationPipeline({ router: {}, offlineDraftStore: { saveDraft() {} } });
+  let calledPayload;
+  pipeline.translateAndReply = async (payload) => {
+    calledPayload = payload;
+    return { replyPayload: { type: "AdaptiveCard", body: [] } };
+  };
+  const processor = new BotCommandProcessor({ pipeline });
+  const card = await processor.handleCommand({
+    text: "/translate to=ja hello world",
+    tenantId: "tenant",
+    userId: "user",
+    channelId: "channel"
+  });
+  assert.equal(card.type, "AdaptiveCard");
+  assert.equal(calledPayload.targetLanguage, "ja");
+  assert.equal(calledPayload.text, "hello world");
+  assert.equal(calledPayload.metadata.origin, "botCommand");
+});
+
+test("unknown command returns help card", async () => {
+  const pipeline = new TranslationPipeline({ router: {}, offlineDraftStore: { saveDraft() {} } });
+  pipeline.translateAndReply = async () => ({ replyPayload: {} });
+  const processor = new BotCommandProcessor({ pipeline });
+  const card = await processor.handleCommand({ text: "/unsupported", tenantId: "t" });
+  assert.equal(card.body[0].text, "翻译助手命令");
+});

--- a/tests/composePlugin.test.js
+++ b/tests/composePlugin.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { initComposePlugin } from "../src/webapp/composePlugin.js";
+
+function createStubElement(initial = {}) {
+  return {
+    value: initial.value ?? "",
+    checked: Boolean(initial.checked),
+    textContent: initial.textContent ?? "",
+    optionsData: [],
+    listeners: new Map(),
+    addEventListener(event, handler) {
+      this.listeners.set(event, handler);
+    },
+    trigger(event) {
+      const handler = this.listeners.get(event);
+      if (handler) {
+        return handler({ target: this });
+      }
+      return undefined;
+    }
+  };
+}
+
+test("compose plugin sends translate request with compose text", async () => {
+  const fetchCalls = [];
+  const fakeFetch = async (url, options = {}) => {
+    if (options.body) {
+      fetchCalls.push({ url, options: JSON.parse(options.body) });
+    }
+    return {
+      ok: true,
+      async json() {
+        if (url === "/api/metadata") {
+          return {
+            models: [{ id: "model-a", displayName: "Model A", costPerCharUsd: 0.00002 }],
+            languages: [
+              { id: "auto", name: "Auto", isDefault: true },
+              { id: "es", name: "Español" }
+            ],
+            features: { terminologyToggle: true },
+            pricing: { currency: "USD" }
+          };
+        }
+        return { text: "hola" };
+      }
+    };
+  };
+  const suggestButton = createStubElement();
+  const applyButton = createStubElement();
+  const input = createStubElement({ value: "hello" });
+  const preview = createStubElement();
+  const targetSelect = createStubElement({ value: "es" });
+  targetSelect.replaceChildren = () => {};
+
+  const teams = {
+    app: {
+      async initialize() {
+        return undefined;
+      },
+      async getContext() {
+        return { tenant: { id: "t" }, user: { id: "u" }, channel: { id: "c" }, app: { locale: "en-US" } };
+      }
+    },
+    conversations: {
+      async sendMessageToConversation() {
+        return undefined;
+      }
+    }
+  };
+
+  await initComposePlugin({
+    ui: { input, targetSelect, suggestButton, applyButton, preview },
+    teams,
+    fetcher: fakeFetch
+  });
+
+  await suggestButton.trigger("click");
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(fetchCalls[0].url, "/api/translate");
+  assert.equal(fetchCalls[0].options.text, "hello");
+  await applyButton.trigger("click");
+  assert.equal(preview.value || preview.textContent, "hola");
+});

--- a/tests/messageExtensionDialog.test.js
+++ b/tests/messageExtensionDialog.test.js
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { initMessageExtensionDialog } from "../src/webapp/dialog.js";
+
+function createStubElement(initial = {}) {
+  return {
+    value: initial.value ?? "",
+    checked: Boolean(initial.checked),
+    textContent: initial.textContent ?? "",
+    hidden: false,
+    listeners: new Map(),
+    replaceChildren() {},
+    addEventListener(event, handler) {
+      this.listeners.set(event, handler);
+    },
+    trigger(event) {
+      const handler = this.listeners.get(event);
+      if (handler) {
+        return handler({ target: this });
+      }
+      return undefined;
+    }
+  };
+}
+
+test("initMessageExtensionDialog posts payload and updates translation", async () => {
+  const fetchCalls = [];
+  const fakeFetch = async (url, options = {}) => {
+    if (options.body) {
+      fetchCalls.push({ url, body: JSON.parse(options.body) });
+    }
+    return {
+      ok: true,
+      async json() {
+        if (url === "/api/metadata") {
+          return {
+            models: [{ id: "model-a", displayName: "Model A", costPerCharUsd: 0.00002 }],
+            languages: [
+              { id: "auto", name: "Auto", isDefault: true },
+              { id: "es", name: "Español" }
+            ],
+            features: { terminologyToggle: true },
+            pricing: { currency: "USD" }
+          };
+        }
+        return { text: "hola", metadata: { modelId: "model-a" } };
+      }
+    };
+  };
+
+  const ui = {
+    modelSelect: createStubElement(),
+    sourceSelect: createStubElement(),
+    targetSelect: createStubElement(),
+    terminologyToggle: createStubElement({ checked: true }),
+    costHint: createStubElement(),
+    input: createStubElement({ value: "hello" }),
+    translation: createStubElement(),
+    previewButton: createStubElement(),
+    submitButton: createStubElement(),
+    errorBanner: createStubElement()
+  };
+
+  const teams = {
+    app: {
+      async initialize() {},
+      async getContext() {
+        return { tenant: { id: "tenant" }, user: { id: "user" }, channel: { id: "channel" }, app: { locale: "en-US" } };
+      }
+    },
+    dialog: {
+      submit(payload) {
+        teams.dialog.lastSubmit = payload;
+      }
+    }
+  };
+
+  await initMessageExtensionDialog({ ui, teams, fetcher: fakeFetch });
+  await ui.input.trigger("input");
+  await ui.previewButton.trigger("click");
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(fetchCalls[0].url, "/api/translate");
+  assert.equal(fetchCalls[0].body.text, "hello");
+  await ui.submitButton.trigger("click");
+  assert.equal(teams.dialog.lastSubmit.translation, "hola");
+});

--- a/tests/messageExtensionDialogState.test.js
+++ b/tests/messageExtensionDialogState.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildDialogState, calculateCostHint, buildTranslatePayload, updateStateWithResponse } from "../src/webapp/dialogState.js";
+
+test("buildDialogState chooses default language from context locale", () => {
+  const models = [
+    { id: "model-a" },
+    { id: "model-b" }
+  ];
+  const languages = [
+    { id: "auto", name: "Auto", isDefault: true },
+    { id: "ja", name: "日本語" },
+    { id: "en", name: "English" }
+  ];
+  const state = buildDialogState({ models, languages, context: { app: { locale: "ja-JP" } } });
+  assert.equal(state.targetLanguage, "ja");
+  assert.equal(state.modelId, "model-a");
+});
+
+test("calculateCostHint multiplies characters and cost", () => {
+  const hint = calculateCostHint({ charCount: 120, modelId: "model-a" }, [{ id: "model-a", costPerCharUsd: 0.00002 }], {
+    currency: "USD"
+  });
+  assert.equal(hint.includes("0.002400"), true);
+});
+
+test("buildTranslatePayload forwards metadata and context", () => {
+  const state = {
+    text: "Hello",
+    sourceLanguage: "auto",
+    targetLanguage: "zh-Hans",
+    modelId: "model-a",
+    useTerminology: false
+  };
+  const context = { tenant: { id: "tenant1" }, user: { id: "user1" }, channel: { id: "channel1" } };
+  const payload = buildTranslatePayload(state, context);
+  assert.equal(payload.targetLanguage, "zh-Hans");
+  assert.equal(payload.sourceLanguage, undefined);
+  assert.deepEqual(payload.metadata, { origin: "messageExtension", modelId: "model-a", useTerminology: false });
+});
+
+test("updateStateWithResponse stores translation text", () => {
+  const state = { text: "Hello", translation: "", modelId: "model-a" };
+  const response = { text: "你好", metadata: { modelId: "model-b" } };
+  const next = updateStateWithResponse(state, response);
+  assert.equal(next.translation, "你好");
+  assert.equal(next.modelId, "model-b");
+});

--- a/tests/settingsTab.test.js
+++ b/tests/settingsTab.test.js
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { initSettingsTab, buildTenantConfig } from "../src/webapp/settingsTab.js";
+
+function createStubElement(initial = {}) {
+  return {
+    value: initial.value ?? "",
+    checked: Boolean(initial.checked),
+    textContent: initial.textContent ?? "",
+    listeners: new Map(),
+    replaceChildren() {},
+    addEventListener(event, handler) {
+      this.listeners.set(event, handler);
+    },
+    trigger(event) {
+      const handler = this.listeners.get(event);
+      if (handler) {
+        return handler({ target: this });
+      }
+      return undefined;
+    }
+  };
+}
+
+test("buildTenantConfig serialises state", () => {
+  const config = buildTenantConfig(
+    {
+      targetLanguage: "ja",
+      allowedModels: new Set(["model-a", "model-b"]),
+      useTerminology: true
+    },
+    { tenant: { id: "tenant-1" } }
+  );
+  assert.deepEqual(config.allowedModels, ["model-a", "model-b"]);
+  assert.equal(config.features.terminology, true);
+  assert.equal(config.tenantId, "tenant-1");
+});
+
+test("initSettingsTab registers save handler", async () => {
+  let savedConfig;
+  let validitySet = false;
+  let successNotified = false;
+  const sdk = {
+    app: {
+      async initialize() {
+        return undefined;
+      },
+      async getContext() {
+        return { tenant: { id: "tenant" }, user: { id: "user" }, app: { locale: "en-US" } };
+      }
+    },
+    pages: {
+      config: {
+        setValidityState(value) {
+          validitySet = value;
+        },
+        registerOnSaveHandler(handler) {
+          const event = {
+            notifySuccess: () => {
+              successNotified = true;
+            }
+          };
+          handler(event);
+        },
+        async setConfig(config) {
+          savedConfig = config;
+        }
+      }
+    }
+  };
+
+  const modelContainer = createStubElement();
+  const defaultLanguageSelect = createStubElement();
+  const terminologyToggle = createStubElement({ checked: true });
+  const statusLabel = createStubElement();
+  const saveButton = createStubElement();
+
+  await initSettingsTab({
+    ui: { modelContainer, defaultLanguageSelect, terminologyToggle, statusLabel, saveButton },
+    teams: sdk,
+    fetcher: async () => ({
+      ok: true,
+      async json() {
+        return {
+          models: [
+            { id: "model-a", displayName: "Model A", costPerCharUsd: 0.0001 },
+            { id: "model-b", displayName: "Model B", costPerCharUsd: 0.0002 }
+          ],
+          languages: [
+            { id: "auto", name: "Auto", isDefault: true },
+            { id: "ja", name: "日本語" }
+          ],
+          features: { terminologyToggle: true },
+          pricing: { currency: "USD" }
+        };
+      }
+    })
+  });
+
+  assert.equal(validitySet, true);
+  await sdk.pages.config.setConfig({});
+  await saveButton.trigger("click");
+  assert.equal(typeof savedConfig.state, "string");
+  assert.equal(statusLabel.textContent, "已保存");
+  assert.equal(successNotified, true);
+});


### PR DESCRIPTION
## Summary
- add Teams message extension dialog with model selection, language toggles, cost hints, and editable translation area
- introduce compose plugin and tenant settings tab backed by a Teams SDK facade plus metadata endpoints
- implement bot command processor and comprehensive UI contract tests for the new front-end modules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db4608f404832f8968611a0cb0d269