### PR TITLE
Remove duplicate test name in MessageExtensionHandlerTests

### DIFF
--- a/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
+++ b/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
@@ -157,39 +157,6 @@ public class MessageExtensionHandlerTests
     }
 
     [Fact]
-    public async Task ReturnsLocalizedErrorCardWhenLocaleProvided()
-    {
-        var options = Options.Create(new PluginOptions
-        {
-            DailyBudgetUsd = 0.00001m,
-            Providers = new List<ModelProviderOptions>
-            {
-                new() { Id = "primary", CostPerCharUsd = 0.1m, Regions = new List<string>{"japan"}, Certifications = new List<string>{"iso"} }
-            },
-            Compliance = new CompliancePolicyOptions
-            {
-                RequiredRegionTags = new List<string> { "japan" },
-                RequiredCertifications = new List<string> { "iso" }
-            }
-        });
-
-        var handler = BuildHandler(options);
-        var response = await handler.HandleTranslateAsync(new TranslationRequest
-        {
-            Text = new string('a', 200),
-            TenantId = "contoso",
-            UserId = "user",
-            TargetLanguage = "ja",
-            SourceLanguage = "en",
-            UiLocale = "zh-CN"
-        });
-
-        var body = response["attachments"]!.AsArray().First()["content"]!.AsObject();
-        var title = body["body"]!.AsArray().First().AsObject();
-        Assert.Contains("预算", title["text"]!.GetValue<string>());
-    }
-
-    [Fact]
     public async Task ReturnsGlossaryConflictCardWhenResolutionRequired()
     {
         var options = Options.Create(new PluginOptions


### PR DESCRIPTION
## Summary
- remove the duplicated ReturnsLocalizedErrorCardWhenLocaleProvided test so only one definition remains

## Testing
- ⚠️ `dotnet test tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj` *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db8d200f34832fb1d0bdaa4f051a3f