### PR TITLE
Integrate Teams Graph client for replies

### DIFF
--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using System;
 using System.Security.Authentication;
 using System.Collections.Generic;
 using System.IO;
@@ -23,6 +24,10 @@ builder.Services.Configure<PluginOptions>(builder.Configuration.GetSection("Plug
 
 builder.Services.AddMemoryCache();
 builder.Services.AddHttpClient();
+builder.Services.AddHttpClient<ITeamsReplyClient, TeamsReplyClient>(client =>
+{
+    client.BaseAddress = new Uri("https://graph.microsoft.com/v1.0/");
+});
 builder.Services.AddSingleton(provider =>
 {
     var glossary = new GlossaryService();

--- a/src/TlaPlugin/Services/TeamsReplyClient.cs
+++ b/src/TlaPlugin/Services/TeamsReplyClient.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// Graph API を通じて Teams への返信メッセージを送信するクライアント。
+/// </summary>
+public class TeamsReplyClient : ITeamsReplyClient
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private readonly HttpClient _httpClient;
+
+    public TeamsReplyClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        if (_httpClient.BaseAddress is null)
+        {
+            _httpClient.BaseAddress = new Uri("https://graph.microsoft.com/v1.0/", UriKind.Absolute);
+        }
+    }
+
+    public async Task<TeamsReplyResponse> SendReplyAsync(TeamsReplyRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var path = BuildRequestPath(request);
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, new Uri(path, UriKind.Relative));
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", request.AccessToken);
+
+        var payload = new
+        {
+            replyToId = request.ThreadId,
+            body = new
+            {
+                contentType = "html",
+                content = FormatContent(request.FinalText)
+            },
+            channelIdentity = string.IsNullOrEmpty(request.ChannelId)
+                ? null
+                : new
+                {
+                    channelId = request.ChannelId,
+                    teamId = request.TenantId
+                },
+            channelData = new
+            {
+                metadata = new
+                {
+                    language = request.Language,
+                    tone = request.Tone
+                }
+            }
+        };
+
+        httpRequest.Content = new StringContent(JsonSerializer.Serialize(payload, SerializerOptions), Encoding.UTF8, "application/json");
+
+        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        var responseBody = response.Content is null
+            ? string.Empty
+            : await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw CreateException(response.StatusCode, responseBody);
+        }
+
+        var messageId = Guid.NewGuid().ToString();
+        DateTimeOffset postedAt = DateTimeOffset.UtcNow;
+        if (!string.IsNullOrWhiteSpace(responseBody))
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(responseBody);
+                if (document.RootElement.TryGetProperty("id", out var idProperty) && idProperty.ValueKind == JsonValueKind.String)
+                {
+                    messageId = idProperty.GetString() ?? messageId;
+                }
+
+                if (document.RootElement.TryGetProperty("createdDateTime", out var createdProperty) && createdProperty.ValueKind == JsonValueKind.String)
+                {
+                    if (DateTimeOffset.TryParse(createdProperty.GetString(), out var parsed))
+                    {
+                        postedAt = parsed;
+                    }
+                }
+
+                if (document.RootElement.TryGetProperty("lastModifiedDateTime", out var modifiedProperty) && modifiedProperty.ValueKind == JsonValueKind.String)
+                {
+                    if (DateTimeOffset.TryParse(modifiedProperty.GetString(), out var parsedModified))
+                    {
+                        postedAt = parsedModified;
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // 成功レスポンスだが JSON ではない場合は既定値を利用する。
+            }
+        }
+
+        var status = response.StatusCode is HttpStatusCode.Created or HttpStatusCode.OK
+            ? "sent"
+            : response.StatusCode.ToString().ToLowerInvariant();
+
+        return new TeamsReplyResponse(messageId, postedAt, status);
+    }
+
+    private static string BuildRequestPath(TeamsReplyRequest request)
+    {
+        var thread = Uri.EscapeDataString(request.ThreadId);
+        if (!string.IsNullOrEmpty(request.ChannelId))
+        {
+            var tenant = Uri.EscapeDataString(request.TenantId);
+            var channel = Uri.EscapeDataString(request.ChannelId);
+            return $"teams/{tenant}/channels/{channel}/messages/{thread}/replies";
+        }
+
+        return $"chats/{thread}/messages";
+    }
+
+    private static string FormatContent(string text)
+    {
+        var encoded = HtmlEncoder.Default.Encode(text ?? string.Empty);
+        return encoded.Replace("\n", "<br />", StringComparison.Ordinal);
+    }
+
+    private static TeamsReplyException CreateException(HttpStatusCode statusCode, string body)
+    {
+        string message = string.IsNullOrWhiteSpace(body)
+            ? statusCode.ToString()
+            : body;
+
+        string? errorCode = null;
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                using var document = JsonDocument.Parse(body);
+                if (document.RootElement.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.Object)
+                {
+                    if (error.TryGetProperty("message", out var messageProperty) && messageProperty.ValueKind == JsonValueKind.String)
+                    {
+                        message = messageProperty.GetString() ?? message;
+                    }
+
+                    if (error.TryGetProperty("code", out var codeProperty) && codeProperty.ValueKind == JsonValueKind.String)
+                    {
+                        errorCode = codeProperty.GetString();
+                    }
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // ignore malformed error payloads
+        }
+
+        return new TeamsReplyException(statusCode, message, errorCode);
+    }
+}
+
+public interface ITeamsReplyClient
+{
+    Task<TeamsReplyResponse> SendReplyAsync(TeamsReplyRequest request, CancellationToken cancellationToken);
+}
+
+public sealed record TeamsReplyRequest(
+    string ThreadId,
+    string? ChannelId,
+    string TenantId,
+    string FinalText,
+    string Language,
+    string Tone,
+    string AccessToken);
+
+public sealed record TeamsReplyResponse(string MessageId, DateTimeOffset SentAt, string Status);
+
+public class TeamsReplyException : Exception
+{
+    public TeamsReplyException(HttpStatusCode statusCode, string message, string? errorCode)
+        : base(message)
+    {
+        StatusCode = statusCode;
+        ErrorCode = errorCode;
+    }
+
+    public HttpStatusCode StatusCode { get; }
+
+    public string? ErrorCode { get; }
+}

