### PR TITLE
Add MCP server endpoints

### DIFF
--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using System.Security.Authentication;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using TlaPlugin.Configuration;
 using TlaPlugin.Models;
 using TlaPlugin.Services;
@@ -53,10 +54,23 @@ builder.Services.AddSingleton<DevelopmentRoadmapService>();
 builder.Services.AddSingleton<ReplyService>();
 builder.Services.AddSingleton<RewriteService>();
 builder.Services.AddSingleton<CostEstimatorService>();
+builder.Services.AddSingleton<McpToolRegistry>();
+builder.Services.AddSingleton<McpServer>();
 
 var app = builder.Build();
 
 var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+static bool TryAuthorize(HttpRequest request, out IResult? unauthorized)
+{
+    if (!request.Headers.TryGetValue("Authorization", out var header) || string.IsNullOrWhiteSpace(header))
+    {
+        unauthorized = Results.Unauthorized();
+        return false;
+    }
+
+    unauthorized = null;
+    return true;
+}
 
 app.MapPost("/api/translate", async (TranslationRequest request, MessageExtensionHandler handler) =>
 {
@@ -128,6 +142,91 @@ app.MapPost("/api/apply-glossary", (GlossaryApplicationRequest request, Glossary
     catch (GlossaryApplicationException ex)
     {
         return Results.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+    }
+});
+
+app.MapGet("/mcp/tools/list", (HttpRequest request, McpServer server) =>
+{
+    if (!TryAuthorize(request, out var unauthorized))
+    {
+        return unauthorized!;
+    }
+
+    var tools = server.ListTools();
+    return Results.Json(new { tools }, options: jsonOptions);
+});
+
+app.MapPost("/mcp/tools/call", async (HttpRequest request, McpServer server, CancellationToken cancellationToken) =>
+{
+    if (!TryAuthorize(request, out var unauthorized))
+    {
+        return unauthorized!;
+    }
+
+    JsonObject arguments;
+    string? toolName;
+    try
+    {
+        using var document = await JsonDocument.ParseAsync(request.Body, cancellationToken: cancellationToken);
+        var root = document.RootElement;
+        if (!root.TryGetProperty("name", out var nameProperty) || nameProperty.ValueKind != JsonValueKind.String)
+        {
+            return Results.BadRequest(new { error = "name is required." });
+        }
+
+        toolName = nameProperty.GetString();
+        if (string.IsNullOrWhiteSpace(toolName))
+        {
+            return Results.BadRequest(new { error = "name is required." });
+        }
+
+        if (root.TryGetProperty("arguments", out var argumentsProperty))
+        {
+            var parsed = JsonNode.Parse(argumentsProperty.GetRawText());
+            arguments = parsed as JsonObject ?? new JsonObject();
+        }
+        else
+        {
+            arguments = new JsonObject();
+        }
+    }
+    catch (JsonException)
+    {
+        return Results.BadRequest(new { error = "Invalid JSON payload." });
+    }
+
+    try
+    {
+        var result = await server.CallToolAsync(toolName!, arguments, cancellationToken);
+        return Results.Json(new { result }, options: jsonOptions);
+    }
+    catch (McpValidationException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+    catch (GlossaryApplicationException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+    }
+    catch (ReplyAuthorizationException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status403Forbidden);
+    }
+    catch (BudgetExceededException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status402PaymentRequired);
+    }
+    catch (AuthenticationException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status401Unauthorized);
+    }
+    catch (TranslationException ex)
+    {
+        return Results.Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+    }
+    catch (KeyNotFoundException)
+    {
+        return Results.NotFound(new { error = "Tool not found." });
     }
 });
 

