### PR TITLE
Balance Kanji detection between Chinese and Japanese

### DIFF
--- a/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
+++ b/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using TlaPlugin.Services;
 using Xunit;
 
@@ -25,5 +26,17 @@ public class LanguageDetectorTests
 
         Assert.Equal("es", result.Language);
         Assert.True(result.Confidence >= 0.75);
+    }
+
+    [Fact]
+    public void Detect_ReturnsJapaneseCandidateForKanjiOnlyText()
+    {
+        var detector = new LanguageDetector();
+
+        var result = detector.Detect("東京都庁");
+
+        Assert.True(result.Confidence < 0.75);
+        Assert.Contains(result.Candidates, candidate => string.Equals(candidate.Language, "ja", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Candidates, candidate => string.Equals(candidate.Language, "zh", StringComparison.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
## Summary
- add a Han-script Japanese definition so Kanji-only strings surface ja candidates
- rebalance Han scoring to treat ambiguous Kanji as low confidence while keeping zh vs. ja signals
- cover the Kanji-only scenarios with unit and pipeline tests to ensure Japanese remains in the candidate list

## Testing
- dotnet test *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db821e8be0832fa0e7c61024e4886c