### PR TITLE
Align Han-only shared punctuation tests

### DIFF
--- a/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
+++ b/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
@@ -57,7 +57,7 @@ public class LanguageDetectorTests
     {
         var detector = new LanguageDetector();
 
-        var result = detector.Detect("漢字表記のみ、句読点。");
+        var result = detector.Detect("漢字語彙句読点、標準。");
 
         Assert.True(result.Confidence < 0.75);
         Assert.Contains(result.Candidates, candidate => string.Equals(candidate.Language, "ja", StringComparison.OrdinalIgnoreCase));

--- a/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
@@ -538,7 +538,7 @@ public class TranslationPipelineTests
 
         var result = await pipeline.ExecuteAsync(new TranslationRequest
         {
-            Text = "漢字表記のみ、句読点。",
+            Text = "漢字語彙句読点、標準。",
             TenantId = "contoso",
             UserId = "user",
             TargetLanguage = "en"


### PR DESCRIPTION
## Summary
- update the language detector shared punctuation test to use a kana-free Han sample
- mirror the same input text in the translation pipeline test to keep scenarios aligned

## Testing
- `dotnet test tests/TlaPlugin.Tests` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db8ba0808c832fae2ad76b78feb188