### PR TITLE
Add auxiliary translation APIs and tests

### DIFF
--- a/src/TlaPlugin/Configuration/PluginOptions.cs
+++ b/src/TlaPlugin/Configuration/PluginOptions.cs
@@ -103,4 +103,5 @@ public class SecurityOptions
     {
         ["tla-client-secret"] = "local-dev-secret"
     };
+    public IList<string> AllowedReplyChannels { get; set; } = new List<string>();
 }

--- a/src/TlaPlugin/Models/CostLatencyEstimate.cs
+++ b/src/TlaPlugin/Models/CostLatencyEstimate.cs
@@ -1,0 +1,6 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 表示成本与延迟估算的返回值。
+/// </summary>
+public record CostLatencyEstimate(decimal Cost, int LatencyMs, string ModelId);

--- a/src/TlaPlugin/Models/GlossaryApplicationRequest.cs
+++ b/src/TlaPlugin/Models/GlossaryApplicationRequest.cs
@@ -1,0 +1,15 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 表示 /apply-glossary 接口的请求体。
+/// </summary>
+public class GlossaryApplicationRequest
+{
+    public string Text { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string? ChannelId { get; set; }
+        = null;
+    public string Policy { get; set; } = GlossaryPolicy.Strict.ToString();
+    public IList<string> GlossaryIds { get; set; } = new List<string>();
+}

--- a/src/TlaPlugin/Models/GlossaryPolicy.cs
+++ b/src/TlaPlugin/Models/GlossaryPolicy.cs
@@ -1,0 +1,20 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 控制术语应用行为的策略枚举。
+/// </summary>
+public enum GlossaryPolicy
+{
+    Strict,
+    Fallback
+}
+
+/// <summary>
+/// 表示术语匹配结果。
+/// </summary>
+public record GlossaryMatch(string Term, string Translation, string Scope, int Count);
+
+/// <summary>
+/// 表示术语应用后的结果。
+/// </summary>
+public record GlossaryApplicationResult(string ProcessedText, IReadOnlyList<GlossaryMatch> Matches);

--- a/src/TlaPlugin/Models/LanguageDetectionRequest.cs
+++ b/src/TlaPlugin/Models/LanguageDetectionRequest.cs
@@ -1,0 +1,10 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 表示语言检测 API 的请求负载。
+/// </summary>
+public class LanguageDetectionRequest
+{
+    public string Text { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+}

--- a/src/TlaPlugin/Models/ReplyModels.cs
+++ b/src/TlaPlugin/Models/ReplyModels.cs
@@ -1,0 +1,30 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 回复线程请求中的语言策略。
+/// </summary>
+public class ReplyLanguagePolicy
+{
+    public string TargetLang { get; set; } = string.Empty;
+    public string Tone { get; set; } = TranslationRequest.DefaultTone;
+}
+
+/// <summary>
+/// 表示 /reply 接口的请求体。
+/// </summary>
+public class ReplyRequest
+{
+    public string ThreadId { get; set; } = string.Empty;
+    public string ReplyText { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string? ChannelId { get; set; }
+        = null;
+    public ReplyLanguagePolicy? LanguagePolicy { get; set; }
+        = null;
+}
+
+/// <summary>
+/// 回复请求的响应。
+/// </summary>
+public record ReplyResult(string MessageId, string Status, string? FinalText = null, string? ToneApplied = null);

--- a/src/TlaPlugin/Models/RewriteRequest.cs
+++ b/src/TlaPlugin/Models/RewriteRequest.cs
@@ -1,0 +1,19 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 表示改写调用的请求体。
+/// </summary>
+public class RewriteRequest
+{
+    public string Text { get; set; } = string.Empty;
+    public string Tone { get; set; } = TranslationRequest.DefaultTone;
+    public string TenantId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string? ChannelId { get; set; }
+        = null;
+}
+
+/// <summary>
+/// 改写操作返回的结果。
+/// </summary>
+public record RewriteResult(string RewrittenText, string ModelId, decimal CostUsd, int LatencyMs);

--- a/src/TlaPlugin/Models/SummarizeRequest.cs
+++ b/src/TlaPlugin/Models/SummarizeRequest.cs
@@ -1,0 +1,16 @@
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 表示摘要接口的请求。
+/// </summary>
+public class SummarizeRequest
+{
+    public string Context { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// 提供摘要操作的响应模型。
+/// </summary>
+public record SummarizeResult(string Summary, string ModelId, decimal CostUsd, int LatencyMs);

--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using System.Security.Authentication;
 using System.Text.Json;
 using TlaPlugin.Configuration;
 using TlaPlugin.Models;
@@ -48,65 +50,184 @@ builder.Services.AddSingleton<MessageExtensionHandler>();
 builder.Services.AddSingleton<ConfigurationSummaryService>();
 builder.Services.AddSingleton<ProjectStatusService>();
 builder.Services.AddSingleton<DevelopmentRoadmapService>();
+builder.Services.AddSingleton<ReplyService>();
+builder.Services.AddSingleton<CostEstimatorService>();
 
 var app = builder.Build();
+
+var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
 app.MapPost("/api/translate", async (TranslationRequest request, MessageExtensionHandler handler) =>
 {
     var result = await handler.HandleTranslateAsync(request);
-    return Results.Json(result, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    return Results.Json(result, options: jsonOptions);
 });
 
 app.MapPost("/api/offline-draft", async (OfflineDraftRequest request, MessageExtensionHandler handler) =>
 {
     var result = await handler.HandleOfflineDraftAsync(request);
-    return Results.Json(result, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    return Results.Json(result, options: jsonOptions);
+});
+
+app.MapPost("/api/detect", async (LanguageDetectionRequest request, TranslationRouter router, IOptions<PluginOptions> options, CancellationToken cancellationToken) =>
+{
+    if (request.Text.Length > options.Value.MaxCharactersPerRequest)
+    {
+        return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+    }
+
+    try
+    {
+        var detection = await router.DetectAsync(request, cancellationToken);
+        return Results.Json(detection, options: jsonOptions);
+    }
+    catch (TranslationException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+    }
+});
+
+app.MapPost("/api/rewrite", async (RewriteRequest request, TranslationRouter router, CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var result = await router.RewriteAsync(request, cancellationToken);
+        return Results.Json(new
+        {
+            rewrittenText = result.RewrittenText,
+            modelId = result.ModelId,
+            cost = result.CostUsd,
+            latencyMs = result.LatencyMs
+        }, options: jsonOptions);
+    }
+    catch (BudgetExceededException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status402PaymentRequired);
+    }
+    catch (AuthenticationException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status401Unauthorized);
+    }
+    catch (TranslationException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+    }
+});
+
+app.MapPost("/api/apply-glossary", (GlossaryApplicationRequest request, GlossaryService glossary) =>
+{
+    var policy = Enum.TryParse<GlossaryPolicy>(request.Policy, true, out var parsed) ? parsed : GlossaryPolicy.Fallback;
+    try
+    {
+        var result = glossary.ApplyDetailed(request.Text, request.TenantId, request.ChannelId, request.UserId, policy, request.GlossaryIds);
+        return Results.Json(new
+        {
+            processedText = result.ProcessedText,
+            matches = result.Matches
+        }, options: jsonOptions);
+    }
+    catch (GlossaryApplicationException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+    }
+});
+
+app.MapPost("/api/reply", async (ReplyRequest request, ReplyService service, CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var result = await service.SendReplyAsync(request, cancellationToken);
+        return Results.Json(result, options: jsonOptions);
+    }
+    catch (ReplyAuthorizationException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status403Forbidden);
+    }
+    catch (BudgetExceededException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status402PaymentRequired);
+    }
+    catch (AuthenticationException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status401Unauthorized);
+    }
+    catch (TranslationException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+});
+
+app.MapGet("/api/cost-latency", (int payloadSize, string modelId, CostEstimatorService estimator) =>
+{
+    try
+    {
+        var estimate = estimator.Estimate(payloadSize, modelId);
+        return Results.Json(estimate, options: jsonOptions);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+    catch (ArgumentOutOfRangeException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+    catch (KeyNotFoundException ex)
+    {
+        return Results.NotFound(new { error = ex.Message });
+    }
 });
 
 app.MapGet("/api/configuration", (ConfigurationSummaryService service) =>
 {
     var summary = service.CreateSummary();
-    return Results.Json(summary, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    return Results.Json(summary, options: jsonOptions);
 });
 
 app.MapGet("/api/glossary", (GlossaryService glossary) =>
 {
-    return Results.Json(glossary.GetEntries(), options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    return Results.Json(glossary.GetEntries(), options: jsonOptions);
 });
 
 app.MapGet("/api/audit", (AuditLogger auditLogger) =>
 {
-    return Results.Json(auditLogger.Export(), options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    return Results.Json(auditLogger.Export(), options: jsonOptions);
 });
 
 app.MapGet("/api/status", (ProjectStatusService statusService) =>
 {
     var snapshot = statusService.GetSnapshot();
-    return Results.Json(snapshot, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    return Results.Json(snapshot, options: jsonOptions);
 });
 
 app.MapGet("/api/metrics", (UsageMetricsService metrics) =>
 {
     var report = metrics.GetReport();
-    return Results.Json(report, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    return Results.Json(report, options: jsonOptions);
 });
 
 app.MapGet("/api/localization/locales", (LocalizationCatalogService localization) =>
 {
     var locales = localization.GetAvailableLocales();
-    return Results.Json(locales, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    return Results.Json(locales, options: jsonOptions);
 });
 
 app.MapGet("/api/localization/catalog/{locale?}", (string? locale, LocalizationCatalogService localization) =>
 {
     var catalog = localization.GetCatalog(locale);
-    return Results.Json(catalog, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    return Results.Json(catalog, options: jsonOptions);
 });
 
 app.MapGet("/api/roadmap", (DevelopmentRoadmapService roadmapService) =>
 {
     var roadmap = roadmapService.GetRoadmap();
-    return Results.Json(roadmap, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    return Results.Json(roadmap, options: jsonOptions);
 });
 
 app.Run();
+
+public partial class Program;

--- a/src/TlaPlugin/Providers/IModelProvider.cs
+++ b/src/TlaPlugin/Providers/IModelProvider.cs
@@ -14,6 +14,7 @@ public interface IModelProvider
     Task<DetectionResult> DetectAsync(string text, CancellationToken cancellationToken);
     Task<ModelTranslationResult> TranslateAsync(string text, string sourceLanguage, string targetLanguage, string promptPrefix, CancellationToken cancellationToken);
     Task<string> RewriteAsync(string translatedText, string tone, CancellationToken cancellationToken);
+    Task<string> SummarizeAsync(string text, CancellationToken cancellationToken);
     ModelProviderOptions Options { get; }
 }
 

--- a/src/TlaPlugin/Providers/MockModelProvider.cs
+++ b/src/TlaPlugin/Providers/MockModelProvider.cs
@@ -59,4 +59,15 @@ public class MockModelProvider : IModelProvider
         };
         return Task.FromResult($"{translatedText} {suffix}");
     }
+
+    public Task<string> SummarizeAsync(string text, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return Task.FromResult(string.Empty);
+        }
+
+        var trimmed = text.Length > 60 ? text[..60] + "…" : text;
+        return Task.FromResult($"概要: {trimmed}");
+    }
 }

--- a/src/TlaPlugin/Services/CostEstimatorService.cs
+++ b/src/TlaPlugin/Services/CostEstimatorService.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 根据模型配置估算成本与延迟的服务。
+/// </summary>
+public class CostEstimatorService
+{
+    private readonly ModelProviderFactory _factory;
+
+    public CostEstimatorService(ModelProviderFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public CostLatencyEstimate Estimate(int payloadSize, string modelId)
+    {
+        if (payloadSize < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(payloadSize), "payloadSize は 0 以上である必要があります。");
+        }
+
+        if (string.IsNullOrWhiteSpace(modelId))
+        {
+            throw new ArgumentException("modelId は必須です。", nameof(modelId));
+        }
+
+        var provider = _factory.CreateProviders().FirstOrDefault(p => p.Options.Id == modelId);
+        if (provider is null)
+        {
+            throw new KeyNotFoundException($"モデル {modelId} が見つかりません。");
+        }
+
+        var cost = decimal.Round(provider.Options.CostPerCharUsd * payloadSize, 6);
+        var baseLatency = provider.Options.LatencyTargetMs <= 0 ? 200 : provider.Options.LatencyTargetMs;
+        var latency = baseLatency + (int)Math.Min(Math.Max(payloadSize / 50, 0), baseLatency * 3);
+        return new CostLatencyEstimate(cost, latency, provider.Options.Id);
+    }
+}

--- a/src/TlaPlugin/Services/GlossaryApplicationException.cs
+++ b/src/TlaPlugin/Services/GlossaryApplicationException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 表示术语应用阶段的业务异常。
+/// </summary>
+public class GlossaryApplicationException : Exception
+{
+    public GlossaryApplicationException(string message) : base(message)
+    {
+    }
+}

--- a/src/TlaPlugin/Services/ReplyAuthorizationException.cs
+++ b/src/TlaPlugin/Services/ReplyAuthorizationException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 在回复线程时缺乏授权的异常。
+/// </summary>
+public class ReplyAuthorizationException : Exception
+{
+    public ReplyAuthorizationException(string message) : base(message)
+    {
+    }
+}

--- a/src/TlaPlugin/Services/ReplyService.cs
+++ b/src/TlaPlugin/Services/ReplyService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 负责处理回帖操作与语气校准的服务。
+/// </summary>
+public class ReplyService
+{
+    private readonly TranslationRouter _router;
+    private readonly PluginOptions _options;
+
+    public ReplyService(TranslationRouter router, IOptions<PluginOptions>? options = null)
+    {
+        _router = router;
+        _options = options?.Value ?? new PluginOptions();
+    }
+
+    public async Task<ReplyResult> SendReplyAsync(ReplyRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.ThreadId))
+        {
+            throw new ArgumentException("threadId は必須です。", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ReplyText))
+        {
+            throw new ArgumentException("replyText は必須です。", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.TenantId) || string.IsNullOrWhiteSpace(request.UserId))
+        {
+            throw new ArgumentException("tenantId と userId は必須です。", nameof(request));
+        }
+
+        if (_options.Security.AllowedReplyChannels.Count > 0)
+        {
+            if (string.IsNullOrWhiteSpace(request.ChannelId) || !_options.Security.AllowedReplyChannels.Contains(request.ChannelId))
+            {
+                throw new ReplyAuthorizationException("指定されたチャネルでは返信権限がありません。");
+            }
+        }
+
+        string finalText = request.ReplyText;
+        string? toneApplied = null;
+        if (!string.IsNullOrWhiteSpace(request.LanguagePolicy?.Tone) && request.LanguagePolicy!.Tone != TranslationRequest.DefaultTone)
+        {
+            var rewrite = await _router.RewriteAsync(new RewriteRequest
+            {
+                Text = request.ReplyText,
+                Tone = request.LanguagePolicy.Tone,
+                TenantId = request.TenantId,
+                UserId = request.UserId,
+                ChannelId = request.ChannelId
+            }, cancellationToken);
+            finalText = rewrite.RewrittenText;
+            toneApplied = request.LanguagePolicy.Tone;
+        }
+
+        return new ReplyResult(Guid.NewGuid().ToString(), "sent", finalText, toneApplied);
+    }
+}

--- a/src/TlaPlugin/Services/TranslationRouter.cs
+++ b/src/TlaPlugin/Services/TranslationRouter.cs
@@ -51,6 +51,38 @@ public class TranslationRouter
 
     public PluginOptions Options { get; }
 
+    public async Task<DetectionResult> DetectAsync(LanguageDetectionRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Text))
+        {
+            throw new TranslationException("検出対象のテキストは必須です。");
+        }
+
+        if (request.Text.Length > Options.MaxCharactersPerRequest)
+        {
+            throw new TranslationException("検出対象が許容される文字数を超えています。");
+        }
+
+        foreach (var provider in _providers)
+        {
+            try
+            {
+                return await provider.DetectAsync(request.Text, cancellationToken);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or TaskCanceledException)
+            {
+                continue;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(request.TenantId))
+        {
+            _metrics.RecordFailure(request.TenantId, UsageMetricsService.FailureReasons.Provider);
+        }
+
+        throw new TranslationException("言語を検出できません。");
+    }
+
     public async Task<TranslationResult> TranslateAsync(TranslationRequest request, CancellationToken cancellationToken)
     {
         var sourceLanguage = request.SourceLanguage;
@@ -61,28 +93,7 @@ public class TranslationRouter
             sourceLanguage = detection.Language;
         }
 
-        if (string.IsNullOrEmpty(request.UserId))
-        {
-            _metrics.RecordFailure(request.TenantId, UsageMetricsService.FailureReasons.Authentication);
-            throw new AuthenticationException("ユーザー ID が空のため、トークンを取得できません。");
-        }
-
-        AccessToken token;
-        try
-        {
-            token = await _tokenBroker.ExchangeOnBehalfOfAsync(request.TenantId, request.UserId, cancellationToken);
-        }
-        catch (AuthenticationException)
-        {
-            _metrics.RecordFailure(request.TenantId, UsageMetricsService.FailureReasons.Authentication);
-            throw;
-        }
-
-        if (token.ExpiresOn <= DateTimeOffset.UtcNow)
-        {
-            _metrics.RecordFailure(request.TenantId, UsageMetricsService.FailureReasons.Authentication);
-            throw new AuthenticationException("取得したトークンの有効期限が切れています。");
-        }
+        var token = await AcquireTokenAsync(request.TenantId, request.UserId, cancellationToken);
 
         var promptPrefix = _tones.GetPromptPrefix(request.Tone);
 
@@ -153,6 +164,146 @@ public class TranslationRouter
         }
 
         throw new TranslationException("利用可能なモデルが見つかりません。");
+    }
+
+    public async Task<RewriteResult> RewriteAsync(RewriteRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Text))
+        {
+            throw new TranslationException("改写する本文は必須です。");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.TenantId) || string.IsNullOrWhiteSpace(request.UserId))
+        {
+            throw new AuthenticationException("tenantId と userId は必須です。");
+        }
+
+        var token = await AcquireTokenAsync(request.TenantId, request.UserId, cancellationToken);
+        _ = token; // トークン取得は成功の検証として使用する。
+
+        var allowedProviders = 0;
+        foreach (var provider in _providers)
+        {
+            var report = _compliance.Evaluate(request.Text, provider.Options);
+            if (!report.Allowed)
+            {
+                continue;
+            }
+
+            allowedProviders++;
+            var estimatedCost = request.Text.Length * provider.Options.CostPerCharUsd;
+            if (!_budget.TryReserve(request.TenantId, estimatedCost))
+            {
+                _metrics.RecordFailure(request.TenantId, UsageMetricsService.FailureReasons.Budget);
+                throw new BudgetExceededException("本日の翻訳予算を超過しています。");
+            }
+
+            try
+            {
+                var rewritten = await provider.RewriteAsync(request.Text, request.Tone, cancellationToken);
+                var latency = provider.Options.LatencyTargetMs;
+                _metrics.RecordSuccess(request.TenantId, provider.Options.Id, estimatedCost, latency, 1);
+                return new RewriteResult(rewritten, provider.Options.Id, estimatedCost, latency);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or TaskCanceledException)
+            {
+                continue;
+            }
+        }
+
+        if (allowedProviders == 0)
+        {
+            _metrics.RecordFailure(request.TenantId, UsageMetricsService.FailureReasons.Compliance);
+        }
+        else
+        {
+            _metrics.RecordFailure(request.TenantId, UsageMetricsService.FailureReasons.Provider);
+        }
+
+        throw new TranslationException("改写に使用できるモデルが見つかりません。");
+    }
+
+    public async Task<SummarizeResult> SummarizeAsync(SummarizeRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Context))
+        {
+            throw new TranslationException("要約対象のコンテキストは必須です。");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.TenantId) || string.IsNullOrWhiteSpace(request.UserId))
+        {
+            throw new AuthenticationException("tenantId と userId は必須です。");
+        }
+
+        var token = await AcquireTokenAsync(request.TenantId, request.UserId, cancellationToken);
+        _ = token;
+
+        var allowedProviders = 0;
+        foreach (var provider in _providers)
+        {
+            var report = _compliance.Evaluate(request.Context, provider.Options);
+            if (!report.Allowed)
+            {
+                continue;
+            }
+
+            allowedProviders++;
+            var estimatedCost = request.Context.Length * provider.Options.CostPerCharUsd;
+            if (!_budget.TryReserve(request.TenantId, estimatedCost))
+            {
+                _metrics.RecordFailure(request.TenantId, UsageMetricsService.FailureReasons.Budget);
+                throw new BudgetExceededException("本日の翻訳予算を超過しています。");
+            }
+
+            try
+            {
+                var summary = await provider.SummarizeAsync(request.Context, cancellationToken);
+                var latency = provider.Options.LatencyTargetMs;
+                _metrics.RecordSuccess(request.TenantId, provider.Options.Id, estimatedCost, latency, 1);
+                return new SummarizeResult(summary, provider.Options.Id, estimatedCost, latency);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or TaskCanceledException)
+            {
+                continue;
+            }
+        }
+
+        if (allowedProviders == 0)
+        {
+            _metrics.RecordFailure(request.TenantId, UsageMetricsService.FailureReasons.Compliance);
+        }
+        else
+        {
+            _metrics.RecordFailure(request.TenantId, UsageMetricsService.FailureReasons.Provider);
+        }
+
+        throw new TranslationException("要約に使用できるモデルが見つかりません。");
+    }
+
+    private async Task<AccessToken> AcquireTokenAsync(string tenantId, string userId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(userId))
+        {
+            _metrics.RecordFailure(tenantId, UsageMetricsService.FailureReasons.Authentication);
+            throw new AuthenticationException("ユーザー ID が空のため、トークンを取得できません。");
+        }
+
+        try
+        {
+            var token = await _tokenBroker.ExchangeOnBehalfOfAsync(tenantId, userId, cancellationToken);
+            if (token.ExpiresOn <= DateTimeOffset.UtcNow)
+            {
+                _metrics.RecordFailure(tenantId, UsageMetricsService.FailureReasons.Authentication);
+                throw new AuthenticationException("取得したトークンの有効期限が切れています。");
+            }
+
+            return token;
+        }
+        catch (AuthenticationException)
+        {
+            _metrics.RecordFailure(tenantId, UsageMetricsService.FailureReasons.Authentication);
+            throw;
+        }
     }
 
     private JsonObject BuildAdaptiveCard(

--- a/tests/TlaPlugin.Tests/ApiEndpointsTests.cs
+++ b/tests/TlaPlugin.Tests/ApiEndpointsTests.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class ApiEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ApiEndpointsTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task DetectEndpointReturnsLanguage()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/detect", new LanguageDetectionRequest
+        {
+            Text = "こんにちは",
+            TenantId = "contoso"
+        });
+
+        response.EnsureSuccessStatusCode();
+        var detection = await response.Content.ReadFromJsonAsync<DetectionResult>();
+        Assert.NotNull(detection);
+        Assert.Equal("ja", detection!.Language);
+    }
+
+    [Fact]
+    public async Task ApplyGlossaryReturnsMatches()
+    {
+        var client = _factory.CreateClient();
+        var request = new GlossaryApplicationRequest
+        {
+            Text = "CPU compliance",
+            TenantId = "contoso",
+            UserId = "admin",
+            Policy = GlossaryPolicy.Fallback.ToString()
+        };
+
+        var response = await client.PostAsJsonAsync("/api/apply-glossary", request);
+        response.EnsureSuccessStatusCode();
+        var payload = await response.Content.ReadFromJsonAsync<GlossaryResponse>();
+        Assert.NotNull(payload);
+        Assert.Contains("中央处理器", payload!.ProcessedText);
+        Assert.NotEmpty(payload.Matches);
+    }
+
+    [Fact]
+    public async Task ReplyEndpointHonorsChannelRestrictions()
+    {
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.PostConfigure<PluginOptions>(options =>
+                {
+                    options.Security.AllowedReplyChannels = new List<string> { "allowed" };
+                });
+            });
+        }).CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/reply", new ReplyRequest
+        {
+            ThreadId = "thread",
+            ReplyText = "hello",
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "blocked"
+        });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CostLatencyEndpointReturnsNotFoundForUnknownModel()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/cost-latency?payloadSize=100&modelId=unknown");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RewriteEndpointReturnsPaymentRequiredWhenOverBudget()
+    {
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.PostConfigure<PluginOptions>(options =>
+                {
+                    options.DailyBudgetUsd = 0.00001m;
+                });
+            });
+        }).CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/rewrite", new RewriteRequest
+        {
+            Text = new string('a', 10),
+            TenantId = "contoso",
+            UserId = "user",
+            Tone = ToneTemplateService.Business
+        });
+
+        Assert.Equal(HttpStatusCode.PaymentRequired, response.StatusCode);
+    }
+
+    private sealed class GlossaryResponse
+    {
+        public string ProcessedText { get; set; } = string.Empty;
+        public List<GlossaryMatch> Matches { get; set; } = new();
+    }
+}

