### PR TITLE
Handle glossary conflict escalation in message extension

### DIFF
--- a/src/teamsClient/messageExtensionDialog.js
+++ b/src/teamsClient/messageExtensionDialog.js
@@ -188,6 +188,15 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
       updateError(ui, "");
       const payload = buildTranslatePayload(state, context);
       const response = await translateText(payload, fetcher);
+      if (response?.type === "glossaryConflict") {
+        sdk.dialog?.submit?.({
+          type: "glossaryConflict",
+          card: response.attachments?.[0]?.content ?? null,
+          attachments: response.attachments ?? [],
+          metadata: response.metadata ?? {}
+        });
+        return state;
+      }
       const nextState = updateStateWithResponse(state, response);
       state.translation = nextState.translation;
       state.modelId = nextState.modelId;

--- a/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
+++ b/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
@@ -191,7 +191,7 @@ public class MessageExtensionHandlerTests
             ChannelId = "finance"
         });
 
-        Assert.Equal("message", response["type"]?.GetValue<string>());
+        Assert.Equal("glossaryConflict", response["type"]?.GetValue<string>());
         var attachment = response["attachments"]!.AsArray().First().AsObject();
         var card = attachment["content"]!.AsObject();
         Assert.Equal("AdaptiveCard", card["type"]!.GetValue<string>());
@@ -204,7 +204,17 @@ public class MessageExtensionHandlerTests
         Assert.Equal("GPU", decoded["source"]!.GetValue<string>());
         Assert.Equal("UsePreferred", decoded["kind"]!.GetValue<string>());
         var actions = card["actions"]!.AsArray();
-        Assert.Contains(actions.Select(action => action!.AsObject()["data"]!.AsObject()["action"]?.GetValue<string>()), value => value == "resolveGlossary");
+        var submit = Assert.Single(actions
+            .Select(action => action!.AsObject())
+            .Where(node => node["data"]!.AsObject()["action"]!.GetValue<string>() == "resolveGlossary"));
+        var submitData = submit["data"]!.AsObject();
+        Assert.Equal("resolveGlossary", submitData["action"]!.GetValue<string>());
+        var pendingRequest = submitData["pendingRequest"]!.AsObject();
+        Assert.Equal("GPU", pendingRequest["text"]!.GetValue<string>());
+        Assert.Equal("ja", pendingRequest["targetLanguage"]!.GetValue<string>());
+        Assert.Equal("en", pendingRequest["sourceLanguage"]!.GetValue<string>());
+        Assert.Equal("contoso", pendingRequest["tenantId"]!.GetValue<string>());
+        Assert.True(pendingRequest["glossaryDecisions"]!.AsObject().Count == 0);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- return glossary conflict adaptive cards directly from the Teams message extension when resolution is required and include the serialized pending request in the action payload
- keep the glossary conflict metadata intact for downstream requests and extend unit coverage for translation, language selection, and glossary conflict branches
- teach the message extension dialog client to forward glossary conflict responses to the host and cover the new flow with tests

## Testing
- npm test -- tests/messageExtensionDialog.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dbdb19b3b8832f95b04b15758c44e0