### PR TITLE
Handle low-confidence language detection in pipeline

### DIFF
--- a/src/TlaPlugin/Models/PipelineExecutionResult.cs
+++ b/src/TlaPlugin/Models/PipelineExecutionResult.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// 表示翻译管线执行的结果，可能是翻译内容或语言识别候选。
+/// </summary>
+public class PipelineExecutionResult
+{
+    private PipelineExecutionResult(TranslationResult? translation, DetectionResult? detection)
+    {
+        Translation = translation;
+        Detection = detection;
+    }
+
+    /// <summary>
+    /// 获取翻译结果，如果本次执行未进行翻译则为 null。
+    /// </summary>
+    public TranslationResult? Translation { get; }
+
+    /// <summary>
+    /// 获取语言识别结果，当需要用户确认语言时提供候选列表。
+    /// </summary>
+    public DetectionResult? Detection { get; }
+
+    /// <summary>
+    /// 指示是否需要用户选择源语言。
+    /// </summary>
+    public bool RequiresLanguageSelection => Detection is not null && Translation is null;
+
+    public static PipelineExecutionResult FromTranslation(TranslationResult translation)
+    {
+        if (translation is null)
+        {
+            throw new ArgumentNullException(nameof(translation));
+        }
+
+        return new PipelineExecutionResult(translation, null);
+    }
+
+    public static PipelineExecutionResult FromDetection(DetectionResult detection)
+    {
+        if (detection is null)
+        {
+            throw new ArgumentNullException(nameof(detection));
+        }
+
+        return new PipelineExecutionResult(null, detection);
+    }
+}

--- a/src/TlaPlugin/Services/TranslationPipeline.cs
+++ b/src/TlaPlugin/Services/TranslationPipeline.cs
@@ -33,7 +33,7 @@ public class TranslationPipeline
         _options = options?.Value ?? new PluginOptions();
     }
 
-    public async Task<TranslationResult> ExecuteAsync(TranslationRequest request, CancellationToken cancellationToken)
+    public async Task<PipelineExecutionResult> ExecuteAsync(TranslationRequest request, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(request.Text))
         {
@@ -88,7 +88,7 @@ public class TranslationPipeline
             var detection = _detector.Detect(resolvedRequest.Text);
             if (detection.Confidence < 0.75)
             {
-                throw new LanguageDetectionLowConfidenceException(detection);
+                return PipelineExecutionResult.FromDetection(detection);
             }
             resolvedRequest.SourceLanguage = detection.Language;
         }
@@ -96,14 +96,14 @@ public class TranslationPipeline
         if (_cache.TryGet(resolvedRequest, out var cached))
         {
             cached.SetGlossaryMatches(matchSnapshots.Select(match => match.Clone()));
-            return cached;
+            return PipelineExecutionResult.FromTranslation(cached);
         }
 
         using var lease = await _throttle.AcquireAsync(resolvedRequest.TenantId, cancellationToken);
         var result = await _router.TranslateAsync(resolvedRequest, cancellationToken);
         result.SetGlossaryMatches(matchSnapshots);
         _cache.Set(resolvedRequest, result);
-        return result;
+        return PipelineExecutionResult.FromTranslation(result);
     }
 
     public OfflineDraftRecord SaveDraft(OfflineDraftRequest request)

--- a/src/TlaPlugin/Services/TranslationRouter.cs
+++ b/src/TlaPlugin/Services/TranslationRouter.cs
@@ -432,17 +432,6 @@ public class TranslationRouter
     }
 }
 
