### PR TITLE
Ensure target language defaults skip auto selection

### DIFF
--- a/src/teamsClient/composePlugin.js
+++ b/src/teamsClient/composePlugin.js
@@ -56,9 +56,15 @@ export async function initComposePlugin({ ui = resolveComposeUi(), teams, fetche
     ui.targetSelect.optionsData = targetLanguages;
   }
 
+  const availableTargetIds = targetLanguages.map((lang) => lang.id);
+  const fallbackTarget = availableTargetIds[0] ?? "";
+  if (!availableTargetIds.includes(state.targetLanguage)) {
+    state.targetLanguage = fallbackTarget;
+  }
+
   if (ui.targetSelect) {
-    if (!targetLanguages.some((lang) => lang.id === state.targetLanguage) && targetLanguages.length) {
-      state.targetLanguage = targetLanguages[0].id;
+    if (!availableTargetIds.includes(ui.targetSelect.value)) {
+      ui.targetSelect.value = fallbackTarget;
     }
     ui.targetSelect.value = state.targetLanguage;
     ui.targetSelect.addEventListener?.("change", (event) => {

--- a/src/teamsClient/messageExtensionDialog.js
+++ b/src/teamsClient/messageExtensionDialog.js
@@ -102,11 +102,9 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
   });
 
   const availableTargetIds = targetLanguages.map((lang) => lang.id);
-  if (!availableTargetIds.includes(state.targetLanguage) && availableTargetIds.length) {
-    state.targetLanguage = availableTargetIds[0];
-    if (ui.targetSelect) {
-      ui.targetSelect.value = state.targetLanguage;
-    }
+  const fallbackTarget = availableTargetIds[0] ?? "";
+  if (!availableTargetIds.includes(state.targetLanguage)) {
+    state.targetLanguage = fallbackTarget;
   }
 
   if (ui.modelSelect) {
@@ -128,6 +126,9 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
     });
   }
   if (ui.targetSelect) {
+    if (!availableTargetIds.includes(ui.targetSelect.value)) {
+      ui.targetSelect.value = fallbackTarget;
+    }
     ui.targetSelect.value = state.targetLanguage;
     ui.targetSelect.addEventListener?.("change", (event) => {
       state.targetLanguage = event.target.value;

--- a/src/teamsClient/settingsTab.js
+++ b/src/teamsClient/settingsTab.js
@@ -51,6 +51,11 @@ function renderDefaultLanguage(select, languages, state) {
     return;
   }
   const candidates = languages.filter((lang) => lang.id !== "auto");
+  const candidateIds = candidates.map((lang) => lang.id);
+  const fallbackTarget = candidateIds[0] ?? "";
+  if (!candidateIds.includes(state.targetLanguage)) {
+    state.targetLanguage = fallbackTarget;
+  }
   if (typeof select.replaceChildren === "function" && typeof document !== "undefined") {
     const options = candidates.map((lang) => {
       const option = document.createElement("option");
@@ -61,6 +66,9 @@ function renderDefaultLanguage(select, languages, state) {
     select.replaceChildren(...options);
   } else {
     select.optionsData = candidates;
+  }
+  if (!candidateIds.includes(select.value)) {
+    select.value = fallbackTarget;
   }
   select.value = state.targetLanguage;
   select.addEventListener?.("change", (event) => {

--- a/src/teamsClient/state.js
+++ b/src/teamsClient/state.js
@@ -1,29 +1,33 @@
 import { FALLBACK_METADATA } from "./api.js";
 
+function isSelectableLanguage(language) {
+  return Boolean(language?.id) && language.id !== "auto";
+}
+
 function resolveDefaultTargetLanguage(languages = [], locale = "") {
   if (!Array.isArray(languages) || languages.length === 0) {
     return "en";
   }
   const exactLocale = languages.find((lang) => lang.id === locale);
-  if (exactLocale) {
+  if (isSelectableLanguage(exactLocale)) {
     return exactLocale.id;
   }
   const normalized = locale?.split?.("-")?.[0];
   if (normalized) {
     const match = languages.find((lang) => lang.id === normalized);
-    if (match) {
+    if (isSelectableLanguage(match)) {
       return match.id;
     }
   }
-  const defaultLocale = languages.find((lang) => lang.isDefault && lang.id !== "auto");
+  const defaultLocale = languages.find((lang) => lang.isDefault && isSelectableLanguage(lang));
   if (defaultLocale) {
     return defaultLocale.id;
   }
-  const firstNonAuto = languages.find((lang) => lang.id !== "auto");
-  if (firstNonAuto) {
-    return firstNonAuto.id;
+  const firstSelectable = languages.find((lang) => isSelectableLanguage(lang));
+  if (firstSelectable) {
+    return firstSelectable.id;
   }
-  return languages[0].id;
+  return languages[0]?.id ?? "en";
 }
 
 export function buildDialogState({ models, languages, context } = {}) {

--- a/src/webapp/composePlugin.js
+++ b/src/webapp/composePlugin.js
@@ -49,14 +49,12 @@ export async function initComposePlugin({ ui = resolveComposeUi(), teams, fetche
   }
 
   const availableTargetIds = targetLanguages.map((lang) => lang.id);
+  const fallbackTarget = availableTargetIds[0] ?? "";
   if (!availableTargetIds.includes(state.targetLanguage)) {
-    state.targetLanguage = availableTargetIds[0] ?? "";
+    state.targetLanguage = fallbackTarget;
   }
 
   if (ui.targetSelect) {
-    if (!availableTargetIds.includes(ui.targetSelect.value)) {
-      ui.targetSelect.value = availableTargetIds[0] ?? "";
-    }
     ui.targetSelect.value = state.targetLanguage;
     ui.targetSelect.addEventListener?.("change", (event) => {
       state.targetLanguage = event.target.value;

--- a/src/webapp/dialog.js
+++ b/src/webapp/dialog.js
@@ -76,8 +76,9 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
   });
 
   const availableTargetIds = targetLanguages.map((lang) => lang.id);
+  const fallbackTarget = availableTargetIds[0] ?? "";
   if (!availableTargetIds.includes(state.targetLanguage)) {
-    state.targetLanguage = availableTargetIds[0] ?? "";
+    state.targetLanguage = fallbackTarget;
   }
 
   if (ui.modelSelect) {
@@ -94,9 +95,6 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
     });
   }
   if (ui.targetSelect) {
-    if (!availableTargetIds.includes(ui.targetSelect.value)) {
-      ui.targetSelect.value = availableTargetIds[0] ?? "";
-    }
     ui.targetSelect.value = state.targetLanguage;
     ui.targetSelect.addEventListener?.("change", (event) => {
       state.targetLanguage = event.target.value;

--- a/src/webapp/dialogState.js
+++ b/src/webapp/dialogState.js
@@ -23,15 +23,15 @@ function resolveDefaultTargetLanguage(languages = [], locale = "") {
       return match.id;
     }
   }
-  const defaultLocale = languages.find((lang) => lang.isDefault && lang.id !== "auto");
+  const defaultLocale = languages.find((lang) => lang.isDefault && isSelectableLanguage(lang));
   if (defaultLocale) {
     return defaultLocale.id;
   }
-  const firstNonAuto = languages.find((lang) => lang.id !== "auto");
-  if (firstNonAuto) {
-    return firstNonAuto.id;
+  const firstSelectable = languages.find((lang) => isSelectableLanguage(lang));
+  if (firstSelectable) {
+    return firstSelectable.id;
   }
-  return languages[0].id;
+  return languages[0]?.id ?? "en";
 }
 
 export function buildDialogState({ models, languages, context } = {}) {


### PR DESCRIPTION
## Summary
- prevent "auto" from being selected as the default translation target when metadata lacks locale matches
- keep dialog, compose plugin, and settings target pickers aligned with available options
- extend dialog, compose, and settings tests to cover locale-less metadata and assert concrete target languages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db8f524af0832fabcb90b5e9a038fe