### PR TITLE
Add Graph-backed context retrieval with caching and resiliency

### DIFF
--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Microsoft.Graph;
 using TlaPlugin.Configuration;
 using TlaPlugin.Models;
 using TlaPlugin.Services;
@@ -23,6 +24,8 @@ builder.Services.Configure<PluginOptions>(builder.Configuration.GetSection("Plug
 
 builder.Services.AddMemoryCache();
 builder.Services.AddHttpClient();
+builder.Services.AddSingleton<GraphServiceClient>(_ => new GraphServiceClient(new AnonymousAuthenticationProvider()));
+builder.Services.AddSingleton<ITeamsMessageClient, GraphTeamsMessageClient>();
 builder.Services.AddSingleton(provider =>
 {
     var glossary = new GlossaryService();

--- a/src/TlaPlugin/Services/AnonymousAuthenticationProvider.cs
+++ b/src/TlaPlugin/Services/AnonymousAuthenticationProvider.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Abstractions;
+using Microsoft.Kiota.Abstractions.Authentication;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 空认证提供器，允许在本地或测试环境创建 Graph 客户端。
+/// </summary>
+public sealed class AnonymousAuthenticationProvider : IAuthenticationProvider
+{
+    public Task AuthenticateRequestAsync(
+        RequestInformation request,
+        Dictionary<string, object>? additionalAuthenticationContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/TlaPlugin/Services/GraphTeamsMessageClient.cs
+++ b/src/TlaPlugin/Services/GraphTeamsMessageClient.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 使用 Microsoft Graph SDK 访问 Teams 消息的默认实现。
+/// </summary>
+public class GraphTeamsMessageClient : ITeamsMessageClient
+{
+    private static readonly Regex HtmlTagRegex = new("<[^>]+>", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private readonly GraphServiceClient _graphClient;
+
+    public GraphTeamsMessageClient(GraphServiceClient graphClient)
+    {
+        _graphClient = graphClient ?? throw new ArgumentNullException(nameof(graphClient));
+    }
+
+    public async Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
+        string tenantId,
+        string? channelId,
+        string? threadId,
+        int maxMessages,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId) || string.IsNullOrWhiteSpace(channelId))
+        {
+            return Array.Empty<ContextMessage>();
+        }
+
+        maxMessages = Math.Max(1, maxMessages);
+
+        var messages = new List<ContextMessage>();
+
+        if (!string.IsNullOrEmpty(threadId))
+        {
+            var root = await _graphClient.Teams[tenantId].Channels[channelId].Messages[threadId]
+                .GetAsync(static request =>
+                {
+                    request.QueryParameters.Select = new[] { "id", "body", "from", "createdDateTime", "lastModifiedDateTime", "replyToId" };
+                }, cancellationToken).ConfigureAwait(false);
+
+            if (root is not null)
+            {
+                messages.Add(Convert(root));
+            }
+
+            var replies = await _graphClient.Teams[tenantId].Channels[channelId].Messages[threadId].Replies
+                .GetAsync(request =>
+                {
+                    request.QueryParameters.Top = maxMessages;
+                    request.QueryParameters.Orderby = new[] { "lastModifiedDateTime desc" };
+                    request.QueryParameters.Select = new[] { "id", "body", "from", "createdDateTime", "lastModifiedDateTime", "replyToId" };
+                }, cancellationToken).ConfigureAwait(false);
+
+            if (replies?.Value is not null)
+            {
+                messages.AddRange(replies.Value.Select(Convert));
+            }
+        }
+        else
+        {
+            var response = await _graphClient.Teams[tenantId].Channels[channelId].Messages
+                .GetAsync(request =>
+                {
+                    request.QueryParameters.Top = maxMessages;
+                    request.QueryParameters.Orderby = new[] { "lastModifiedDateTime desc" };
+                    request.QueryParameters.Select = new[] { "id", "body", "from", "createdDateTime", "lastModifiedDateTime", "replyToId" };
+                }, cancellationToken).ConfigureAwait(false);
+
+            if (response?.Value is not null)
+            {
+                messages.AddRange(response.Value.Select(Convert));
+            }
+        }
+
+        return messages
+            .OrderByDescending(message => message.Timestamp)
+            .Take(maxMessages)
+            .ToList();
+    }
+
+    private static ContextMessage Convert(ChatMessage message)
+    {
+        var timestamp = message.LastModifiedDateTime ?? message.CreatedDateTime ?? DateTimeOffset.UtcNow;
+        var text = message.Body?.Content ?? string.Empty;
+        if (message.Body?.ContentType == BodyType.Html)
+        {
+            text = HtmlTagRegex.Replace(text, string.Empty);
+        }
+
+        var author = message.From?.User?.DisplayName
+            ?? message.From?.Application?.DisplayName
+            ?? message.From?.Device?.DisplayName
+            ?? string.Empty;
+
+        return new ContextMessage
+        {
+            Id = message.Id ?? Guid.NewGuid().ToString("N"),
+            Author = author,
+            Text = text.Trim(),
+            Timestamp = timestamp,
+            RelevanceScore = 0d
+        };
+    }
+}

--- a/src/TlaPlugin/Services/ITeamsMessageClient.cs
+++ b/src/TlaPlugin/Services/ITeamsMessageClient.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 抽象化 Teams/Graph SDK，提供从频道检索最近消息的接口。
+/// </summary>
+public interface ITeamsMessageClient
+{
+    /// <summary>
+    /// 获取指定频道或线程的最新消息集合。
+    /// </summary>
+    /// <param name="tenantId">目标团队或租户标识。</param>
+    /// <param name="channelId">频道标识。</param>
+    /// <param name="threadId">线程标识，当为 null 时读取频道顶层消息。</param>
+    /// <param name="maxMessages">最大返回消息数量。</param>
+    /// <param name="cancellationToken">取消标记。</param>
+    /// <returns>按时间降序排列的消息列表。</returns>
+    Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
+        string tenantId,
+        string? channelId,
+        string? threadId,
+        int maxMessages,
+        CancellationToken cancellationToken);
+}

--- a/src/TlaPlugin/Services/NullTeamsMessageClient.cs
+++ b/src/TlaPlugin/Services/NullTeamsMessageClient.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 返回空结果的占位实现，用于未配置 Graph 客户端的场景。
+/// </summary>
+public sealed class NullTeamsMessageClient : ITeamsMessageClient
+{
+    public Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
+        string tenantId,
+        string? channelId,
+        string? threadId,
+        int maxMessages,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<ContextMessage> empty = Array.Empty<ContextMessage>();
+        return Task.FromResult(empty);
+    }
+}

--- a/src/TlaPlugin/Services/TranslationPipeline.cs
+++ b/src/TlaPlugin/Services/TranslationPipeline.cs
@@ -211,14 +211,27 @@ public class TranslationPipeline
             return;
         }
 
-        var retrieval = await _contextRetrieval.GetContextAsync(new ContextRetrievalRequest
+        ContextRetrievalResult retrieval;
+        try
         {
-            TenantId = request.TenantId,
-            ChannelId = request.ChannelId,
-            ThreadId = request.ChannelId,
-            MaxMessages = _options.Rag.MaxMessages,
-            ContextHints = new List<string>(request.ContextHints)
-        }, cancellationToken);
+            retrieval = await _contextRetrieval.GetContextAsync(new ContextRetrievalRequest
+            {
+                TenantId = request.TenantId,
+                ChannelId = request.ChannelId,
+                ThreadId = request.ChannelId,
+                MaxMessages = _options.Rag.MaxMessages,
+                ContextHints = new List<string>(request.ContextHints)
+            }, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            request.ContextSummary = null;
+            return;
+        }
 
         if (!retrieval.HasContext)
         {

--- a/src/TlaPlugin/TlaPlugin.csproj
+++ b/src/TlaPlugin/TlaPlugin.csproj
@@ -6,5 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.20" />
+    <PackageReference Include="Microsoft.Graph" Version="5.53.0" />
   </ItemGroup>
 </Project>

--- a/tests/TlaPlugin.Tests/ContextRetrievalIntegrationTests.cs
+++ b/tests/TlaPlugin.Tests/ContextRetrievalIntegrationTests.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class ContextRetrievalIntegrationTests
+{
+    [Fact]
+    public async Task RetrievesContextThroughGraphClient()
+    {
+        var options = CreateOptions();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var graph = new FakeTeamsMessageClient();
+        graph.Messages.AddRange(new[]
+        {
+            new ContextMessage { Author = "Alex", Text = "Budget approval pending", Timestamp = DateTimeOffset.UtcNow.AddMinutes(-3) },
+            new ContextMessage { Author = "Taylor", Text = "Contract draft ready for review", Timestamp = DateTimeOffset.UtcNow.AddMinutes(-1) }
+        });
+
+        var pipeline = BuildPipeline(options, graph, cache);
+
+        var result = await pipeline.TranslateAsync(new TranslationRequest
+        {
+            Text = "Here is the purchase summary",
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "general",
+            TargetLanguage = "ja",
+            SourceLanguage = "en",
+            UseRag = true
+        }, CancellationToken.None);
+
+        var translation = Assert.NotNull(result.Translation);
+        Assert.Contains("[Context]", translation.RawTranslatedText, StringComparison.Ordinal);
+        Assert.Equal(1, graph.CallCount);
+    }
+
+    [Fact]
+    public async Task AppliesHintFilteringWhenProvided()
+    {
+        var options = CreateOptions();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var graph = new FakeTeamsMessageClient();
+        graph.Messages.AddRange(new[]
+        {
+            new ContextMessage { Author = "Alex", Text = "Budget approval pending", Timestamp = DateTimeOffset.UtcNow.AddMinutes(-3) },
+            new ContextMessage { Author = "Taylor", Text = "Contract draft ready for review", Timestamp = DateTimeOffset.UtcNow.AddMinutes(-1) }
+        });
+
+        var pipeline = BuildPipeline(options, graph, cache);
+
+        var result = await pipeline.TranslateAsync(new TranslationRequest
+        {
+            Text = "Here is the purchase summary",
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "general",
+            TargetLanguage = "ja",
+            SourceLanguage = "en",
+            UseRag = true,
+            ContextHints = new List<string> { "contract" }
+        }, CancellationToken.None);
+
+        var translation = Assert.NotNull(result.Translation);
+        Assert.Contains("Contract draft", translation.RawTranslatedText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Budget approval", translation.RawTranslatedText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UsesCachedMessagesOnSubsequentRequests()
+    {
+        var options = CreateOptions();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var graph = new FakeTeamsMessageClient();
+        graph.Messages.AddRange(new[]
+        {
+            new ContextMessage { Author = "Alex", Text = "Budget approval pending", Timestamp = DateTimeOffset.UtcNow.AddMinutes(-3) },
+            new ContextMessage { Author = "Taylor", Text = "Contract draft ready for review", Timestamp = DateTimeOffset.UtcNow.AddMinutes(-1) }
+        });
+
+        var pipeline = BuildPipeline(options, graph, cache);
+
+        var request = new TranslationRequest
+        {
+            Text = "Here is the purchase summary",
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "general",
+            TargetLanguage = "ja",
+            SourceLanguage = "en",
+            UseRag = true
+        };
+
+        var first = await pipeline.TranslateAsync(request, CancellationToken.None);
+        var second = await pipeline.TranslateAsync(request, CancellationToken.None);
+
+        Assert.NotNull(first.Translation);
+        Assert.NotNull(second.Translation);
+        Assert.Equal(1, graph.CallCount);
+    }
+
+    [Fact]
+    public async Task FallsBackWhenGraphThrows()
+    {
+        var options = CreateOptions();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var graph = new FakeTeamsMessageClient { ShouldThrow = true };
+
+        var pipeline = BuildPipeline(options, graph, cache);
+
+        var result = await pipeline.TranslateAsync(new TranslationRequest
+        {
+            Text = "Here is the purchase summary",
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "general",
+            TargetLanguage = "ja",
+            SourceLanguage = "en",
+            UseRag = true
+        }, CancellationToken.None);
+
+        var translation = Assert.NotNull(result.Translation);
+        Assert.DoesNotContain("[Context]", translation.RawTranslatedText, StringComparison.Ordinal);
+        Assert.Equal(1, graph.CallCount);
+    }
+
+    private static TranslationPipeline BuildPipeline(IOptions<PluginOptions> options, ITeamsMessageClient graph, IMemoryCache cache)
+    {
+        var glossary = new GlossaryService();
+        var localization = new LocalizationCatalogService();
+        var router = new TranslationRouter(
+            new ModelProviderFactory(options),
+            new ComplianceGateway(options),
+            new BudgetGuard(options.Value),
+            new AuditLogger(),
+            new ToneTemplateService(),
+            new TokenBroker(new KeyVaultSecretResolver(options), options),
+            new UsageMetricsService(),
+            localization,
+            options);
+
+        var context = new ContextRetrievalService(graph, cache, options);
+        var cacheStore = new TranslationCache(options);
+        var throttle = new TranslationThrottle(options);
+        var rewrite = new RewriteService(router, throttle);
+        var reply = new ReplyService(rewrite, options);
+
+        return new TranslationPipeline(
+            router,
+            glossary,
+            new OfflineDraftStore(options),
+            new LanguageDetector(),
+            cacheStore,
+            throttle,
+            context,
+            rewrite,
+            reply,
+            options);
+    }
+
+    private static IOptions<PluginOptions> CreateOptions()
+    {
+        return Options.Create(new PluginOptions
+        {
+            DailyBudgetUsd = 1m,
+            CacheTtl = TimeSpan.FromHours(1),
+            RequestsPerMinute = 10,
+            MaxConcurrentTranslations = 2,
+            Rag = new RagOptions
+            {
+                Enabled = true,
+                MaxMessages = 5,
+                SummaryThreshold = 1200,
+                SummaryTargetLength = 480
+            },
+            Providers = new List<ModelProviderOptions>
+            {
+                new()
+                {
+                    Id = "primary",
+                    CostPerCharUsd = 0.1m,
+                    Regions = new List<string> { "japan" },
+                    Certifications = new List<string> { "iso" }
+                }
+            },
+            Compliance = new CompliancePolicyOptions
+            {
+                RequiredRegionTags = new List<string> { "japan" },
+                RequiredCertifications = new List<string> { "iso" }
+            }
+        });
+    }
+
+    private sealed class FakeTeamsMessageClient : ITeamsMessageClient
+    {
+        public List<ContextMessage> Messages { get; } = new();
+        public int CallCount { get; private set; }
+        public bool ShouldThrow { get; set; }
+
+        public Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
+            string tenantId,
+            string? channelId,
+            string? threadId,
+            int maxMessages,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            if (ShouldThrow)
+            {
+                throw new InvalidOperationException("Graph failure");
+            }
+
+            var ordered = Messages
+                .OrderByDescending(message => message.Timestamp)
+                .Take(Math.Max(1, maxMessages))
+                .Select(message => new ContextMessage
+                {
+                    Id = message.Id,
+                    Author = message.Author,
+                    Timestamp = message.Timestamp,
+                    Text = message.Text,
+                    RelevanceScore = message.RelevanceScore
+                })
+                .ToList();
+
+            IReadOnlyList<ContextMessage> snapshot = ordered;
+            return Task.FromResult(snapshot);
+        }
+    }
+}

--- a/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
+++ b/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using TlaPlugin.Configuration;
 using TlaPlugin.Models;
@@ -470,7 +471,7 @@ public class MessageExtensionHandlerTests
         var throttle = new TranslationThrottle(options);
         var rewrite = new RewriteService(router, throttle);
         var reply = new ReplyService(rewrite, options);
-        var context = contextOverride ?? new ContextRetrievalService(options);
+        var context = contextOverride ?? new ContextRetrievalService(new NullTeamsMessageClient(), new MemoryCache(new MemoryCacheOptions()), options);
         var pipeline = new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, context, rewrite, reply, options);
         return new MessageExtensionHandler(pipeline, localization, options);
     }

--- a/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using TlaPlugin.Configuration;
 using TlaPlugin.Models;
@@ -123,14 +124,14 @@ public class TranslationPipelineTests
             }
         });
 
