### PR TITLE
Handle shared Han punctuation as ambiguous

### DIFF
--- a/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
+++ b/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
@@ -49,6 +49,19 @@ public class LanguageDetectorTests
 
         Assert.True(result.Confidence < 0.75);
         Assert.Contains(result.Candidates, candidate => string.Equals(candidate.Language, "ja", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Candidates, candidate => string.Equals(candidate.Language, "zh", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Detect_PureHanTextWithSharedPunctuationKeepsBothCandidates()
+    {
+        var detector = new LanguageDetector();
+
+        var result = detector.Detect("漢字表記のみ、句読点。");
+
+        Assert.True(result.Confidence < 0.75);
+        Assert.Contains(result.Candidates, candidate => string.Equals(candidate.Language, "ja", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Candidates, candidate => string.Equals(candidate.Language, "zh", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- treat shared Han punctuation as still ambiguous by aligning zh/ja penalties and removing the zh-only boost
- extend language detector tests with Han-only samples that include shared punctuation and assert both zh and ja candidates remain
- add translation pipeline coverage for the shared punctuation scenario to confirm the low-confidence path exposes both candidates

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db88f54bdc832fbfbdea5edaa5de61