### PR TITLE
Persist translate metadata in compose workflow

### DIFF
--- a/src/teamsClient/composePlugin.js
+++ b/src/teamsClient/composePlugin.js
@@ -110,10 +110,7 @@ export async function initComposePlugin({ ui = resolveComposeUi(), teams, fetche
     try {
       const response = await translateText(payload, fetcher);
       const nextState = updateStateWithResponse(state, response);
-      state.translation = nextState.translation;
-      state.modelId = nextState.modelId;
-      state.tone = nextState.tone;
-      state.detectedLanguage = nextState.detectedLanguage;
+      Object.assign(state, nextState);
       if (ui.toneToggle) {
         ui.toneToggle.checked = state.tone === "formal";
       }

--- a/tests/composePlugin.test.js
+++ b/tests/composePlugin.test.js
@@ -95,6 +95,8 @@ test("compose plugin translates and posts reply payload", async () => {
   assert.equal(fetchCalls[1].url, "/api/reply");
   assert.equal(fetchCalls[1].options.translation, "hola");
   assert.equal(fetchCalls[1].options.sourceLanguage, "en");
+  assert.equal(fetchCalls[1].options.sourceLanguage, state.detectedLanguage);
+  assert.equal(fetchCalls[1].options.metadata.modelId, "model-a");
   assert.equal(fetchCalls[1].options.metadata.tone, "formal");
   assert.equal(state.tone, "formal");
 });


### PR DESCRIPTION
## Summary
- merge translate responses into the compose plugin state so tone, detected language, and model metadata persist
- extend the compose workflow test to assert detected languages are forwarded with the reply payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db9b214250832f86fc58008e159447