### PR TITLE
Add Jest and Playwright coverage for Teams dialog flows

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  testMatch: ["**/tests/**/*.jest.js"],
+  testEnvironment: "jsdom",
+  transform: {},
+  extensionsToTreatAsEsm: [".js"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1.js"
+  },
+  testEnvironmentOptions: {
+    customExportConditions: ["node", "node-addons"]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "test:jest": "jest --config jest.config.cjs",
+    "test:playwright": "playwright test"
   },
   "keywords": [
     "teams",
@@ -16,5 +18,11 @@
   ],
   "author": "",
   "license": "MIT",
-  "type": "module"
+  "type": "module",
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@playwright/test": "^1.44.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
+  }
 }

--- a/tests/messageExtensionDialog.jest.js
+++ b/tests/messageExtensionDialog.jest.js
@@ -1,0 +1,165 @@
+import { describe, test, expect, beforeEach, jest } from "@jest/globals";
+import { initMessageExtensionDialog } from "../src/teamsClient/messageExtensionDialog.js";
+
+function createDialogDom() {
+  document.body.innerHTML = `
+    <main data-dialog-root>
+      <select data-model-select></select>
+      <select data-source-select></select>
+      <p data-detected-language></p>
+      <select data-target-select></select>
+      <label><input type="checkbox" data-terminology-toggle /></label>
+      <label><input type="checkbox" data-tone-toggle /></label>
+      <p data-cost-hint></p>
+      <textarea data-source-text></textarea>
+      <textarea data-translation-text></textarea>
+      <button data-preview-translation></button>
+      <button data-submit-translation></button>
+      <p data-error-banner></p>
+    </main>
+  `;
+}
+
+describe("message extension dialog (jest)", () => {
+  let teams;
+  let fetchCalls;
+  let fakeFetch;
+
+  beforeEach(() => {
+    createDialogDom();
+    fetchCalls = [];
+    fakeFetch = jest.fn(async (url, options = {}) => {
+      const bodyText = options.body;
+      if (bodyText) {
+        fetchCalls.push({ url, body: JSON.parse(bodyText) });
+      } else {
+        fetchCalls.push({ url });
+      }
+      if (url === "/api/metadata") {
+        return {
+          ok: true,
+          async json() {
+            return {
+              models: [{ id: "model-a", displayName: "Model A", costPerCharUsd: 0.00002 }],
+              languages: [
+                { id: "auto", name: "Auto", isDefault: true },
+                { id: "es", name: "Español" },
+                { id: "ja", name: "日本語" }
+              ],
+              features: { terminologyToggle: true, toneToggle: true },
+              pricing: { currency: "USD" }
+            };
+          }
+        };
+      }
+      if (url === "/api/detect") {
+        return {
+          ok: true,
+          async json() {
+            return { language: "en", confidence: 0.92 };
+          }
+        };
+      }
+      if (url === "/api/translate") {
+        return {
+          ok: true,
+          async json() {
+            return {
+              text: fetchCalls.at(-1).body.targetLanguage === "ja" ? "こんにちは" : "hola",
+              detectedLanguage: "en",
+              metadata: { modelId: "model-a", tone: "formal" }
+            };
+          }
+        };
+      }
+      if (url === "/api/rewrite") {
+        return {
+          ok: true,
+          async json() {
+            return { text: `【润色】${fetchCalls.at(-1).body.text}`, metadata: { tone: "formal" } };
+          }
+        };
+      }
+      if (url === "/api/reply") {
+        return {
+          ok: true,
+          async json() {
+            return { status: "ok", card: { type: "AdaptiveCard", body: [] } };
+          }
+        };
+      }
+      throw new Error(`Unexpected url ${url}`);
+    });
+    teams = {
+      dialog: {
+        submit: jest.fn((payload) => {
+          teams.dialog.lastSubmit = payload;
+        })
+      },
+      app: {
+        initialize: jest.fn(async () => undefined),
+        getContext: jest.fn(async () => ({
+          tenant: { id: "tenant" },
+          user: { id: "user" },
+          channel: { id: "channel" },
+          app: { locale: "en-US" }
+        }))
+      }
+    };
+  });
+
+  async function flushPromises() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  test("allows switching languages and previews translation", async () => {
+    const { state } = await initMessageExtensionDialog({ teams, fetcher: fakeFetch });
+    const input = document.querySelector("[data-source-text]");
+    const target = document.querySelector("[data-target-select]");
+    const preview = document.querySelector("[data-preview-translation]");
+    const translation = document.querySelector("[data-translation-text]");
+
+    expect(state.targetLanguage).toBe("es");
+    target.value = "ja";
+    target.dispatchEvent(new Event("change"));
+    input.value = "hello";
+    input.dispatchEvent(new Event("input"));
+    await flushPromises();
+    preview.dispatchEvent(new Event("click"));
+    await flushPromises();
+
+    expect(fetchCalls.find((call) => call.url === "/api/detect")).toBeTruthy();
+    const translateCall = fetchCalls.find((call) => call.url === "/api/translate" && call.body.text === "hello");
+    expect(translateCall.body.targetLanguage).toBe("ja");
+    expect(translation.value).toBe("こんにちは");
+    const detectedLabel = document.querySelector("[data-detected-language]");
+    expect(detectedLabel.textContent).toContain("en");
+    expect(state.targetLanguage).toBe("ja");
+  });
+
+  test("submits edited translation with rewrite and reply", async () => {
+    await initMessageExtensionDialog({ teams, fetcher: fakeFetch });
+    const input = document.querySelector("[data-source-text]");
+    const preview = document.querySelector("[data-preview-translation]");
+    const translation = document.querySelector("[data-translation-text]");
+    const submit = document.querySelector("[data-submit-translation]");
+
+    input.value = "good morning";
+    input.dispatchEvent(new Event("input"));
+    await flushPromises();
+    preview.dispatchEvent(new Event("click"));
+    await flushPromises();
+
+    translation.value = "hola";
+    submit.dispatchEvent(new Event("click"));
+    await flushPromises();
+
+    const rewriteCall = fetchCalls.find((call) => call.url === "/api/rewrite");
+    const replyCall = fetchCalls.find((call) => call.url === "/api/reply");
+    expect(rewriteCall.body.text).toBe("hola");
+    expect(replyCall.body.translation).toBe("【润色】hola");
+    expect(teams.dialog.submit).toHaveBeenCalled();
+    expect(teams.dialog.lastSubmit.translation).toBe("【润色】hola");
+    expect(translation.value).toBe("【润色】hola");
+  });
+});