--- a/tests/TlaPlugin.Tests/ReplyServiceTests.cs
+++ b/tests/TlaPlugin.Tests/ReplyServiceTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class ReplyServiceTests
+{
+    [Fact]
+    public async Task ThrowsWhenChannelNotAllowed()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Security = new SecurityOptions
+            {
+                AllowedReplyChannels = new List<string> { "general" }
+            },
+            Providers = new List<ModelProviderOptions> { new() { Id = "primary" } }
+        });
+
+        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new RecordingTokenBroker(), new UsageMetricsService(), new LocalizationCatalogService(), options);
+        var service = new ReplyService(router, options);
+
+        await Assert.ThrowsAsync<ReplyAuthorizationException>(() => service.SendReplyAsync(new ReplyRequest
+        {
+            ThreadId = "thread",
+            ReplyText = "hello",
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "random"
+        }, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task AppliesToneWhenLanguagePolicySpecified()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Security = new SecurityOptions
+            {
+                AllowedReplyChannels = new List<string>()
+            },
+            Providers = new List<ModelProviderOptions> { new() { Id = "primary" } }
+        });
+
+        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new RecordingTokenBroker(), new UsageMetricsService(), new LocalizationCatalogService(), options);
+        var service = new ReplyService(router, options);
+
+        var result = await service.SendReplyAsync(new ReplyRequest
+        {
+            ThreadId = "thread",
+            ReplyText = "こんにちは",
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "general",
+            LanguagePolicy = new ReplyLanguagePolicy { Tone = ToneTemplateService.Business }
+        }, CancellationToken.None);
+
+        Assert.Equal("sent", result.Status);
+        Assert.Contains("商务语气", result.FinalText);
+        Assert.Equal(ToneTemplateService.Business, result.ToneApplied);
+    }
+
+    private sealed class RecordingTokenBroker : ITokenBroker
+    {
+        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new AccessToken("token", DateTimeOffset.UtcNow.AddMinutes(10), "audience"));
+        }
+    }
+}

--- a/tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj
+++ b/tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.20" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- register the detect, rewrite, apply glossary, reply, and cost latency endpoints and related services in the plugin host
- expand the model routing layer with detection/rewrite/summarize branches plus reply and cost estimation helpers
- add unit and integration coverage for the new APIs, including permission and failure paths

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db46126130832f95a5ddc1c3a00c80