-        var context = new ContextRetrievalService(options);
-        context.SeedMessages("contoso", "general", new[]
+        var graph = new FakeTeamsMessageClient();
+        graph.Messages.AddRange(new[]
         {
             new ContextMessage { Author = "Alex", Text = "Budget approval pending", Timestamp = DateTimeOffset.UtcNow.AddMinutes(-3) },
             new ContextMessage { Author = "Taylor", Text = "Please translate the contract draft", Timestamp = DateTimeOffset.UtcNow.AddMinutes(-1) }
         });
 
-        var pipeline = BuildPipeline(options, contextOverride: context);
+        var pipeline = BuildPipeline(options, teamsClient: graph);
 
         var request = new TranslationRequest
         {
@@ -185,14 +186,14 @@ public class TranslationPipelineTests
             }
         });
 
-        var context = new ContextRetrievalService(options);
-        context.SeedMessages("contoso", "general", new[]
+        var graph = new FakeTeamsMessageClient();
+        graph.Messages.AddRange(new[]
         {
             new ContextMessage { Author = "Alex", Text = "Budget approval pending", Timestamp = DateTimeOffset.UtcNow.AddMinutes(-3) },
             new ContextMessage { Author = "Taylor", Text = "Contract draft ready for review", Timestamp = DateTimeOffset.UtcNow.AddMinutes(-1) }
         });
 
-        var pipeline = BuildPipeline(options, contextOverride: context);
+        var pipeline = BuildPipeline(options, teamsClient: graph);
 
         var request = new TranslationRequest
         {
@@ -245,8 +246,8 @@ public class TranslationPipelineTests
             }
         });
 