--- a/tests/playwright/dialog.spec.js
+++ b/tests/playwright/dialog.spec.js
@@ -1,0 +1,165 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../..");
+const srcRoot = path.join(repoRoot, "src");
+
+function readFileFromSrc(relativePath) {
+  const absolute = path.join(srcRoot, relativePath);
+  const normalized = path.normalize(absolute);
+  if (!normalized.startsWith(srcRoot)) {
+    throw new Error(`Attempted to read outside src: ${relativePath}`);
+  }
+  return readFileSync(normalized, "utf8");
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.route("http://local.test/**", async (route) => {
+    const url = new URL(route.request().url());
+    const relative = url.pathname.replace(/^\//, "");
+    const target = path.join(srcRoot, relative);
+    const normalized = path.normalize(target);
+    if (normalized.startsWith(srcRoot)) {
+      const body = readFileSync(normalized);
+      const contentType = normalized.endsWith(".css") ? "text/css" : "text/javascript";
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": contentType },
+        body
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  const metadata = {
+    models: [{ id: "model-a", displayName: "Model A", costPerCharUsd: 0.00002 }],
+    languages: [
+      { id: "auto", name: "Auto", isDefault: true },
+      { id: "es", name: "Español" },
+      { id: "ja", name: "日本語" }
+    ],
+    features: { terminologyToggle: true, toneToggle: true },
+    pricing: { currency: "USD" }
+  };
+
+  await page.route("**/api/metadata", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(metadata)
+    });
+  });
+
+  await page.route("**/api/detect", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ language: "en", confidence: 0.88 })
+    });
+  });
+
+  await page.route("**/api/translate", async (route) => {
+    const payload = JSON.parse(route.request().postData() ?? "{}");
+    const text = payload.targetLanguage === "ja" ? "こんにちは" : "hola";
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        text,
+        detectedLanguage: "en",
+        metadata: { modelId: "model-a", tone: payload.targetLanguage === "ja" ? "formal" : "neutral" }
+      })
+    });
+  });
+
+  await page.route("**/api/rewrite", async (route) => {
+    const payload = JSON.parse(route.request().postData() ?? "{}");
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: `【润色】${payload.text ?? ""}`, metadata: { tone: "formal" } })
+    });
+  });
+
+  await page.route("**/api/reply", async (route) => {
+    const payload = JSON.parse(route.request().postData() ?? "{}");
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: "ok", echo: payload, card: { type: "AdaptiveCard", body: [] } })
+    });
+  });
+
+  await page.addInitScript(() => {
+    window.microsoftTeams = {
+      dialog: {
+        submit(payload) {
+          window.microsoftTeams.dialog.lastSubmit = payload;
+        }
+      },
+      app: {
+        async initialize() {
+          return undefined;
+        },
+        async getContext() {
+          return {
+            tenant: { id: "tenant" },
+            user: { id: "user" },
+            channel: { id: "channel" },
+            app: { locale: "en-US" }
+          };
+        }
+      }
+    };
+  });
+
+  const html = readFileFromSrc("webapp/dialog.html");
+  const sanitized = html.replace('<script type="module" src="./dialog.js"></script>', "");
+  const injection = `
+    <script type="module">
+      import { initMessageExtensionDialog } from "http://local.test/teamsClient/messageExtensionDialog.js";
+      window.__initDialog = initMessageExtensionDialog;
+    </script>
+  `;
+  const patched = sanitized.replace("</body>", `${injection}</body>`);
+  await page.setContent(patched, { waitUntil: "load" });
+  await page.evaluate(() => window.__initDialog());
+});
+
+test("switching language updates translate payload", async ({ page }) => {
+  const sourceInput = page.locator("[data-source-text]");
+  const previewButton = page.locator("[data-preview-translation]");
+  const translationInput = page.locator("[data-translation-text]");
+  const targetSelect = page.locator("[data-target-select]");
+
+  await sourceInput.fill("hello world");
+  await previewButton.click();
+  await expect(translationInput).toHaveValue("hola");
+  await targetSelect.selectOption("ja");
+  await sourceInput.fill("good night");
+  await previewButton.click();
+  await expect(translationInput).toHaveValue("こんにちは");
+  const detected = await page.locator("[data-detected-language]").innerText();
+  expect(detected).toContain("en");
+});
+
+test("edited translation is rewritten before reply", async ({ page }) => {
+  const sourceInput = page.locator("[data-source-text]");
+  const previewButton = page.locator("[data-preview-translation]");
+  const translationInput = page.locator("[data-translation-text]");
+  const submitButton = page.locator("[data-submit-translation]");
+
+  await sourceInput.fill("hello there");
+  await previewButton.click();
+  await translationInput.fill("hola team");
+  await submitButton.click();
+  await expect(translationInput).toHaveValue("【润色】hola team");
+  const lastSubmit = await page.evaluate(() => window.microsoftTeams.dialog.lastSubmit);
+  expect(lastSubmit.translation).toBe("【润色】hola team");
+  expect(lastSubmit.replyStatus).toBe("ok");
+  expect(lastSubmit.tone).toBe("formal");
+});


### PR DESCRIPTION
## Summary
- add Jest and Playwright scripts and dependencies for the Teams client workspace
- implement jsdom-based Jest tests covering language switching and edited replies in the message extension dialog
- add Playwright specs that exercise dialog language selection and submission flows against the real HTML

## Testing
- npm test
- npm run test:jest *(fails: jest executable is not available in the environment)*
- npm run test:playwright *(fails: playwright executable is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb3270080832fa953bb3b506cdcd0