-public class LanguageDetectionLowConfidenceException : TranslationException
-{
-    public LanguageDetectionLowConfidenceException(DetectionResult detection)
-        : base("言語を自動判定できません。候補から選択してください。")
-    {
-        Detection = detection;
-    }
-
-    public DetectionResult Detection { get; }
-}
-
 public class TranslationException : Exception
 {
     public TranslationException(string message) : base(message) { }

--- a/src/services/languageDetector.js
+++ b/src/services/languageDetector.js
@@ -4,15 +4,207 @@ export class LanguageDetector {
   }
 
   async detect(request) {
+    const text = request?.text ?? "";
     for (const provider of this.providers) {
       if (typeof provider.detect === "function") {
         const result = await provider.detect(request);
         if (result && result.language) {
-          return result;
+          return this.#normalize(result, text);
         }
       }
     }
-    return { language: "en", confidence: 0.5 };
+    return this.#fallback(text);
+  }
+
+  #normalize(result, text) {
+    const fallback = this.#fallback(text);
+    const primaryLanguage = result.language ?? fallback.language;
+    const confidence = typeof result.confidence === "number" ? this.#clamp(result.confidence) : fallback.confidence;
+    const providedCandidates = Array.isArray(result.candidates)
+      ? result.candidates
+          .filter((item) => item && item.language)
+          .map((item) => ({
+            language: item.language,
+            confidence: typeof item.confidence === "number" ? this.#clamp(item.confidence) : confidence
+          }))
+      : [];
+
+    const registry = new Map();
+    const register = (language, score) => {
+      if (!language) return;
+      const next = this.#clamp(score);
+      if (!registry.has(language) || registry.get(language) < next) {
+        registry.set(language, next);
+      }
+    };
+
+    register(primaryLanguage, confidence);
+    for (const candidate of providedCandidates) {
+      register(candidate.language, candidate.confidence);
+    }
+    for (const candidate of fallback.candidates) {
+      register(candidate.language, candidate.confidence);
+    }
+
+    const candidates = Array.from(registry.entries())
+      .map(([language, value]) => ({ language, confidence: this.#round(value) }))
+      .sort((a, b) => b.confidence - a.confidence || a.language.localeCompare(b.language))
+      .slice(0, 6);
+
+    return {
+      language: candidates[0]?.language ?? primaryLanguage ?? fallback.language,
+      confidence: candidates[0]?.confidence ?? this.#round(confidence),
+      candidates
+    };
+  }
+
+  #fallback(text) {
+    const registry = new Map();
+    const register = (language, score) => {
+      if (!language) return;
+      const clamped = this.#clamp(score);
+      if (!registry.has(language) || registry.get(language) < clamped) {
+        registry.set(language, clamped);
+      }
+    };
+
+    const matches = this.#evaluateHeuristics(text ?? "");
+    for (const entry of matches) {
+      register(entry.language, entry.confidence);
+    }
+
+    if (!registry.size) {
+      register("en", 0.5);
+    }
+
+    const ordered = Array.from(registry.entries())
+      .map(([language, confidence]) => ({ language, confidence: this.#round(confidence) }))
+      .sort((a, b) => b.confidence - a.confidence || a.language.localeCompare(b.language));
+
+    return {
+      language: ordered[0].language,
+      confidence: ordered[0].confidence,
+      candidates: ordered.slice(0, 6)
+    };
+  }
+
+  #evaluateHeuristics(text) {
+    const normalized = typeof text === "string" ? text.trim() : "";
+    if (!normalized) {
+      return [];
+    }
+
+    const results = [];
+    const register = (language, confidence) => {
+      results.push({ language, confidence });
+    };
+
+    const pushWithAlternatives = (language, confidence, alternatives = []) => {
+      register(language, confidence);
+      for (const option of alternatives) {
+        const delta = typeof option.delta === "number" ? option.delta : -0.2;
+        register(option.language, Math.max(0.1, confidence + delta));
+      }
+    };
+
+    const has = (pattern) => pattern.test(normalized);
+
+    if (has(/[\p{Script=Hiragana}\p{Script=Katakana}]/u)) {
+      pushWithAlternatives("ja", 0.96, [
+        { language: "zh-Hans", delta: -0.25 },
+        { language: "ko", delta: -0.3 }
+      ]);
+    }
+
+    if (has(/[\u4E00-\u9FFF]/u)) {
+      pushWithAlternatives("zh-Hans", 0.88, [
+        { language: "ja", delta: -0.18 },
+        { language: "ko", delta: -0.25 }
+      ]);
+    }
+
+    if (has(/[\uAC00-\uD7AF]/u)) {
+      pushWithAlternatives("ko", 0.94, [
+        { language: "ja", delta: -0.22 },
+        { language: "zh-Hans", delta: -0.28 }
+      ]);
+    }
+
+    if (has(/[\u0400-\u04FF]/u)) {
+      pushWithAlternatives("ru", 0.9, [{ language: "uk", delta: -0.1 }]);
+    }
+
+    if (has(/[\u0600-\u06FF]/u)) {
+      pushWithAlternatives("ar", 0.9, [{ language: "fa", delta: -0.08 }]);
+    }
+
+    if (has(/[\u0900-\u097F]/u)) {
+      pushWithAlternatives("hi", 0.9, [{ language: "mr", delta: -0.08 }]);
+    }
+
+    if (has(/[\u0E00-\u0E7F]/u)) {
+      register("th", 0.92);
+    }
+
+    if (has(/[ñáéíóúü¿¡]/iu)) {
+      pushWithAlternatives("es", 0.84, [
+        { language: "pt", delta: -0.12 },
+        { language: "en", delta: -0.22 }
+      ]);
+    }
+
+    if (has(/[ãõáâàêéíóôúç]/iu)) {
+      pushWithAlternatives("pt", 0.82, [{ language: "es", delta: -0.1 }]);
+    }
+
+    if (has(/[àâçéèêëîïôûùüÿœæ]/iu)) {
+      pushWithAlternatives("fr", 0.82, [{ language: "it", delta: -0.12 }]);
+    }
+
+    if (has(/[äöüß]/iu)) {
+      pushWithAlternatives("de", 0.82, [{ language: "sv", delta: -0.14 }]);
+    }
+
+    if (has(/[åäö]/iu)) {
+      pushWithAlternatives("sv", 0.78, [{ language: "fi", delta: -0.16 }]);
+    }
+
+    if (has(/[æøå]/iu)) {
+      pushWithAlternatives("no", 0.78, [{ language: "da", delta: -0.1 }]);
+    }
+
+    if (has(/[ąćęłńóśźż]/iu)) {
+      register("pl", 0.82);
+    }
+
+    if (has(/[čďěňřšťůž]/iu)) {
+      register("cs", 0.8);
+    }
+
+    const totalLetters = (normalized.match(/\p{L}/gu) ?? []).length;
+    const asciiLetters = (normalized.match(/[A-Za-z]/g) ?? []).length;
+    if (totalLetters > 0) {
+      const ratio = asciiLetters / totalLetters;
+      const base = ratio >= 0.95 ? 0.74 : ratio >= 0.75 ? 0.68 : 0.58;
+      pushWithAlternatives("en", base, [
+        { language: "de", delta: -0.16 },
+        { language: "fr", delta: -0.16 },
+        { language: "es", delta: -0.18 }
+      ]);
+    }
+
+    return results;
+  }
+
+  #clamp(value) {
+    if (Number.isNaN(value)) {
+      return 0;
+    }
+    return Math.max(0, Math.min(0.99, value));
+  }
+
+  #round(value) {
+    return Math.round(this.#clamp(value) * 100) / 100;
   }
 }
 

--- a/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
+++ b/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
@@ -56,6 +56,39 @@ public class MessageExtensionHandlerTests
     }
 
     [Fact]
+    public async Task ReturnsLanguageSelectionWhenDetectionLow()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var handler = BuildHandler(options);
+        var response = await handler.HandleTranslateAsync(new TranslationRequest
+        {
+            Text = "Hello team",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja"
+        });
+
+        Assert.Equal("languageSelection", response["type"]?.GetValue<string>());
+        var candidates = response["candidates"]!.AsArray();
+        Assert.NotEmpty(candidates);
+        var first = candidates[0]!.AsObject();
+        Assert.True(first.ContainsKey("language"));
+        Assert.True(first.ContainsKey("confidence"));
+    }
+
+    [Fact]
     public async Task RendersAdditionalTranslationsInAdaptiveCard()
     {
         var options = Options.Create(new PluginOptions


### PR DESCRIPTION
## Summary
- expand the JavaScript language detector to surface confidence scores and ranked candidates using heuristics across multiple scripts
- adjust the .NET translation pipeline to return either translation data or detection results via a new PipelineExecutionResult model and consume it in the Teams message handler
- add coverage for low-confidence detection flows in pipeline and handler tests, including manual language selection continuation

## Testing
- npm test
- (fails: dotnet test – dotnet CLI is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68db7d4859d8832fa55a624609675da3