### PR TITLE
Tighten Latin detection heuristic for English

### DIFF
--- a/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
+++ b/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
@@ -39,4 +39,14 @@ public class LanguageDetectorTests
         Assert.Contains(result.Candidates, candidate => string.Equals(candidate.Language, "ja", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(result.Candidates, candidate => string.Equals(candidate.Language, "zh", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public void Detect_DiacriticFreeForeignSentenceRemainsUncertain()
+    {
+        var detector = new LanguageDetector();
+
+        var result = detector.Detect("Besok pagi kami akan berangkat ke pasar untuk membeli sayur segar dan buah segar.");
+
+        Assert.True(result.Confidence < 0.75);
+    }
 }

--- a/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
@@ -350,6 +350,37 @@ public class TranslationPipelineTests
     }
 
     [Fact]
+    public async Task ReturnsLanguageSelectionForAmbiguousLatinSentence()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var pipeline = BuildPipeline(options);
+
+        var result = await pipeline.ExecuteAsync(new TranslationRequest
+        {
+            Text = "Besok pagi kami akan berangkat ke pasar untuk membeli sayur segar dan buah segar.",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja"
+        }, CancellationToken.None);
+
+        Assert.True(result.RequiresLanguageSelection);
+        var detection = Assert.NotNull(result.Detection);
+        Assert.True(detection.Confidence < 0.75);
+    }
+
+    [Fact]
     public async Task ReturnsJapaneseCandidateForKanjiOnlyDetection()
     {
         var options = Options.Create(new PluginOptions


### PR DESCRIPTION
## Summary
- require English-specific indicators before waiving the Latin script penalty in the language detector
- add unit coverage for diacritic-free foreign sentences to ensure low confidence
- extend the translation pipeline tests to expect language selection for ambiguous Latin text

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db8545cb2c832fbd767f3b05676f35