### PR TITLE
Reduce English evidence from shared Latin suffixes

### DIFF
--- a/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
+++ b/tests/TlaPlugin.Tests/LanguageDetectorTests.cs
@@ -74,4 +74,15 @@ public class LanguageDetectorTests
         Assert.True(result.Confidence < 0.75);
         Assert.NotEmpty(result.Candidates);
     }
+
+    [Fact]
+    public void Detect_DiacriticFreeFrenchSentenceRemainsUncertain()
+    {
+        var detector = new LanguageDetector();
+
+        var result = detector.Detect("La nation et la population attendent une solution rapide.");
+
+        Assert.True(result.Confidence < 0.75);
+        Assert.NotEmpty(result.Candidates);
+    }
 }

--- a/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
@@ -381,6 +381,38 @@ public class TranslationPipelineTests
     }
 
     [Fact]
+    public async Task ReturnsLanguageSelectionForDiacriticFreeFrenchSentence()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions>
+            {
+                new() { Id = "primary", Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+
+        var pipeline = BuildPipeline(options);
+
+        var result = await pipeline.ExecuteAsync(new TranslationRequest
+        {
+            Text = "La nation et la population attendent une solution rapide.",
+            TenantId = "contoso",
+            UserId = "user",
+            TargetLanguage = "ja"
+        }, CancellationToken.None);
+
+        Assert.True(result.RequiresLanguageSelection);
+        var detection = Assert.NotNull(result.Detection);
+        Assert.True(detection.Confidence < 0.75);
+        Assert.NotEmpty(detection.Candidates);
+    }
+
+    [Fact]
     public async Task DetectAsync_DiacriticFreeForeignSentenceRemainsUncertain()
     {
         var options = Options.Create(new PluginOptions


### PR DESCRIPTION
## Summary
- limit English morphological evidence to real verb endings and require stopword support before treating it as strong
- keep ambiguous Latin sentences penalized by the detector and add regression tests for accent-free French text in both service and pipeline layers

## Testing
- node --test tests/pipeline.test.js
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db8ad0d468832f9b4ba23342861243