### PR TITLE
Guard detect endpoint against missing text

### DIFF
--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -71,6 +71,11 @@ app.MapPost("/api/offline-draft", async (OfflineDraftRequest request, MessageExt
 
 app.MapPost("/api/detect", async (LanguageDetectionRequest request, TranslationRouter router, IOptions<PluginOptions> options, CancellationToken cancellationToken) =>
 {
+    if (request is null || string.IsNullOrWhiteSpace(request.Text))
+    {
+        return Results.BadRequest(new { error = "Text is required." });
+    }
+
     if (request.Text.Length > options.Value.MaxCharactersPerRequest)
     {
         return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);

--- a/tests/TlaPlugin.Tests/ApiEndpointsTests.cs
+++ b/tests/TlaPlugin.Tests/ApiEndpointsTests.cs
@@ -36,6 +36,26 @@ public class ApiEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.Equal("ja", detection!.Language);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task DetectEndpointReturnsBadRequestForMissingText(string? text)
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/detect", new
+        {
+            Text = text,
+            TenantId = "contoso"
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+        Assert.NotNull(payload);
+        Assert.Equal("Text is required.", payload!["error"]);
+    }
+
     [Fact]
     public async Task ApplyGlossaryReturnsMatches()
     {


### PR DESCRIPTION
## Summary
- guard the `/api/detect` endpoint against requests that omit text and respond with a client error
- add coverage to the API endpoint tests to assert the new bad request response

## Testing
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db7a986f80832f9f7deac79debc397