### PR TITLE
Lower confidence for plain ASCII language detection

### DIFF
--- a/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
+++ b/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
@@ -1,0 +1,29 @@
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class LanguageDetectorTests
+{
+    [Fact]
+    public void Detect_DowngradesPlainAsciiConfidence()
+    {
+        var detector = new LanguageDetector();
+
+        var result = detector.Detect("This is a simple test message written with plain ASCII letters only.");
+
+        Assert.Equal("en", result.Language);
+        Assert.True(result.Confidence < 0.75);
+    }
+
+    [Fact]
+    public void Detect_KeepsConfidenceForTextWithDistinctFeatures()
+    {
+        var detector = new LanguageDetector();
+
+        var result = detector.Detect("¿Dónde está la biblioteca? Necesito información rápida.");
+
+        Assert.Equal("es", result.Language);
+        Assert.True(result.Confidence >= 0.75);
+    }
+}


### PR DESCRIPTION
## Summary
- penalize language detection confidence when input lacks distinctive signatures or letter variety
- clamp scores after applying the new heuristic to keep confidence bounded
- add unit tests covering featureless ASCII text and accented text scenarios

## Testing
- dotnet test *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db649c4f10832facfea1ac8d95424d