### PR TITLE
Handle detected language in compose flow

### DIFF
--- a/src/teamsClient/composePlugin.js
+++ b/src/teamsClient/composePlugin.js
@@ -102,6 +102,13 @@ export async function initComposePlugin({ ui = resolveComposeUi(), teams, fetche
     const payload = buildTranslatePayload({ ...state }, context);
     try {
       const response = await translateText(payload, fetcher);
+      if (response?.metadata?.tone) {
+        state.tone = response.metadata.tone;
+        if (ui.toneToggle) {
+          ui.toneToggle.checked = state.tone === "formal";
+        }
+      }
+      state.detectedLanguage = response?.detectedLanguage ?? state.detectedLanguage;
       state.translation = response.text ?? "";
       setPreview(ui.preview, state.translation);
     } catch (error) {

--- a/src/webapp/dialogState.js
+++ b/src/webapp/dialogState.js
@@ -1,5 +1,9 @@
 import { FALLBACK_METADATA } from "./apiClient.js";
 
+export { buildDetectPayload, buildRewritePayload, buildReplyPayload, updateStateWithResponse } from "../teamsClient/state.js";
+
+export { default } from "../teamsClient/state.js";
+
 function isSelectableLanguage(language) {
   return Boolean(language?.id) && language.id !== "auto";
 }
@@ -81,28 +85,3 @@ export function buildTranslatePayload(state, context) {
   };
 }
 
-export function updateStateWithResponse(state, response) {
-  if (!state || !response) {
-    return state;
-  }
-  const next = { ...state };
-  if (typeof response.text === "string") {
-    next.translation = response.text;
-  }
-  if (response.metadata?.modelId) {
-    next.modelId = response.metadata.modelId;
-  }
-  return next;
-}
-
-export default {
-  buildDialogState,
-  calculateCostHint,
-  buildTranslatePayload,
-  buildDetectPayload,
-  buildRewritePayload,
-  buildReplyPayload,
-  updateStateWithResponse
-} from "../teamsClient/state.js";
-
-export { default } from "../teamsClient/state.js";

--- a/tests/composePlugin.test.js
+++ b/tests/composePlugin.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { initComposePlugin } from "../src/webapp/composePlugin.js";
+import { initComposePlugin } from "../src/teamsClient/composePlugin.js";
 
 function createStubElement(initial = {}) {
   return {
@@ -43,7 +43,7 @@ test("compose plugin translates and posts reply payload", async () => {
           };
         }
         if (url === "/api/translate") {
-          return { text: "hola", metadata: { modelId: "model-a" } };
+          return { text: "hola", detectedLanguage: "en", metadata: { modelId: "model-a", tone: "formal" } };
         }
         if (url === "/api/reply") {
           return { status: "ok" };
@@ -92,6 +92,7 @@ test("compose plugin translates and posts reply payload", async () => {
   assert.equal(preview.value || preview.textContent, "hola");
   assert.equal(fetchCalls[1].url, "/api/reply");
   assert.equal(fetchCalls[1].options.translation, "hola");
+  assert.equal(fetchCalls[1].options.sourceLanguage, "en");
   assert.equal(fetchCalls[1].options.metadata.tone, "formal");
   assert.equal(state.tone, "formal");
 });

--- a/tests/messageExtensionDialog.test.js
+++ b/tests/messageExtensionDialog.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { initMessageExtensionDialog } from "../src/webapp/dialog.js";
+import { initMessageExtensionDialog } from "../src/teamsClient/messageExtensionDialog.js";
 
 function createStubElement(initial = {}) {
   return {
@@ -236,6 +236,7 @@ test("initMessageExtensionDialog corrects target when locale missing from metada
 
   assert.equal(state.targetLanguage, "ja");
   assert.equal(ui.targetSelect.value, "ja");
-  assert.equal(fetchCalls.length, 1);
-  assert.equal(fetchCalls[0].body.targetLanguage, "ja");
+  assert.equal(fetchCalls[0].url, "/api/detect");
+  assert.equal(fetchCalls.at(-1).url, "/api/translate");
+  assert.equal(fetchCalls.at(-1).body.targetLanguage, "ja");
 });

--- a/tests/messageExtensionDialogState.test.js
+++ b/tests/messageExtensionDialogState.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildDialogState, calculateCostHint, buildTranslatePayload, updateStateWithResponse } from "../src/webapp/dialogState.js";
+import { buildDialogState, calculateCostHint, buildTranslatePayload, updateStateWithResponse } from "../src/teamsClient/state.js";
 
 test("buildDialogState chooses default language from context locale", () => {
   const models = [


### PR DESCRIPTION
## Summary
- update the Teams compose suggestion handler to persist detected language metadata and sync tone before previewing translations
- align the webapp dialog state exports with the Teams implementation
- update compose and message extension tests to assert detected language handling and exercise the Teams client flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db81f9b0bc832f843e3484f0d21c7d