### PR TITLE
Restore English confidence for Latin detection

### DIFF
--- a/src/TlaPlugin/Services/LanguageDetector.cs
+++ b/src/TlaPlugin/Services/LanguageDetector.cs
@@ -178,7 +178,13 @@ public class LanguageDetector
             scored.Add((definition, score));
         }
 
-        var featurePenalty = CalculateFeaturePenalty(primary.Key, hasSignatureMatch, uniqueLetters, primary.Value, usesBasicLatinOnly);
+        var featurePenalty = CalculateFeaturePenalty(
+            primary.Key,
+            hasSignatureMatch,
+            uniqueLetters,
+            primary.Value,
+            usesBasicLatinOnly,
+            trimmed);
         if (featurePenalty > 0)
         {
             for (var i = 0; i < scored.Count; i++)
@@ -252,7 +258,8 @@ public class LanguageDetector
         bool hasSignatureMatch,
         int uniqueLetters,
         int scriptLetterCount,
-        bool usesBasicLatinOnly)
+        bool usesBasicLatinOnly,
+        string text)
     {
         double penalty = 0;
 
@@ -260,7 +267,16 @@ public class LanguageDetector
         {
             if (!hasSignatureMatch && usesBasicLatinOnly)
             {
-                penalty = scriptLetterCount >= 12 ? 0.22 : 0.18;
+                var wordCount = CountWords(text);
+                var hasRepresentativeStructure =
+                    wordCount >= 4 &&
+                    scriptLetterCount >= 18 &&
+                    uniqueLetters >= 7;
+
+                if (!hasRepresentativeStructure)
+                {
+                    penalty = scriptLetterCount >= 12 ? 0.22 : 0.18;
+                }
             }
 
             if (scriptLetterCount >= 6 && uniqueLetters <= 4)
@@ -278,6 +294,30 @@ public class LanguageDetector
         }
 
         return penalty;
+    }
+
+    private static int CountWords(string text)
+    {
+        var count = 0;
+        var inWord = false;
+
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (Rune.IsLetter(rune))
+            {
+                if (!inWord)
+                {
+                    inWord = true;
+                    count++;
+                }
+            }
+            else
+            {
+                inWord = false;
+            }
+        }
+
+        return count;
     }
 
     private static int CountUniqueLetters(string text, WritingSystem script)

--- a/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
+++ b/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
@@ -6,14 +6,14 @@ namespace TlaPlugin.Tests;
 public class LanguageDetectorTests
 {
     [Fact]
-    public void Detect_DowngradesPlainAsciiConfidence()
+    public void Detect_PlainAsciiSentenceMaintainsConfidence()
     {
         var detector = new LanguageDetector();
 
         var result = detector.Detect("This is a simple test message written with plain ASCII letters only.");
 
         Assert.Equal("en", result.Language);
-        Assert.True(result.Confidence < 0.75);
+        Assert.True(result.Confidence >= 0.75);
     }
 
     [Fact]
@@ -25,5 +25,16 @@ public class LanguageDetectorTests
 
         Assert.Equal("es", result.Language);
         Assert.True(result.Confidence >= 0.75);
+    }
+
+    [Fact]
+    public void Detect_StillDowngradesAmbiguousAscii()
+    {
+        var detector = new LanguageDetector();
+
+        var result = detector.Detect("Hello world!");
+
+        Assert.Equal("en", result.Language);
+        Assert.True(result.Confidence < 0.75);
     }
 }


### PR DESCRIPTION
## Summary
- relax the Latin basic script penalty when the sample has enough words and variety to resemble English sentences
- keep ambiguity protection by preserving penalties for short or low-diversity ASCII snippets
- update detector tests to assert high confidence for representative English text and low confidence for ambiguous samples

## Testing
- `dotnet test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db8227e9c8832f9d901c7ca13264a5