### PR TITLE
Add glossary conflict preview workflow

### DIFF
--- a/src/TlaPlugin/Services/TranslationPipeline.cs
+++ b/src/TlaPlugin/Services/TranslationPipeline.cs
@@ -75,7 +75,13 @@ public class TranslationPipeline
     {
         ValidateTranslationRequest(request);
 
-        var glossaryResult = ResolveGlossary(request);
+        var preview = PreviewGlossary(request);
+        if (preview.RequiresResolution)
+        {
+            return PipelineExecutionResult.FromGlossaryConflict(preview, request);
+        }
+
+        var glossaryResult = ApplyGlossary(request);
         var matchSnapshots = glossaryResult.Matches.Select(match => match.Clone()).ToList();
         var normalizedRequest = NormalizeRequestForTranslation(request, glossaryResult.Text);
 
@@ -108,7 +114,7 @@ public class TranslationPipeline
         }
     }
 
-    private GlossaryApplicationResult ResolveGlossary(TranslationRequest request)
+    private GlossaryApplicationResult PreviewGlossary(TranslationRequest request)
     {
         if (!request.UseGlossary)
         {
@@ -119,13 +125,33 @@ public class TranslationPipeline
             };
         }
 
-        var result = _glossary.Apply(request.Text, request.TenantId, request.ChannelId, request.UserId, request.GlossaryDecisions);
-        if (result.RequiresResolution)
+        return _glossary.Preview(
+            request.Text,
+            request.TenantId,
+            request.ChannelId,
+            request.UserId,
+            GlossaryPolicy.Fallback,
+            null,
+            request.GlossaryDecisions);
+    }
+
+    private GlossaryApplicationResult ApplyGlossary(TranslationRequest request)
+    {
+        if (!request.UseGlossary)
         {
-            throw new GlossaryConflictException(result, request);
+            return new GlossaryApplicationResult
+            {
+                Text = request.Text,
+                Matches = Array.Empty<GlossaryMatchDetail>()
+            };
         }
 
-        return result;
+        return _glossary.Apply(
+            request.Text,
+            request.TenantId,
+            request.ChannelId,
+            request.UserId,
+            request.GlossaryDecisions);
     }
 
     private TranslationRequest NormalizeRequestForTranslation(TranslationRequest request, string resolvedText)

--- a/tests/TlaPlugin.Tests/GlossaryServiceTests.cs
+++ b/tests/TlaPlugin.Tests/GlossaryServiceTests.cs
@@ -9,7 +9,7 @@ namespace TlaPlugin.Tests;
 public class GlossaryServiceTests
 {
     [Fact]
-    public void Apply_DetectsConflict_AndHonorsAlternativeSelection()
+    public void Preview_DetectsConflict_AndHonorsAlternativeSelection()
     {
         var service = new GlossaryService();
         service.LoadEntries(new[]
@@ -18,15 +18,18 @@ public class GlossaryServiceTests
             new GlossaryEntry("GPU", "显卡", "channel:finance")
         });
 
-        var unresolved = service.Apply("GPU 加速", "contoso", "finance", "user");
+        var unresolved = service.Preview("GPU 加速", "contoso", "finance", "user");
 
         Assert.True(unresolved.HasConflicts);
         Assert.True(unresolved.RequiresResolution);
+        Assert.Equal("GPU 加速", unresolved.Text);
         var conflict = Assert.Single(unresolved.Matches);
         Assert.True(conflict.HasConflict);
         Assert.Equal(GlossaryDecisionKind.Unspecified, conflict.Resolution);
         Assert.Equal(2, conflict.Candidates.Count);
         Assert.False(conflict.Replaced);
+        Assert.Equal(0, conflict.Candidates[0].Priority);
+        Assert.Equal(1, conflict.Candidates[1].Priority);
 
         var decisions = new Dictionary<string, GlossaryDecision>(StringComparer.OrdinalIgnoreCase)
         {
@@ -86,10 +89,11 @@ public class GlossaryServiceTests
             new GlossaryEntry("CPU", "自定义翻译", "user:owner")
         });
 
-        var result = service.Apply("CPU upgrade", "contoso", "finance", "owner");
+        var result = service.Preview("CPU upgrade", "contoso", "finance", "owner");
 
         Assert.True(result.HasConflicts);
         Assert.True(result.RequiresResolution);
+        Assert.Equal("CPU upgrade", result.Text);
         var match = Assert.Single(result.Matches);
         Assert.Equal("CPU", match.Source);
         Assert.True(match.HasConflict);


### PR DESCRIPTION
## Summary
- add a glossary preview API so callers can inspect conflicts and priorities before applying replacements
- surface unresolved glossary conflicts in the translation pipeline and Teams message extension to trigger the client-side resolution flow
- extend unit tests to cover conflict prompting, priority ordering, and applying user selections in the resulting translation

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbb31f6778832fba496454617af20b