--- a/src/TlaPlugin/Services/McpServer.cs
+++ b/src/TlaPlugin/Services/McpServer.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using TlaPlugin.Models;
+using TlaPlugin.Teams;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// Handles Model Context Protocol tool discovery and invocation.
+/// </summary>
+public class McpServer
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly McpToolRegistry _registry;
+    private readonly MessageExtensionHandler _messageExtension;
+    private readonly TranslationPipeline _pipeline;
+    private readonly GlossaryService _glossary;
+    private readonly ReplyService _replyService;
+
+    public McpServer(
+        McpToolRegistry registry,
+        MessageExtensionHandler messageExtension,
+        TranslationPipeline pipeline,
+        GlossaryService glossary,
+        ReplyService replyService)
+    {
+        _registry = registry;
+        _messageExtension = messageExtension;
+        _pipeline = pipeline;
+        _glossary = glossary;
+        _replyService = replyService;
+    }
+
+    public IReadOnlyCollection<McpToolDefinition> ListTools()
+    {
+        return _registry.ListTools();
+    }
+
+    public async Task<JsonNode> CallToolAsync(string name, JsonObject arguments, CancellationToken cancellationToken)
+    {
+        if (!_registry.TryGetDefinition(name, out var definition))
+        {
+            throw new KeyNotFoundException($"Tool '{name}' was not found.");
+        }
+
+        ValidateArguments(definition, arguments);
+
+        return name switch
+        {
+            "tla.translate" => await InvokeTranslateAsync(arguments, cancellationToken),
+            "tla.detectLanguage" => await InvokeDetectAsync(arguments, cancellationToken),
+            "tla.applyGlossary" => InvokeGlossary(arguments),
+            "tla.replyInThread" => await InvokeReplyAsync(arguments, cancellationToken),
+            _ => throw new KeyNotFoundException($"Tool '{name}' was not found.")
+        };
+    }
+
+    private static void ValidateArguments(McpToolDefinition definition, JsonObject arguments)
+    {
+        foreach (var required in definition.RequiredProperties)
+        {
+            if (!arguments.TryGetPropertyValue(required, out var value) || value is null)
+            {
+                throw new McpValidationException($"Missing required property '{required}'.");
+            }
+
+            if (value is JsonValue jsonValue)
+            {
+                if (jsonValue.TryGetValue<string?>(out var text))
+                {
+                    if (string.IsNullOrWhiteSpace(text))
+                    {
+                        throw new McpValidationException($"Property '{required}' must be a non-empty string.");
+                    }
+                }
+            }
+        }
+    }
+
+    private async Task<JsonNode> InvokeTranslateAsync(JsonObject arguments, CancellationToken cancellationToken)
+    {
+        var request = arguments.Deserialize<TranslationRequest>(SerializerOptions)
+            ?? throw new McpValidationException("Invalid translation payload.");
+
+        var response = await _messageExtension.HandleTranslateAsync(request);
+        return response;
+    }
+
+    private async Task<JsonNode> InvokeDetectAsync(JsonObject arguments, CancellationToken cancellationToken)
+    {
+        var request = arguments.Deserialize<LanguageDetectionRequest>(SerializerOptions)
+            ?? throw new McpValidationException("Invalid detection payload.");
+
+        var detection = await _pipeline.DetectAsync(request, cancellationToken);
+        return JsonSerializer.SerializeToNode(detection, SerializerOptions)
+            ?? throw new InvalidOperationException("Failed to serialize detection result.");
+    }
+
+    private JsonNode InvokeGlossary(JsonObject arguments)
+    {
+        var request = arguments.Deserialize<GlossaryApplicationRequest>(SerializerOptions)
+            ?? throw new McpValidationException("Invalid glossary payload.");
+
+        var policy = Enum.TryParse<GlossaryPolicy>(request.Policy, true, out var parsed)
+            ? parsed
+            : GlossaryPolicy.Fallback;
+
+        var result = _glossary.ApplyDetailed(
+            request.Text,
+            request.TenantId,
+            request.ChannelId,
+            request.UserId,
+            policy,
+            request.GlossaryIds);
+
+        return JsonSerializer.SerializeToNode(new
+        {
+            processedText = result.ProcessedText,
+            matches = result.Matches
+        }, SerializerOptions) ?? throw new InvalidOperationException("Failed to serialize glossary result.");
+    }
+
+    private async Task<JsonNode> InvokeReplyAsync(JsonObject arguments, CancellationToken cancellationToken)
+    {
+        var request = arguments.Deserialize<ReplyRequest>(SerializerOptions)
+            ?? throw new McpValidationException("Invalid reply payload.");
+
+        var result = await _replyService.SendReplyAsync(request, cancellationToken);
+        return JsonSerializer.SerializeToNode(result, SerializerOptions)
+            ?? throw new InvalidOperationException("Failed to serialize reply result.");
+    }
+}
+
+public class McpValidationException : Exception
+{
+    public McpValidationException(string message) : base(message)
+    {
+    }
+}