-        var context = new ContextRetrievalService(options);
-        context.SeedMessages("contoso", "general", new[]
+        var graph = new FakeTeamsMessageClient();
+        graph.Messages.AddRange(new[]
         {
             new ContextMessage
             {
@@ -262,7 +263,7 @@ public class TranslationPipelineTests
             }
         });
 
-        var pipeline = BuildPipeline(options, contextOverride: context);
+        var pipeline = BuildPipeline(options, teamsClient: graph);
 
         var request = new TranslationRequest
         {
@@ -964,7 +965,7 @@ public class TranslationPipelineTests
         var rewrite = new RewriteService(router, throttle);
         var reply = new ReplyService(rewrite, options);
 
-        var context = new ContextRetrievalService(options);
+        var context = new ContextRetrievalService(new NullTeamsMessageClient(), new MemoryCache(new MemoryCacheOptions()), options);
 
         var pipeline = new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, context, rewrite, reply, options);
 
@@ -984,7 +985,12 @@ public class TranslationPipelineTests
         Assert.Contains(detectionResult.Candidates, candidate => candidate.Language == "en");
     }
 
-    private static TranslationPipeline BuildPipeline(IOptions<PluginOptions> options, GlossaryService? glossaryOverride = null, ContextRetrievalService? contextOverride = null)
+    private static TranslationPipeline BuildPipeline(
+        IOptions<PluginOptions> options,
+        GlossaryService? glossaryOverride = null,
+        ContextRetrievalService? contextOverride = null,
+        ITeamsMessageClient? teamsClient = null,
+        IMemoryCache? memoryCache = null)
     {
         var glossary = glossaryOverride ?? new GlossaryService();
         var localization = new LocalizationCatalogService();
@@ -993,7 +999,7 @@ public class TranslationPipelineTests
         var throttle = new TranslationThrottle(options);
         var rewrite = new RewriteService(router, throttle);
         var reply = new ReplyService(rewrite, options);
-        var context = contextOverride ?? new ContextRetrievalService(options);
+        var context = contextOverride ?? new ContextRetrievalService(teamsClient ?? new NullTeamsMessageClient(), memoryCache ?? new MemoryCache(new MemoryCacheOptions()), options);
         return new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, context, rewrite, reply, options);
     }
 
