### PR TITLE
Add optional locale to rewrite requests

### DIFF
--- a/src/TlaPlugin/Models/RewriteRequest.cs
+++ b/src/TlaPlugin/Models/RewriteRequest.cs
@@ -13,6 +13,8 @@ public class RewriteRequest
     public string UserId { get; set; } = string.Empty;
     public string? ChannelId { get; set; }
         = null;
+    public string? UiLocale { get; set; }
+        = null;
 }
 
 /// <summary>

--- a/src/TlaPlugin/Services/ReplyService.cs
+++ b/src/TlaPlugin/Services/ReplyService.cs
@@ -58,7 +58,8 @@ public class ReplyService
                 Tone = request.LanguagePolicy.Tone,
                 TenantId = request.TenantId,
                 UserId = request.UserId,
-                ChannelId = request.ChannelId
+                ChannelId = request.ChannelId,
+                UiLocale = request.UiLocale
             }, cancellationToken);
             finalText = rewrite.RewrittenText;
             toneApplied = request.LanguagePolicy.Tone;

--- a/src/TlaPlugin/Services/RewriteService.cs
+++ b/src/TlaPlugin/Services/RewriteService.cs
@@ -48,7 +48,8 @@ public class RewriteService
             Tone = request.Tone,
             TenantId = request.TenantId,
             UserId = request.UserId,
-            ChannelId = request.ChannelId
+            ChannelId = request.ChannelId,
+            UiLocale = request.UiLocale
         };
 
         return await _router.RewriteAsync(normalizedRequest, cancellationToken);


### PR DESCRIPTION
## Summary
- add an optional `UiLocale` field to rewrite requests so callers can supply user locale preferences
- preserve the locale when reply and rewrite services create normalized rewrite requests

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db8d1e3bb4832f879588b88df81edf