### PR TITLE
Tighten English evidence requirement for Latin detection

### DIFF
--- a/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
+++ b/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
@@ -59,5 +59,6 @@ public class LanguageDetectorTests
         var result = detector.Detect("Besok pagi kami akan berangkat ke pasar untuk membeli sayur segar dan buah segar.");
 
         Assert.True(result.Confidence < 0.75);
+        Assert.NotEmpty(result.Candidates);
     }
 }

--- a/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
@@ -381,6 +381,33 @@ public class TranslationPipelineTests
     }
 
     [Fact]
+    public async Task DetectAsync_DiacriticFreeForeignSentenceRemainsUncertain()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var pipeline = BuildPipeline(options);
+
+        var detection = await pipeline.DetectAsync(new LanguageDetectionRequest
+        {
+            Text = "Besok pagi kami akan berangkat ke pasar untuk membeli sayur segar dan buah segar.",
+            TenantId = "contoso"
+        }, CancellationToken.None);
+
+        Assert.True(detection.Confidence < 0.75);
+    }
+
+    [Fact]
     public async Task ReturnsJapaneseCandidateForKanjiOnlyDetection()
     {
         var options = Options.Create(new PluginOptions


### PR DESCRIPTION
## Summary
- require explicit English evidence before clearing the Latin-script basic penalty so long ASCII foreign sentences stay low-confidence
- count repeated English stopwords and morphology n-grams to score evidence and adjust penalties accordingly
- extend detector and pipeline tests with diacritic-free Indonesian text to confirm confidence remains below the fallback threshold

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db87bcc57c832fb4a4f7dbbb7e5098