--- a/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
+++ b/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
@@ -417,6 +417,9 @@ public class MessageExtensionHandlerTests
         Assert.Equal("replyPosted", response["type"]?.GetValue<string>());
         Assert.Contains("自定义编辑内容", response["finalText"]!.GetValue<string>());
         Assert.Equal(ToneTemplateService.Business, response["toneApplied"]?.GetValue<string>());
+        Assert.Equal("reply-001", response["messageId"]?.GetValue<string>());
+        Assert.Equal("sent", response["status"]?.GetValue<string>());
+        Assert.Equal(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero).ToString("O"), response["postedAt"]?.GetValue<string>());
     }
 
     [Fact]
@@ -455,7 +458,7 @@ public class MessageExtensionHandlerTests
         Assert.Equal("application/vnd.microsoft.card.adaptive", attachment["contentType"]!.GetValue<string>());
     }
 
-    private static MessageExtensionHandler BuildHandler(IOptions<PluginOptions> options, GlossaryService? glossaryOverride = null, ContextRetrievalService? contextOverride = null)
+    private static MessageExtensionHandler BuildHandler(IOptions<PluginOptions> options, GlossaryService? glossaryOverride = null, ContextRetrievalService? contextOverride = null, ITeamsReplyClient? replyClientOverride = null)
     {
         var glossary = glossaryOverride ?? new GlossaryService();
         if (glossaryOverride is null)
@@ -465,13 +468,22 @@ public class MessageExtensionHandlerTests
         var compliance = new ComplianceGateway(options);
         var resolver = new KeyVaultSecretResolver(options);
         var localization = new LocalizationCatalogService();
-        var router = new TranslationRouter(new ModelProviderFactory(options), compliance, new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new TokenBroker(resolver, options), new UsageMetricsService(), localization, options);
+        var metrics = new UsageMetricsService();
+        var tokenBroker = new TokenBroker(resolver, options);
+        var router = new TranslationRouter(new ModelProviderFactory(options), compliance, new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), tokenBroker, metrics, localization, options);
         var cache = new TranslationCache(options);
         var throttle = new TranslationThrottle(options);
         var rewrite = new RewriteService(router, throttle);