--- a/src/TlaPlugin/Services/McpToolRegistry.cs
+++ b/src/TlaPlugin/Services/McpToolRegistry.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// Stores MCP tool metadata and exposes schema definitions for discovery.
+/// </summary>
+public class McpToolRegistry
+{
+    private readonly IReadOnlyDictionary<string, McpToolDefinition> _definitions;
+
+    public McpToolRegistry()
+    {
+        _definitions = CreateDefinitions();
+    }
+
+    public IReadOnlyCollection<McpToolDefinition> ListTools() => _definitions.Values;
+
+    public bool TryGetDefinition(string name, out McpToolDefinition definition)
+    {
+        return _definitions.TryGetValue(name, out definition!);
+    }
+
+    private static IReadOnlyDictionary<string, McpToolDefinition> CreateDefinitions()
+    {
+        var definitions = new[]
+        {
+            new McpToolDefinition(
+                "tla.translate",
+                "Translate text into the specified target language while applying configured glossary policies.",
+                CreateTranslationSchema(),
+                new[] { "text", "targetLanguage", "tenantId", "userId" }),
+            new McpToolDefinition(
+                "tla.detectLanguage",
+                "Detect the language of supplied text for a tenant.",
+                CreateDetectionSchema(),
+                new[] { "text", "tenantId" }),
+            new McpToolDefinition(
+                "tla.applyGlossary",
+                "Apply glossary substitutions and return the matches for auditing.",
+                CreateGlossarySchema(),
+                new[] { "text", "tenantId", "userId" }),
+            new McpToolDefinition(
+                "tla.replyInThread",
+                "Post a reply in an existing thread applying tone or glossary policies as needed.",
+                CreateReplySchema(),
+                new[] { "threadId", "replyText", "tenantId", "userId" })
+        };
+
+        return definitions.ToDictionary(definition => definition.Name, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static JsonObject CreateTranslationSchema()
+    {
+        return new JsonObject
+        {
+            ["type"] = "object",
+            ["required"] = new JsonArray("text", "targetLanguage", "tenantId", "userId"),
+            ["properties"] = new JsonObject
+            {
+                ["text"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                },
+                ["sourceLanguage"] = new JsonObject
+                {
+                    ["type"] = "string"
+                },
+                ["targetLanguage"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 2
+                },
+                ["tenantId"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                },
+                ["userId"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                },
+                ["channelId"] = new JsonObject
+                {
+                    ["type"] = "string"
+                },
+                ["tone"] = new JsonObject
+                {
+                    ["type"] = "string"
+                },
+                ["useGlossary"] = new JsonObject
+                {
+                    ["type"] = "boolean"
+                },
+                ["uiLocale"] = new JsonObject
+                {
+                    ["type"] = "string"
+                },
+                ["glossaryDecisions"] = new JsonObject
+                {
+                    ["type"] = "object"
+                },
+                ["additionalTargetLanguages"] = new JsonObject
+                {
+                    ["type"] = "array",
+                    ["items"] = new JsonObject { ["type"] = "string" }
+                }
+            }
+        };
+    }
+
+    private static JsonObject CreateDetectionSchema()
+    {
+        return new JsonObject
+        {
+            ["type"] = "object",
+            ["required"] = new JsonArray("text", "tenantId"),
+            ["properties"] = new JsonObject
+            {
+                ["text"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                },
+                ["tenantId"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                }
+            }
+        };
+    }
+
+    private static JsonObject CreateGlossarySchema()
+    {
+        return new JsonObject
+        {
+            ["type"] = "object",
+            ["required"] = new JsonArray("text", "tenantId", "userId"),
+            ["properties"] = new JsonObject
+            {
+                ["text"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                },
+                ["tenantId"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                },
+                ["userId"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                },
+                ["channelId"] = new JsonObject
+                {
+                    ["type"] = "string"
+                },
+                ["policy"] = new JsonObject
+                {
+                    ["type"] = "string"
+                },
+                ["glossaryIds"] = new JsonObject
+                {
+                    ["type"] = "array",
+                    ["items"] = new JsonObject { ["type"] = "string" }
+                }
+            }
+        };
+    }
+
+    private static JsonObject CreateReplySchema()
+    {
+        return new JsonObject
+        {
+            ["type"] = "object",
+            ["required"] = new JsonArray("threadId", "replyText", "tenantId", "userId"),
+            ["properties"] = new JsonObject
+            {
+                ["threadId"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                },
+                ["replyText"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                },
+                ["text"] = new JsonObject
+                {
+                    ["type"] = "string"
+                },
+                ["editedText"] = new JsonObject
+                {
+                    ["type"] = "string"
+                },
+                ["tenantId"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                },
+                ["userId"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["minLength"] = 1
+                },
+                ["channelId"] = new JsonObject
+                {
+                    ["type"] = "string"
+                },
+                ["language"] = new JsonObject
+                {
+                    ["type"] = "string"
+                },
+                ["uiLocale"] = new JsonObject
+                {
+                    ["type"] = "string"
+                },
+                ["languagePolicy"] = new JsonObject
+                {
+                    ["type"] = "object"
+                }
+            }
+        };
+    }
+}
+
+public sealed class McpToolDefinition
+{
+    public McpToolDefinition(string name, string description, JsonObject inputSchema, IReadOnlyList<string> requiredProperties)
+    {
+        Name = name;
+        Description = description;
+        InputSchema = inputSchema;
+        RequiredProperties = requiredProperties;
+    }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    [JsonPropertyName("input_schema")]
+    public JsonObject InputSchema { get; }
+
+    [JsonIgnore]
+    public IReadOnlyList<string> RequiredProperties { get; }
+}

--- a/tests/TlaPlugin.Tests/McpEndpointsTests.cs
+++ b/tests/TlaPlugin.Tests/McpEndpointsTests.cs
@@ -1,0 +1,159 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using TlaPlugin.Configuration;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class McpEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public McpEndpointsTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ListRequiresAuthorization()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/mcp/tools/list");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ListReturnsSchemas()
+    {
+        var client = _factory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, "/mcp/tools/list");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "token");
+
+        var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<McpListResponse>();
+        Assert.NotNull(payload);
+        Assert.Contains(payload!.Tools, tool => tool.Name == "tla.translate");
+        Assert.All(payload.Tools, tool => Assert.NotNull(tool.InputSchema));
+    }
+
+    [Fact]
+    public async Task CallValidatesSchema()
+    {
+        var client = _factory.CreateClient();
+        var request = CreateCallRequest(new
+        {
+            name = "tla.translate",
+            arguments = new
+            {
+                targetLanguage = "ja",
+                tenantId = "contoso",
+                userId = "user"
+            }
+        });
+
+        var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+        Assert.NotNull(payload);
+        Assert.Equal("Missing required property 'text'.", payload!["error"]);
+    }
+
+    [Fact]
+    public async Task CallMapsGlossaryConflicts()
+    {
+        var client = _factory.CreateClient();
+        var request = CreateCallRequest(new
+        {
+            name = "tla.applyGlossary",
+            arguments = new
+            {
+                text = "no matches here",
+                tenantId = "contoso",
+                userId = "user",
+                policy = "Strict"
+            }
+        });
+
+        var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetailsPayload>();
+        Assert.NotNull(problem);
+        Assert.Contains("用語", problem!.Detail);
+    }
+
+    [Fact]
+    public async Task CallRespectsComplianceGuard()
+    {
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.PostConfigure<PluginOptions>(options =>
+                {
+                    options.Compliance.RequiredRegionTags = new List<string> { "restricted" };
+                    foreach (var provider in options.Providers)
+                    {
+                        provider.Regions = new List<string> { "elsewhere" };
+                    }
+                });
+            });
+        }).CreateClient();
+
+        var request = CreateCallRequest(new
+        {
+            name = "tla.translate",
+            arguments = new
+            {
+                text = "hello world",
+                targetLanguage = "ja",
+                tenantId = "contoso",
+                userId = "user"
+            }
+        });
+
+        var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetailsPayload>();
+        Assert.NotNull(problem);
+        Assert.Contains("モデル", problem!.Detail);
+    }
+
+    private static HttpRequestMessage CreateCallRequest(object body)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/mcp/tools/call")
+        {
+            Content = JsonContent.Create(body, options: new JsonSerializerOptions(JsonSerializerDefaults.Web))
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "token");
+        return request;
+    }
+
+    private sealed class McpListResponse
+    {
+        public IReadOnlyList<McpToolDescriptor> Tools { get; set; } = new List<McpToolDescriptor>();
+    }
+
+    private sealed class McpToolDescriptor
+    {
+        public string Name { get; set; } = string.Empty;
+        public JsonElement InputSchema { get; set; }
+            = JsonDocument.Parse("{}" ).RootElement;
+    }
+
+    private sealed class ProblemDetailsPayload
+    {
+        public string? Title { get; set; }
+            = string.Empty;
+        public string Detail { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
- register an MCP tool registry with JSON schemas for translation, detection, glossary application, and threaded replies
- add an MCP server that dispatches tool calls through existing translation, glossary, and reply services with HTTP endpoints
- create integration coverage for MCP tool calls covering schema validation, error mapping, and compliance gating

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbcf2a909c832f9ef9df171626620f