### PR TITLE
Persist compose translate metadata

### DIFF
--- a/src/teamsClient/composePlugin.js
+++ b/src/teamsClient/composePlugin.js
@@ -4,7 +4,8 @@ import {
   buildDialogState,
   buildTranslatePayload,
   buildReplyPayload,
-  calculateCostHint
+  calculateCostHint,
+  updateStateWithResponse
 } from "./state.js";
 
 function resolveComposeUi(root = typeof document !== "undefined" ? document : undefined) {
@@ -102,15 +103,15 @@ export async function initComposePlugin({ ui = resolveComposeUi(), teams, fetche
     const payload = buildTranslatePayload({ ...state }, context);
     try {
       const response = await translateText(payload, fetcher);
-      if (response?.metadata?.tone) {
-        state.tone = response.metadata.tone;
-        if (ui.toneToggle) {
-          ui.toneToggle.checked = state.tone === "formal";
-        }
+      const nextState = updateStateWithResponse(state, response);
+      state.translation = nextState.translation;
+      state.modelId = nextState.modelId;
+      state.tone = nextState.tone;
+      state.detectedLanguage = nextState.detectedLanguage;
+      if (ui.toneToggle) {
+        ui.toneToggle.checked = state.tone === "formal";
       }
-      state.detectedLanguage = response?.detectedLanguage ?? state.detectedLanguage;
-      state.translation = response.text ?? "";
-      setPreview(ui.preview, state.translation);
+      setPreview(ui.preview, state.translation ?? "");
     } catch (error) {
       setPreview(ui.preview, `翻译失败：${error.message}`);
     }

--- a/tests/composePlugin.test.js
+++ b/tests/composePlugin.test.js
@@ -83,11 +83,13 @@ test("compose plugin translates and posts reply payload", async () => {
     fetcher: fakeFetch
   });
 
+  assert.equal(state.sourceLanguage, "auto");
   toneToggle.checked = true;
   await toneToggle.trigger("change");
   await suggestButton.trigger("click");
   assert.equal(fetchCalls[0].url, "/api/translate");
   assert.equal(fetchCalls[0].options.text, "hello");
+  assert.equal(state.detectedLanguage, "en");
   await applyButton.trigger("click");
   assert.equal(preview.value || preview.textContent, "hola");
   assert.equal(fetchCalls[1].url, "/api/reply");


### PR DESCRIPTION
## Summary
- merge translate responses into the compose plugin state with updateStateWithResponse so tone, model, and detected language persist
- extend the compose workflow test to assert auto-detected languages are forwarded when replying

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db8cc8a24c832fa0181755fd02cdc6