-        var reply = new ReplyService(rewrite, options);
+        var replyClient = replyClientOverride ?? new StubTeamsReplyClient();
+        var reply = new ReplyService(rewrite, replyClient, tokenBroker, metrics, options);
         var context = contextOverride ?? new ContextRetrievalService(options);
         var pipeline = new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, context, rewrite, reply, options);
         return new MessageExtensionHandler(pipeline, localization, options);
+    }
+
+    private sealed class StubTeamsReplyClient : ITeamsReplyClient
+    {
+        public Task<TeamsReplyResponse> SendReplyAsync(TeamsReplyRequest request, CancellationToken cancellationToken)
+            => Task.FromResult(new TeamsReplyResponse("reply-001", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), "sent"));
     }
 }

--- a/tests/TlaPlugin.Tests/ReplyServiceTests.cs
+++ b/tests/TlaPlugin.Tests/ReplyServiceTests.cs
@@ -1,4 +1,10 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
@@ -23,10 +29,9 @@ public class ReplyServiceTests
             Providers = new List<ModelProviderOptions> { new() { Id = "primary" } }
         });
 
-        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new RecordingTokenBroker(), new UsageMetricsService(), new LocalizationCatalogService(), options);
-        var throttle = new TranslationThrottle(options);
-        var rewrite = new RewriteService(router, throttle);
-        var service = new ReplyService(rewrite, options);
+        var metrics = new UsageMetricsService();
+        var teamsClient = new RecordingTeamsClient();
+        var service = CreateService(options, teamsClient, metrics);
 
         await Assert.ThrowsAsync<ReplyAuthorizationException>(() => service.SendReplyAsync(new ReplyRequest
         {
@@ -43,17 +48,15 @@ public class ReplyServiceTests
     {
         var options = Options.Create(new PluginOptions
         {
-            Security = new SecurityOptions
-            {
-                AllowedReplyChannels = new List<string>()
-            },
             Providers = new List<ModelProviderOptions> { new() { Id = "primary" } }
         });
 
-        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new RecordingTokenBroker(), new UsageMetricsService(), new LocalizationCatalogService(), options);
-        var throttle = new TranslationThrottle(options);
-        var rewrite = new RewriteService(router, throttle);
-        var service = new ReplyService(rewrite, options);
+        var metrics = new UsageMetricsService();
+        var teamsClient = new RecordingTeamsClient
+        {
+            Response = new TeamsReplyResponse("msg-1", DateTimeOffset.UtcNow, "sent")
+        };
+        var service = CreateService(options, teamsClient, metrics);
 
         var result = await service.SendReplyAsync(new ReplyRequest
         {
@@ -71,6 +74,9 @@ public class ReplyServiceTests
         Assert.Contains("商务语气", result.FinalText);
         Assert.Equal(ToneTemplateService.Business, result.ToneApplied);
         Assert.Equal("ja", result.Language);
+        Assert.Equal("msg-1", result.MessageId);
+        Assert.Equal("ja", teamsClient.LastRequest?.Language);
+        Assert.Equal(ToneTemplateService.Business, teamsClient.LastRequest?.Tone);
     }
 
     [Fact]
@@ -81,10 +87,8 @@ public class ReplyServiceTests
             Providers = new List<ModelProviderOptions> { new() { Id = "primary" } }
         });
 
-        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new RecordingTokenBroker(), new UsageMetricsService(), new LocalizationCatalogService(), options);
-        var throttle = new TranslationThrottle(options);
-        var rewrite = new RewriteService(router, throttle);
-        var service = new ReplyService(rewrite, options);
+        var metrics = new UsageMetricsService();
+        var service = CreateService(options, new RecordingTeamsClient(), metrics);
 
         await Assert.ThrowsAsync<ArgumentException>(() => service.SendReplyAsync(new ReplyRequest
         {
@@ -102,10 +106,12 @@ public class ReplyServiceTests
             Providers = new List<ModelProviderOptions> { new() { Id = "primary" } }
         });
 
-        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new RecordingTokenBroker(), new UsageMetricsService(), new LocalizationCatalogService(), options);
-        var throttle = new TranslationThrottle(options);
-        var rewrite = new RewriteService(router, throttle);
-        var service = new ReplyService(rewrite, options);
+        var metrics = new UsageMetricsService();
+        var teamsClient = new RecordingTeamsClient
+        {
+            Response = new TeamsReplyResponse("msg-override", DateTimeOffset.UtcNow, "sent")
+        };
+        var service = CreateService(options, teamsClient, metrics);
 
         var result = await service.SendReplyAsync(new ReplyRequest
         {
@@ -119,6 +125,8 @@ public class ReplyServiceTests
 
         Assert.Equal("最终文本", result.FinalText);
         Assert.Equal(ToneTemplateService.Business, result.ToneApplied);
+        Assert.Equal("msg-override", result.MessageId);
+        Assert.Equal("最终文本", teamsClient.LastRequest?.FinalText);
     }
 
     [Fact]
@@ -129,10 +137,8 @@ public class ReplyServiceTests
             Providers = new List<ModelProviderOptions> { new() { Id = "primary" } }
         });
 
