### PR TITLE
Expand glossary conflict options

### DIFF
--- a/src/TlaPlugin/Teams/MessageExtensionHandler.cs
+++ b/src/TlaPlugin/Teams/MessageExtensionHandler.cs
@@ -377,9 +377,8 @@ public class MessageExtensionHandler
                 }
             };
 
-            if (ordered.Count > 1)
+            foreach (var alternate in ordered.Skip(1))
             {
-                var alternate = ordered.Skip(1).First();
                 choices.Add(new JsonObject
                 {
                     ["title"] = string.Format(CultureInfo.InvariantCulture, Resolve(catalog, "tla.ui.glossary.option.alternative"), alternate.Target, alternate.Scope),


### PR DESCRIPTION
## Summary
- update glossary conflict card to include all alternative candidates as separate options
- add a regression test verifying that user, channel, and tenant choices are rendered alongside keeping the original term

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc9504174832f82d58f634140c49a