### PR TITLE
Handle shared CJK punctuation in Han detection

### DIFF
--- a/src/TlaPlugin/Services/LanguageDetector.cs
+++ b/src/TlaPlugin/Services/LanguageDetector.cs
@@ -144,13 +144,18 @@ public class LanguageDetector
         var hasSignatureMatch = false;
         var hasJapaneseKana = false;
         var containsChinesePunctuation = false;
-        var isAmbiguousHan = false;
+        var hasNeutralHanPunctuation = false;
+        var penalizeHanForLackOfKana = false;
 
         if (primary.Key == WritingSystem.Han)
         {
             hasJapaneseKana = ContainsJapaneseKana(trimmed);
             containsChinesePunctuation = ChinesePunctuation.IsMatch(trimmed);
-            isAmbiguousHan = !hasJapaneseKana && !containsChinesePunctuation;
+            if (!hasJapaneseKana)
+            {
+                penalizeHanForLackOfKana = true;
+                hasNeutralHanPunctuation = containsChinesePunctuation;
+            }
         }
 
         foreach (var definition in definitions)
@@ -164,7 +169,7 @@ public class LanguageDetector
 
             if (primary.Key == WritingSystem.Han)
             {
-                if (isAmbiguousHan)
+                if (penalizeHanForLackOfKana)
                 {
                     score -= 0.08;
                 }
@@ -183,11 +188,11 @@ public class LanguageDetector
                     {
                         score -= 0.15;
                     }
-                    if (containsChinesePunctuation)
+                    if (containsChinesePunctuation && !hasNeutralHanPunctuation)
                     {
                         score += 0.05;
                     }
-                    else if (isAmbiguousHan)
+                    if (penalizeHanForLackOfKana)
                     {
                         score -= 0.12;
                     }

--- a/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
+++ b/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
@@ -41,6 +41,17 @@ public class LanguageDetectorTests
     }
 
     [Fact]
+    public void Detect_KanjiOnlyTextWithSharedPunctuationRemainsUncertain()
+    {
+        var detector = new LanguageDetector();
+
+        var result = detector.Detect("東京都大阪府。");
+
+        Assert.True(result.Confidence < 0.75);
+        Assert.Contains(result.Candidates, candidate => string.Equals(candidate.Language, "ja", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Detect_DiacriticFreeForeignSentenceRemainsUncertain()
     {
         var detector = new LanguageDetector();

--- a/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
@@ -413,6 +413,38 @@ public class TranslationPipelineTests
     }
 
     [Fact]
+    public async Task ReturnsJapaneseCandidateForKanjiOnlyDetectionWithSharedPunctuation()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var pipeline = BuildPipeline(options);
+
+        var result = await pipeline.ExecuteAsync(new TranslationRequest
+        {
+            Text = "東京都大阪府。",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "en"
+        }, CancellationToken.None);
+
+        Assert.True(result.RequiresLanguageSelection);
+        var detection = Assert.NotNull(result.Detection);
+        Assert.True(detection.Confidence < 0.75);
+        Assert.Contains(detection.Candidates, candidate => string.Equals(candidate.Language, "ja", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task RespectsManualSourceLanguageAfterDetection()
     {
         var options = Options.Create(new PluginOptions


### PR DESCRIPTION
## Summary
- adjust Han-script scoring so shared CJK punctuation without kana no longer boosts Chinese and keeps zh/ja low-confidence
- add language detector and translation pipeline tests covering kanji-only input with shared punctuation

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db867a3bc0832f9dd52c0b19c8e183