-        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new RecordingTokenBroker(), new UsageMetricsService(), new LocalizationCatalogService(), options);
-        var throttle = new TranslationThrottle(options);
-        var rewrite = new RewriteService(router, throttle);
-        var service = new ReplyService(rewrite, options);
+        var metrics = new UsageMetricsService();
+        var service = CreateService(options, new RecordingTeamsClient(), metrics);
 
         await Assert.ThrowsAsync<ArgumentException>(() => service.SendReplyAsync(new ReplyRequest
         {
@@ -145,11 +151,178 @@ public class ReplyServiceTests
         }, string.Empty, null, CancellationToken.None));
     }
 
+    [Fact]
+    public async Task SendReplyAsyncUsesHttpClientAndMetadata()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions> { new() { Id = "primary" } }
+        });
+
+        JsonDocument? capturedPayload = null;
+        string? capturedPath = null;
+        string? authorization = null;
+
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            capturedPath = request.RequestUri?.PathAndQuery.TrimStart('/');
+            authorization = request.Headers.Authorization?.ToString();
+            var payloadText = request.Content is null ? string.Empty : request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            capturedPayload = string.IsNullOrWhiteSpace(payloadText) ? null : JsonDocument.Parse(payloadText);
+
+            var response = new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent("{\"id\":\"msg-http\",\"createdDateTime\":\"2024-02-01T12:34:56Z\"}", Encoding.UTF8, "application/json")
+            };
+            return response;
+        });
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://graph.test/v1.0/")
+        };
+        var teamsClient = new TeamsReplyClient(httpClient);
+        var metrics = new UsageMetricsService();
+        var service = CreateService(options, teamsClient, metrics, new RecordingTokenBroker("token-http"));
+
+        var result = await service.SendReplyAsync(new ReplyRequest
+        {
+            ThreadId = "message",
+            ReplyText = "ignored",
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "general",
+            LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "ja", Tone = ToneTemplateService.Casual }
+        }, "グラフ投稿", ToneTemplateService.Casual, CancellationToken.None);
+
+        Assert.Equal("msg-http", result.MessageId);
+        Assert.Equal("sent", result.Status);
+        Assert.Equal("ja", result.Language);
+        Assert.Equal(DateTimeOffset.Parse("2024-02-01T12:34:56Z", CultureInfo.InvariantCulture), result.PostedAt);
+        Assert.Equal("teams/contoso/channels/general/messages/message/replies", capturedPath);
+        Assert.Equal("Bearer token-http", authorization);
+        Assert.NotNull(capturedPayload);
+        var root = capturedPayload!.RootElement;
+        Assert.Equal("message", root.GetProperty("replyToId").GetString());
+        Assert.Equal("ja", root.GetProperty("channelData").GetProperty("metadata").GetProperty("language").GetString());
+        Assert.Equal(ToneTemplateService.Casual, root.GetProperty("channelData").GetProperty("metadata").GetProperty("tone").GetString());
+        var html = root.GetProperty("body").GetProperty("content").GetString();
+        Assert.Contains("グラフ投稿", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SendReplyAsyncThrowsReplyAuthorizationWhenForbidden()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions> { new() { Id = "primary" } }
+        });
+
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("{\"error\":{\"code\":\"Forbidden\",\"message\":\"access denied\"}}", Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://graph.test/") };
+        var teamsClient = new TeamsReplyClient(httpClient);
+        var metrics = new UsageMetricsService();
+        var service = CreateService(options, teamsClient, metrics, new RecordingTokenBroker());
+
+        await Assert.ThrowsAsync<ReplyAuthorizationException>(() => service.SendReplyAsync(new ReplyRequest
+        {
+            ThreadId = "thread",
+            ReplyText = "text",
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "general",
+            LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "ja" }
+        }, "最终", null, CancellationToken.None));
+
+        var report = metrics.GetReport();
+        var tenant = Assert.Single(report.Tenants);
+        Assert.Contains(tenant.Failures, failure => failure.Reason == UsageMetricsService.FailureReasons.Authentication && failure.Count == 1);
+    }
+
+    [Fact]
+    public async Task SendReplyAsyncThrowsBudgetExceededWhenPaymentRequired()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Providers = new List<ModelProviderOptions> { new() { Id = "primary" } }
+        });
+
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.PaymentRequired)
+        {
+            Content = new StringContent("{\"error\":{\"code\":\"Budget\",\"message\":\"budget exceeded\"}}", Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://graph.test/") };
+        var teamsClient = new TeamsReplyClient(httpClient);
+        var metrics = new UsageMetricsService();
+        var service = CreateService(options, teamsClient, metrics, new RecordingTokenBroker());
+
+        await Assert.ThrowsAsync<BudgetExceededException>(() => service.SendReplyAsync(new ReplyRequest
+        {
+            ThreadId = "thread",
+            ReplyText = "text",
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "general",
+            LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "ja" }
+        }, "最终", null, CancellationToken.None));
+
+        var report = metrics.GetReport();
+        var tenant = Assert.Single(report.Tenants);
+        Assert.Contains(tenant.Failures, failure => failure.Reason == UsageMetricsService.FailureReasons.Budget && failure.Count == 1);
+    }
+
+    private static ReplyService CreateService(IOptions<PluginOptions> options, ITeamsReplyClient teamsClient, UsageMetricsService metrics, ITokenBroker? tokenBroker = null)
+    {
+        var broker = tokenBroker ?? new RecordingTokenBroker();
+        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), broker, metrics, new LocalizationCatalogService(), options);
+        var throttle = new TranslationThrottle(options);
+        var rewrite = new RewriteService(router, throttle);
+        return new ReplyService(rewrite, teamsClient, broker, metrics, options);
+    }
+
+    private sealed class RecordingTeamsClient : ITeamsReplyClient
+    {
+        public TeamsReplyRequest? LastRequest { get; private set; }
+
+        public TeamsReplyResponse Response { get; set; } = new TeamsReplyResponse("message", DateTimeOffset.UtcNow, "sent");
+
+        public Task<TeamsReplyResponse> SendReplyAsync(TeamsReplyRequest request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(Response);
+        }
+    }
+
     private sealed class RecordingTokenBroker : ITokenBroker
     {
+        private readonly string _token;
+
+        public RecordingTokenBroker(string token = "token")
+        {
+            _token = token;
+        }
+
         public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
         {
-            return Task.FromResult(new AccessToken("token", DateTimeOffset.UtcNow.AddMinutes(10), "audience"));
+            return Task.FromResult(new AccessToken(_token, DateTimeOffset.UtcNow.AddMinutes(10), "audience"));
+        }
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_handler(request));
         }
     }
 }