@@ -1026,5 +1032,42 @@ public class TranslationPipelineTests
     {
         public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
             => Task.FromResult(new AccessToken("token", DateTimeOffset.UtcNow.AddMinutes(5), "api://audience"));
+    }
+
+    private sealed class FakeTeamsMessageClient : ITeamsMessageClient
+    {
+        public List<ContextMessage> Messages { get; } = new();
+        public int CallCount { get; private set; }
+        public bool ShouldThrow { get; set; }
+
+        public Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
+            string tenantId,
+            string? channelId,
+            string? threadId,
+            int maxMessages,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            if (ShouldThrow)
+            {
+                throw new InvalidOperationException("Graph failure");
+            }
+
+            var ordered = Messages
+                .OrderByDescending(message => message.Timestamp)
+                .Take(Math.Max(1, maxMessages))
+                .Select(message => new ContextMessage
+                {
+                    Id = message.Id,
+                    Author = message.Author,
+                    Timestamp = message.Timestamp,
+                    Text = message.Text,
+                    RelevanceScore = message.RelevanceScore
+                })
+                .ToList();
+
+            IReadOnlyList<ContextMessage> snapshot = ordered;
+            return Task.FromResult(snapshot);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- introduce a Teams Graph client abstraction with a default Microsoft Graph implementation and register it in the plugin
- refactor the context retrieval service to use the new client, add memory-cached message snapshots, and tighten filtering/truncation controls
- harden the translation pipeline against context retrieval failures and expand the test suite with Graph-focused integration coverage

## Testing
- dotnet test *(fails: `dotnet` not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1277bc34832fb4c891f591a5cedc