### PR TITLE
Expose glossary conflict resolution details

### DIFF
--- a/src/TlaPlugin/Models/GlossaryDecision.cs
+++ b/src/TlaPlugin/Models/GlossaryDecision.cs
@@ -84,7 +84,22 @@ public class GlossaryApplicationResult
     public string Text { get; set; } = string.Empty;
     public IReadOnlyList<GlossaryMatchDetail> Matches { get; set; } = Array.Empty<GlossaryMatchDetail>();
 
+    public string ProcessedText
+    {
+        get => Text;
+        set => Text = value ?? string.Empty;
+    }
+
     public bool HasConflicts => Matches.Any(match => match.HasConflict);
 
     public bool RequiresResolution => Matches.Any(match => match.HasConflict && match.Resolution == GlossaryDecisionKind.Unspecified);
+
+    public GlossaryApplicationResult Clone()
+    {
+        return new GlossaryApplicationResult
+        {
+            Text = Text,
+            Matches = Matches.Select(match => match.Clone()).ToList()
+        };
+    }
 }

--- a/src/TlaPlugin/Models/GlossaryPolicy.cs
+++ b/src/TlaPlugin/Models/GlossaryPolicy.cs
@@ -8,13 +8,3 @@ public enum GlossaryPolicy
     Strict,
     Fallback
 }
-
-/// <summary>
-/// 表示术语匹配结果。
-/// </summary>
-public record GlossaryMatch(string Term, string Translation, string Scope, int Count);
-
-/// <summary>
-/// 表示术语应用后的结果。
-/// </summary>
-public record GlossaryApplicationResult(string ProcessedText, IReadOnlyList<GlossaryMatch> Matches);

--- a/src/TlaPlugin/Services/GlossaryConflictException.cs
+++ b/src/TlaPlugin/Services/GlossaryConflictException.cs
@@ -13,11 +13,7 @@ public class GlossaryConflictException : TranslationException
     public GlossaryConflictException(GlossaryApplicationResult result, TranslationRequest request)
         : base("Glossary conflicts require resolution.")
     {
-        Result = new GlossaryApplicationResult
-        {
-            Text = result.Text,
-            Matches = result.Matches.Select(match => match.Clone()).ToList()
-        };
+        Result = result.Clone();
 
         Request = new TranslationRequest
         {

--- a/tests/TlaPlugin.Tests/ApiEndpointsTests.cs
+++ b/tests/TlaPlugin.Tests/ApiEndpointsTests.cs
@@ -138,6 +138,6 @@ public class ApiEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
     private sealed class GlossaryResponse
     {
         public string ProcessedText { get; set; } = string.Empty;
-        public List<GlossaryMatch> Matches { get; set; } = new();
+        public List<GlossaryMatchDetail> Matches { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- enhance the glossary service to surface conflict metadata, scope priorities, and respect user decisions before applying replacements
- update the glossary conflict exception and API surface to work with the richer match details
- expand unit tests to cover priority ordering, conflict prompts, and decision-driven outcomes

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dba80436e8832f94aab78c5a1cef0f