--- a/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
@@ -946,14 +946,16 @@ public class TranslationPipelineTests
         });
 
         var localization = new LocalizationCatalogService();
+        var metrics = new UsageMetricsService();
+        var tokenBroker = new StaticTokenBroker();
         var router = new TranslationRouter(
             new ModelProviderFactory(options),
             new ComplianceGateway(options),
             new BudgetGuard(options.Value),
             new AuditLogger(),
             new ToneTemplateService(),
-            new StaticTokenBroker(),
-            new UsageMetricsService(),
+            tokenBroker,
+            metrics,
             localization,
             options,
             new[] { new LowConfidenceModelProvider(providerOptions, detection) });
@@ -962,7 +964,7 @@ public class TranslationPipelineTests
         var glossary = new GlossaryService();
         var cache = new TranslationCache(options);
         var rewrite = new RewriteService(router, throttle);
-        var reply = new ReplyService(rewrite, options);
+        var reply = new ReplyService(rewrite, new NoopTeamsReplyClient(), tokenBroker, metrics, options);
 
         var context = new ContextRetrievalService(options);
 
@@ -988,11 +990,13 @@ public class TranslationPipelineTests
     {
         var glossary = glossaryOverride ?? new GlossaryService();
         var localization = new LocalizationCatalogService();
-        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), new TokenBroker(new KeyVaultSecretResolver(options), options), new UsageMetricsService(), localization, options);
+        var metrics = new UsageMetricsService();
+        var tokenBroker = new TokenBroker(new KeyVaultSecretResolver(options), options);
+        var router = new TranslationRouter(new ModelProviderFactory(options), new ComplianceGateway(options), new BudgetGuard(options.Value), new AuditLogger(), new ToneTemplateService(), tokenBroker, metrics, localization, options);
         var cache = new TranslationCache(options);
         var throttle = new TranslationThrottle(options);
         var rewrite = new RewriteService(router, throttle);
-        var reply = new ReplyService(rewrite, options);
+        var reply = new ReplyService(rewrite, new NoopTeamsReplyClient(), tokenBroker, metrics, options);
         var context = contextOverride ?? new ContextRetrievalService(options);
         return new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, context, rewrite, reply, options);
     }
@@ -1026,5 +1030,11 @@ public class TranslationPipelineTests
     {
         public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
             => Task.FromResult(new AccessToken("token", DateTimeOffset.UtcNow.AddMinutes(5), "api://audience"));
+    }
+
+    private sealed class NoopTeamsReplyClient : ITeamsReplyClient
+    {
+        public Task<TeamsReplyResponse> SendReplyAsync(TeamsReplyRequest request, CancellationToken cancellationToken)
+            => Task.FromResult(new TeamsReplyResponse("noop", DateTimeOffset.UtcNow, "sent"));
     }
 }


### PR DESCRIPTION
## Summary
- integrate a Teams Graph reply client and update ReplyService to send real replies with metadata and usage metrics on failure
- register the client in the service container and surface true message identifiers in the message extension reply payload
- add comprehensive reply unit tests covering success, permission denial, and budget enforcement scenarios

## Testing
- dotnet test *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc127572b8832f8d7b2f21b6ccba21