### PR TITLE
Add background replay for offline drafts

### DIFF
--- a/src/TlaPlugin/Models/OfflineDraftRecord.cs
+++ b/src/TlaPlugin/Models/OfflineDraftRecord.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace TlaPlugin.Models;
 
 /// <summary>
@@ -14,4 +16,20 @@ public class OfflineDraftRecord
     public DateTimeOffset CreatedAt { get; set; }
         = DateTimeOffset.UtcNow;
     public string Status { get; set; } = "PENDING";
+    public string? ResultText { get; set; }
+        = null;
+    public string? ErrorReason { get; set; }
+        = null;
+    public int Attempts { get; set; }
+        = 0;
+    public DateTimeOffset? CompletedAt { get; set; }
+        = null;
+}
+
+public static class OfflineDraftStatus
+{
+    public const string Pending = "PENDING";
+    public const string Processing = "PROCESSING";
+    public const string Completed = "COMPLETED";
+    public const string Failed = "FAILED";
 }

--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -55,7 +55,7 @@ builder.Services.AddSingleton<UsageMetricsService>();
 builder.Services.AddSingleton<LocalizationCatalogService>();
 builder.Services.AddSingleton<ContextRetrievalService>();
 builder.Services.AddSingleton<TranslationRouter>();
-builder.Services.AddSingleton<TranslationPipeline>();
+builder.Services.AddSingleton<ITranslationPipeline, TranslationPipeline>();
 builder.Services.AddSingleton<MessageExtensionHandler>();
 builder.Services.AddSingleton<ConfigurationSummaryService>();
 builder.Services.AddSingleton<ProjectStatusService>();
@@ -65,6 +65,7 @@ builder.Services.AddSingleton<RewriteService>();
 builder.Services.AddSingleton<CostEstimatorService>();
 builder.Services.AddSingleton<McpToolRegistry>();
 builder.Services.AddSingleton<McpServer>();
+builder.Services.AddHostedService<DraftReplayService>();
 
 var app = builder.Build();
 

--- a/src/TlaPlugin/Services/DraftReplayService.cs
+++ b/src/TlaPlugin/Services/DraftReplayService.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// 背景任务，用于重新执行离线草稿的翻译请求。
+/// </summary>
+public class DraftReplayService : BackgroundService
+{
+    private const int MaxBatchSize = 10;
+    private readonly OfflineDraftStore _store;
+    private readonly ITranslationPipeline _pipeline;
+    private readonly ILogger<DraftReplayService> _logger;
+    private readonly TimeSpan _pollingInterval;
+    private readonly int _maxAttempts;
+
+    public DraftReplayService(
+        OfflineDraftStore store,
+        ITranslationPipeline pipeline,
+        ILogger<DraftReplayService> logger)
+    {
+        _store = store;
+        _pipeline = pipeline;
+        _logger = logger;
+        _pollingInterval = TimeSpan.FromSeconds(3);
+        _maxAttempts = 3;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var processedAny = false;
+            try
+            {
+                processedAny = await ProcessPendingDraftsAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error while replaying offline drafts.");
+            }
+
+            if (!processedAny)
+            {
+                try
+                {
+                    await Task.Delay(_pollingInterval, stoppingToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    public async Task<bool> ProcessPendingDraftsAsync(CancellationToken cancellationToken)
+    {
+        var pending = _store.GetPendingDrafts(MaxBatchSize);
+        if (pending.Count == 0)
+        {
+            _store.Cleanup();
+            return false;
+        }
+
+        var processed = false;
+        foreach (var draft in pending)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var attempts = _store.BeginProcessing(draft.Id);
+            try
+            {
+                var request = new TranslationRequest
+                {
+                    Text = draft.OriginalText,
+                    TargetLanguage = draft.TargetLanguage,
+                    TenantId = draft.TenantId,
+                    UserId = draft.UserId
+                };
+
+                var result = await _pipeline.TranslateAsync(request, cancellationToken).ConfigureAwait(false);
+                if (result.Translation is { } translation)
+                {
+                    _store.MarkCompleted(draft.Id, translation.TranslatedText);
+                }
+                else if (result.RequiresLanguageSelection)
+                {
+                    _store.MarkFailed(draft.Id, "Language confirmation required.", finalFailure: true);
+                }
+                else if (result.RequiresGlossaryResolution)
+                {
+                    _store.MarkFailed(draft.Id, "Glossary decision required.", finalFailure: true);
+                }
+                else
+                {
+                    var final = attempts >= _maxAttempts;
+                    _store.MarkFailed(draft.Id, "Translation pipeline did not return a result.", final);
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                var final = attempts >= _maxAttempts;
+                _store.MarkFailed(draft.Id, ex.Message, final);
+                if (final)
+                {
+                    _logger.LogError(ex, "Failed to replay draft {DraftId} after {Attempts} attempts.", draft.Id, attempts);
+                }
+                else
+                {
+                    _logger.LogWarning(ex, "Failed to replay draft {DraftId}. Will retry.", draft.Id);
+                }
+            }
+
+            processed = true;
+        }
+
+        _store.Cleanup();
+        return processed;
+    }
+}

--- a/src/TlaPlugin/Services/ITranslationPipeline.cs
+++ b/src/TlaPlugin/Services/ITranslationPipeline.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+public interface ITranslationPipeline
+{
+    Task<DetectionResult> DetectAsync(LanguageDetectionRequest request, CancellationToken cancellationToken);
+    Task<PipelineExecutionResult> TranslateAsync(TranslationRequest request, CancellationToken cancellationToken);
+    Task<PipelineExecutionResult> TranslateAsync(TranslationRequest request, DetectionResult? detection, CancellationToken cancellationToken);
+    OfflineDraftRecord SaveDraft(OfflineDraftRequest request);
+    OfflineDraftRecord MarkDraftProcessing(long draftId);
+    Task<RewriteResult> RewriteAsync(RewriteRequest request, CancellationToken cancellationToken);
+    Task<ReplyResult> PostReplyAsync(ReplyRequest request, CancellationToken cancellationToken);
+    Task<ReplyResult> PostReplyAsync(ReplyRequest request, string finalText, string? toneApplied, CancellationToken cancellationToken);
+}

--- a/src/TlaPlugin/Services/McpServer.cs
+++ b/src/TlaPlugin/Services/McpServer.cs
@@ -21,14 +21,14 @@ public class McpServer
 
     private readonly McpToolRegistry _registry;
     private readonly MessageExtensionHandler _messageExtension;
-    private readonly TranslationPipeline _pipeline;
+    private readonly ITranslationPipeline _pipeline;
     private readonly GlossaryService _glossary;
     private readonly ReplyService _replyService;
 
     public McpServer(
         McpToolRegistry registry,
         MessageExtensionHandler messageExtension,
-        TranslationPipeline pipeline,
+        ITranslationPipeline pipeline,
         GlossaryService glossary,
         ReplyService replyService)
     {

--- a/src/TlaPlugin/Services/OfflineDraftStore.cs
+++ b/src/TlaPlugin/Services/OfflineDraftStore.cs
@@ -12,6 +12,7 @@ namespace TlaPlugin.Services;
 /// </summary>
 public class OfflineDraftStore
 {
+    private const string SelectColumns = "Id, UserId, TenantId, OriginalText, TargetLanguage, CreatedAt, Status, ResultText, ErrorReason, Attempts, CompletedAt";
     private readonly PluginOptions _options;
 
     public OfflineDraftStore(IOptions<PluginOptions>? options = null)
@@ -26,14 +27,15 @@ public class OfflineDraftStore
         connection.Open();
         using var command = connection.CreateCommand();
         command.CommandText =
-            @"INSERT INTO Drafts(UserId, TenantId, OriginalText, TargetLanguage, CreatedAt, Status)
-              VALUES ($userId, $tenantId, $text, $target, $createdAt, 'PENDING');
+            @"INSERT INTO Drafts(UserId, TenantId, OriginalText, TargetLanguage, CreatedAt, Status, ResultText, ErrorReason, Attempts, CompletedAt)
+              VALUES ($userId, $tenantId, $text, $target, $createdAt, $status, NULL, NULL, 0, NULL);
               SELECT last_insert_rowid();";
         command.Parameters.AddWithValue("$userId", request.UserId);
         command.Parameters.AddWithValue("$tenantId", request.TenantId);
         command.Parameters.AddWithValue("$text", request.OriginalText);
         command.Parameters.AddWithValue("$target", request.TargetLanguage);
         command.Parameters.AddWithValue("$createdAt", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("$status", OfflineDraftStatus.Pending);
 
         var id = (long)(command.ExecuteScalar() ?? 0);
         return new OfflineDraftRecord
@@ -44,8 +46,111 @@ public class OfflineDraftStore
             OriginalText = request.OriginalText,
             TargetLanguage = request.TargetLanguage,
             CreatedAt = DateTimeOffset.UtcNow,
-            Status = "PENDING"
+            Status = OfflineDraftStatus.Pending,
+            Attempts = 0
         };
+    }
+
+    public OfflineDraftRecord MarkProcessing(long id)
+    {
+        using var connection = new SqliteConnection(_options.OfflineDraftConnectionString);
+        connection.Open();
+        using var transaction = connection.BeginTransaction();
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "UPDATE Drafts SET Status = $status, ErrorReason = NULL WHERE Id = $id";
+            command.Parameters.AddWithValue("$status", OfflineDraftStatus.Processing);
+            command.Parameters.AddWithValue("$id", id);
+            command.ExecuteNonQuery();
+        }
+
+        var record = GetDraftById(connection, id, transaction);
+        transaction.Commit();
+        return record;
+    }
+
+    public int BeginProcessing(long id)
+    {
+        using var connection = new SqliteConnection(_options.OfflineDraftConnectionString);
+        connection.Open();
+        using var transaction = connection.BeginTransaction();
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = @"UPDATE Drafts
+SET Status = $status,
+    Attempts = Attempts + 1,
+    ErrorReason = NULL,
+    ResultText = NULL,
+    CompletedAt = NULL
+WHERE Id = $id";
+            command.Parameters.AddWithValue("$status", OfflineDraftStatus.Processing);
+            command.Parameters.AddWithValue("$id", id);
+            command.ExecuteNonQuery();
+        }
+
+        int attempts;
+        using (var select = connection.CreateCommand())
+        {
+            select.Transaction = transaction;
+            select.CommandText = "SELECT Attempts FROM Drafts WHERE Id = $id";
+            select.Parameters.AddWithValue("$id", id);
+            attempts = Convert.ToInt32(select.ExecuteScalar());
+        }
+
+        transaction.Commit();
+        return attempts;
+    }
+
+    public void MarkCompleted(long id, string translatedText)
+    {
+        using var connection = new SqliteConnection(_options.OfflineDraftConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"UPDATE Drafts
+SET Status = $status,
+    ResultText = $result,
+    ErrorReason = NULL,
+    CompletedAt = $completedAt
+WHERE Id = $id";
+        command.Parameters.AddWithValue("$status", OfflineDraftStatus.Completed);
+        command.Parameters.AddWithValue("$result", translatedText);
+        command.Parameters.AddWithValue("$completedAt", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        command.Parameters.AddWithValue("$id", id);
+        command.ExecuteNonQuery();
+    }
+
+    public void MarkFailed(long id, string errorReason, bool finalFailure)
+    {
+        using var connection = new SqliteConnection(_options.OfflineDraftConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        if (finalFailure)
+        {
+            command.CommandText = @"UPDATE Drafts
+SET Status = $failedStatus,
+    ErrorReason = $reason,
+    ResultText = NULL,
+    CompletedAt = $completedAt
+WHERE Id = $id";
+            command.Parameters.AddWithValue("$failedStatus", OfflineDraftStatus.Failed);
+            command.Parameters.AddWithValue("$completedAt", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        }
+        else
+        {
+            command.CommandText = @"UPDATE Drafts
+SET Status = $pendingStatus,
+    ErrorReason = $reason,
+    ResultText = NULL,
+    CompletedAt = NULL
+WHERE Id = $id";
+            command.Parameters.AddWithValue("$pendingStatus", OfflineDraftStatus.Pending);
+        }
+
+        command.Parameters.AddWithValue("$reason", errorReason);
+        command.Parameters.AddWithValue("$id", id);
+        command.ExecuteNonQuery();
     }
 
     public IReadOnlyList<OfflineDraftRecord> ListDrafts(string userId)
@@ -54,21 +159,30 @@ public class OfflineDraftStore
         using var connection = new SqliteConnection(_options.OfflineDraftConnectionString);
         connection.Open();
         using var command = connection.CreateCommand();
-        command.CommandText = "SELECT Id, UserId, TenantId, OriginalText, TargetLanguage, CreatedAt, Status FROM Drafts WHERE UserId = $user";
+        command.CommandText = $"SELECT {SelectColumns} FROM Drafts WHERE UserId = $user";
         command.Parameters.AddWithValue("$user", userId);
         using var reader = command.ExecuteReader();
         while (reader.Read())
         {
-            results.Add(new OfflineDraftRecord
-            {
-                Id = reader.GetInt64(0),
-                UserId = reader.GetString(1),
-                TenantId = reader.GetString(2),
-                OriginalText = reader.GetString(3),
-                TargetLanguage = reader.GetString(4),
-                CreatedAt = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64(5)),
-                Status = reader.GetString(6)
-            });
+            results.Add(ReadRecord(reader));
+        }
+        return results;
+    }
+
+    public IReadOnlyList<OfflineDraftRecord> GetPendingDrafts(int maxCount)
+    {
+        var results = new List<OfflineDraftRecord>();
+        using var connection = new SqliteConnection(_options.OfflineDraftConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT {SelectColumns} FROM Drafts WHERE Status IN ($pending, $processing) AND CompletedAt IS NULL ORDER BY CreatedAt LIMIT $limit";
+        command.Parameters.AddWithValue("$pending", OfflineDraftStatus.Pending);
+        command.Parameters.AddWithValue("$processing", OfflineDraftStatus.Processing);
+        command.Parameters.AddWithValue("$limit", maxCount);
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            results.Add(ReadRecord(reader));
         }
         return results;
     }
@@ -88,17 +202,75 @@ public class OfflineDraftStore
     {
         using var connection = new SqliteConnection(_options.OfflineDraftConnectionString);
         connection.Open();
-        using var command = connection.CreateCommand();
-        command.CommandText =
-            @"CREATE TABLE IF NOT EXISTS Drafts (
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText =
+                @"CREATE TABLE IF NOT EXISTS Drafts (
                 Id INTEGER PRIMARY KEY AUTOINCREMENT,
                 UserId TEXT NOT NULL,
                 TenantId TEXT NOT NULL,
                 OriginalText TEXT NOT NULL,
                 TargetLanguage TEXT NOT NULL,
                 CreatedAt INTEGER NOT NULL,
-                Status TEXT NOT NULL
+                Status TEXT NOT NULL,
+                ResultText TEXT,
+                ErrorReason TEXT,
+                Attempts INTEGER NOT NULL DEFAULT 0,
+                CompletedAt INTEGER
             );";
-        command.ExecuteNonQuery();
+            command.ExecuteNonQuery();
+        }
+
+        EnsureColumn(connection, "ResultText", "TEXT");
+        EnsureColumn(connection, "ErrorReason", "TEXT");
+        EnsureColumn(connection, "Attempts", "INTEGER NOT NULL DEFAULT 0");
+        EnsureColumn(connection, "CompletedAt", "INTEGER");
+    }
+
+    private static void EnsureColumn(SqliteConnection connection, string columnName, string definition)
+    {
+        using var check = connection.CreateCommand();
+        check.CommandText = "SELECT 1 FROM pragma_table_info('Drafts') WHERE name = $name";
+        check.Parameters.AddWithValue("$name", columnName);
+        var exists = check.ExecuteScalar();
+        if (exists is null)
+        {
+            using var alter = connection.CreateCommand();
+            alter.CommandText = $"ALTER TABLE Drafts ADD COLUMN {columnName} {definition}";
+            alter.ExecuteNonQuery();
+        }
+    }
+
+    private static OfflineDraftRecord GetDraftById(SqliteConnection connection, long id, SqliteTransaction? transaction)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = $"SELECT {SelectColumns} FROM Drafts WHERE Id = $id";
+        command.Parameters.AddWithValue("$id", id);
+        using var reader = command.ExecuteReader();
+        if (!reader.Read())
+        {
+            throw new InvalidOperationException($"Draft {id} does not exist.");
+        }
+
+        return ReadRecord(reader);
+    }
+
+    private static OfflineDraftRecord ReadRecord(SqliteDataReader reader)
+    {
+        return new OfflineDraftRecord
+        {
+            Id = reader.GetInt64(0),
+            UserId = reader.GetString(1),
+            TenantId = reader.GetString(2),
+            OriginalText = reader.GetString(3),
+            TargetLanguage = reader.GetString(4),
+            CreatedAt = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64(5)),
+            Status = reader.GetString(6),
+            ResultText = reader.IsDBNull(7) ? null : reader.GetString(7),
+            ErrorReason = reader.IsDBNull(8) ? null : reader.GetString(8),
+            Attempts = reader.IsDBNull(9) ? 0 : reader.GetInt32(9),
+            CompletedAt = reader.IsDBNull(10) ? null : DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64(10))
+        };
     }
 }

--- a/src/TlaPlugin/Services/TranslationPipeline.cs
+++ b/src/TlaPlugin/Services/TranslationPipeline.cs
@@ -12,7 +12,7 @@ namespace TlaPlugin.Services;
 /// <summary>
 /// 翻訳フローを編成し Teams 応答を生成するパイプライン。
 /// </summary>
-public class TranslationPipeline
+public class TranslationPipeline : ITranslationPipeline
 {
     private readonly TranslationRouter _router;
     private readonly GlossaryService _glossary;
@@ -317,6 +317,11 @@ public class TranslationPipeline
     public OfflineDraftRecord SaveDraft(OfflineDraftRequest request)
     {
         return _drafts.SaveDraft(request);
+    }
+
+    public OfflineDraftRecord MarkDraftProcessing(long draftId)
+    {
+        return _drafts.MarkProcessing(draftId);
     }
 
     public Task<RewriteResult> RewriteAsync(RewriteRequest request, CancellationToken cancellationToken)

--- a/src/TlaPlugin/Teams/MessageExtensionHandler.cs
+++ b/src/TlaPlugin/Teams/MessageExtensionHandler.cs
@@ -19,11 +19,11 @@ namespace TlaPlugin.Teams;
 /// </summary>
 public class MessageExtensionHandler
 {
-    private readonly TranslationPipeline _pipeline;
+    private readonly ITranslationPipeline _pipeline;
     private readonly LocalizationCatalogService _localization;
     private readonly PluginOptions _options;
 
-    public MessageExtensionHandler(TranslationPipeline pipeline, LocalizationCatalogService localization, IOptions<PluginOptions>? options = null)
+    public MessageExtensionHandler(ITranslationPipeline pipeline, LocalizationCatalogService localization, IOptions<PluginOptions>? options = null)
     {
         _pipeline = pipeline;
         _localization = localization;
@@ -99,12 +99,17 @@ public class MessageExtensionHandler
     public Task<JsonObject> HandleOfflineDraftAsync(OfflineDraftRequest request)
     {
         var record = _pipeline.SaveDraft(request);
+        record = _pipeline.MarkDraftProcessing(record.Id);
         return Task.FromResult(new JsonObject
         {
             ["type"] = "offlineDraftSaved",
             ["draftId"] = record.Id,
             ["status"] = record.Status,
-            ["createdAt"] = record.CreatedAt.ToString("O")
+            ["createdAt"] = record.CreatedAt.ToString("O"),
+            ["attempts"] = record.Attempts,
+            ["resultText"] = JsonValue.Create(record.ResultText),
+            ["errorReason"] = JsonValue.Create(record.ErrorReason),
+            ["completedAt"] = record.CompletedAt.HasValue ? record.CompletedAt.Value.ToString("O") : null
         });
     }
 

--- a/tests/TlaPlugin.Tests/ApiEndpointsTests.cs
+++ b/tests/TlaPlugin.Tests/ApiEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -271,6 +272,7 @@ public class ApiEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.NotNull(saved);
         Assert.Equal("offlineDraftSaved", saved!.Type);
         Assert.True(saved.DraftId > 0);
+        Assert.Equal(OfflineDraftStatus.Processing, saved.Status);
 
         var listRequest = new HttpRequestMessage(HttpMethod.Get, "/api/offline-draft?userId=user")
         {
@@ -281,6 +283,10 @@ public class ApiEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
         var list = await listResponse.Content.ReadFromJsonAsync<OfflineDraftListResponse>();
         Assert.NotNull(list);
         Assert.Contains(list!.Drafts, draft => draft.Id == saved.DraftId);
+        var stored = list!.Drafts.Single(draft => draft.Id == saved.DraftId);
+        Assert.Equal(OfflineDraftStatus.Processing, stored.Status);
+        Assert.Equal(0, stored.Attempts);
+        Assert.Null(stored.CompletedAt);
     }
 
     private sealed class GlossaryResponse

--- a/tests/TlaPlugin.Tests/DraftReplayServiceTests.cs
+++ b/tests/TlaPlugin.Tests/DraftReplayServiceTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class DraftReplayServiceTests
+{
+    [Fact]
+    public async Task ProcessesPendingDraftsAndStoresResult()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var options = Options.Create(new PluginOptions
+            {
+                OfflineDraftConnectionString = $"Data Source={dbPath}"
+            });
+
+            var store = new OfflineDraftStore(options);
+            var pipeline = new StubTranslationPipeline
+            {
+                TranslationFactory = request => PipelineExecutionResult.FromTranslation(new TranslationResult
+                {
+                    RawTranslatedText = request.Text,
+                    TranslatedText = $"{request.Text}-完成",
+                    SourceLanguage = "en",
+                    TargetLanguage = request.TargetLanguage
+                })
+            };
+
+            var service = new DraftReplayService(store, pipeline, NullLogger<DraftReplayService>.Instance);
+            var record = store.SaveDraft(new OfflineDraftRequest
+            {
+                OriginalText = "需要翻译",
+                TargetLanguage = "ja",
+                TenantId = "contoso",
+                UserId = "user"
+            });
+            store.MarkProcessing(record.Id);
+
+            await service.ProcessPendingDraftsAsync(CancellationToken.None);
+
+            var saved = Assert.Single(store.ListDrafts("user"));
+            Assert.Equal(OfflineDraftStatus.Completed, saved.Status);
+            Assert.Equal("需要翻译-完成", saved.ResultText);
+            Assert.NotNull(saved.CompletedAt);
+        }
+        finally
+        {
+            File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task RetriesUntilDraftFails()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var options = Options.Create(new PluginOptions
+            {
+                OfflineDraftConnectionString = $"Data Source={dbPath}"
+            });
+
+            var store = new OfflineDraftStore(options);
+            var pipeline = new StubTranslationPipeline
+            {
+                ExceptionFactory = attempt => new InvalidOperationException($"boom-{attempt}")
+            };
+
+            var service = new DraftReplayService(store, pipeline, NullLogger<DraftReplayService>.Instance);
+            var record = store.SaveDraft(new OfflineDraftRequest
+            {
+                OriginalText = "将失败",
+                TargetLanguage = "fr",
+                TenantId = "contoso",
+                UserId = "retry"
+            });
+            store.MarkProcessing(record.Id);
+
+            await service.ProcessPendingDraftsAsync(CancellationToken.None);
+            var first = Assert.Single(store.ListDrafts("retry"));
+            Assert.Equal(OfflineDraftStatus.Pending, first.Status);
+            Assert.Equal(1, first.Attempts);
+            Assert.Equal("boom-1", first.ErrorReason);
+
+            await service.ProcessPendingDraftsAsync(CancellationToken.None);
+            var second = Assert.Single(store.ListDrafts("retry"));
+            Assert.Equal(OfflineDraftStatus.Pending, second.Status);
+            Assert.Equal(2, second.Attempts);
+            Assert.Equal("boom-2", second.ErrorReason);
+
+            await service.ProcessPendingDraftsAsync(CancellationToken.None);
+            var failed = Assert.Single(store.ListDrafts("retry"));
+            Assert.Equal(OfflineDraftStatus.Failed, failed.Status);
+            Assert.Equal(3, failed.Attempts);
+            Assert.Equal("boom-3", failed.ErrorReason);
+            Assert.NotNull(failed.CompletedAt);
+        }
+        finally
+        {
+            File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task CleanupRemovesExpiredDrafts()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var options = Options.Create(new PluginOptions
+            {
+                OfflineDraftConnectionString = $"Data Source={dbPath}",
+                DraftRetention = TimeSpan.FromHours(1)
+            });
+
+            var store = new OfflineDraftStore(options);
+            var pipeline = new StubTranslationPipeline
+            {
+                TranslationFactory = request => PipelineExecutionResult.FromTranslation(new TranslationResult
+                {
+                    RawTranslatedText = request.Text,
+                    TranslatedText = request.Text,
+                    SourceLanguage = "en",
+                    TargetLanguage = request.TargetLanguage
+                })
+            };
+
+            var service = new DraftReplayService(store, pipeline, NullLogger<DraftReplayService>.Instance);
+            var record = store.SaveDraft(new OfflineDraftRequest
+            {
+                OriginalText = "已完成",
+                TargetLanguage = "de",
+                TenantId = "contoso",
+                UserId = "cleanup"
+            });
+            store.MarkProcessing(record.Id);
+            await service.ProcessPendingDraftsAsync(CancellationToken.None);
+
+            var completed = Assert.Single(store.ListDrafts("cleanup"));
+            Assert.Equal(OfflineDraftStatus.Completed, completed.Status);
+
+            // 使记录过期
+            using var connection = new SqliteConnection(options.Value.OfflineDraftConnectionString);
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "UPDATE Drafts SET CreatedAt = $createdAt WHERE Id = $id";
+            command.Parameters.AddWithValue("$createdAt", DateTimeOffset.UtcNow.AddHours(-2).ToUnixTimeSeconds());
+            command.Parameters.AddWithValue("$id", completed.Id);
+            command.ExecuteNonQuery();
+
+            await service.ProcessPendingDraftsAsync(CancellationToken.None);
+
+            Assert.Empty(store.ListDrafts("cleanup"));
+        }
+        finally
+        {
+            File.Delete(dbPath);
+        }
+    }
+
+    private sealed class StubTranslationPipeline : ITranslationPipeline
+    {
+        public Func<TranslationRequest, PipelineExecutionResult>? TranslationFactory { get; init; }
+        public Func<int, Exception>? ExceptionFactory { get; init; }
+        private int _callCount;
+
+        public Task<DetectionResult> DetectAsync(LanguageDetectionRequest request, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<PipelineExecutionResult> TranslateAsync(TranslationRequest request, CancellationToken cancellationToken)
+            => TranslateAsync(request, (DetectionResult?)null, cancellationToken);
+
+        public Task<PipelineExecutionResult> TranslateAsync(TranslationRequest request, DetectionResult? detection, CancellationToken cancellationToken)
+        {
+            _callCount++;
+            if (ExceptionFactory is not null)
+            {
+                throw ExceptionFactory(_callCount);
+            }
+
+            var factory = TranslationFactory ?? (_ => PipelineExecutionResult.FromTranslation(new TranslationResult
+            {
+                RawTranslatedText = request.Text,
+                TranslatedText = request.Text,
+                SourceLanguage = "en",
+                TargetLanguage = request.TargetLanguage
+            }));
+            return Task.FromResult(factory(request));
+        }
+
+        public OfflineDraftRecord SaveDraft(OfflineDraftRequest request)
+            => throw new NotImplementedException();
+
+        public OfflineDraftRecord MarkDraftProcessing(long draftId)
+            => throw new NotImplementedException();
+
+        public Task<RewriteResult> RewriteAsync(RewriteRequest request, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<ReplyResult> PostReplyAsync(ReplyRequest request, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<ReplyResult> PostReplyAsync(ReplyRequest request, string finalText, string? toneApplied, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+    }
+}

--- a/tests/TlaPlugin.Tests/OfflineDraftStoreTests.cs
+++ b/tests/TlaPlugin.Tests/OfflineDraftStoreTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Options;
 using TlaPlugin.Configuration;
 using TlaPlugin.Models;
@@ -14,26 +15,95 @@ public class OfflineDraftStoreTests
     public void PersistsDraftsToSqlite()
     {
         var dbPath = Path.GetTempFileName();
-        var options = Options.Create(new PluginOptions
+        try
         {
-            OfflineDraftConnectionString = $"Data Source={dbPath}",
-            DraftRetention = TimeSpan.FromDays(1)
-        });
+            var options = Options.Create(new PluginOptions
+            {
+                OfflineDraftConnectionString = $"Data Source={dbPath}",
+                DraftRetention = TimeSpan.FromDays(1)
+            });
 
-        var store = new OfflineDraftStore(options);
-        var record = store.SaveDraft(new OfflineDraftRequest
+            var store = new OfflineDraftStore(options);
+            var record = store.SaveDraft(new OfflineDraftRequest
+            {
+                OriginalText = "test",
+                TargetLanguage = "ja",
+                TenantId = "contoso",
+                UserId = "alice"
+            });
+
+            Assert.Equal(OfflineDraftStatus.Pending, record.Status);
+            Assert.Equal(0, record.Attempts);
+
+            var processing = store.MarkProcessing(record.Id);
+            Assert.Equal(OfflineDraftStatus.Processing, processing.Status);
+
+            var attempts = store.BeginProcessing(record.Id);
+            Assert.Equal(1, attempts);
+
+            store.MarkCompleted(record.Id, "完成翻译");
+
+            var drafts = store.ListDrafts("alice");
+            var saved = Assert.Single(drafts);
+            Assert.Equal("完成翻译", saved.ResultText);
+            Assert.Equal(OfflineDraftStatus.Completed, saved.Status);
+            Assert.NotNull(saved.CompletedAt);
+
+            using var connection = new SqliteConnection(options.Value.OfflineDraftConnectionString);
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "UPDATE Drafts SET CreatedAt = $createdAt WHERE Id = $id";
+            command.Parameters.AddWithValue("$createdAt", DateTimeOffset.UtcNow.AddDays(-2).ToUnixTimeSeconds());
+            command.Parameters.AddWithValue("$id", saved.Id);
+            command.ExecuteNonQuery();
+
+            store.Cleanup();
+            Assert.Empty(store.ListDrafts("alice"));
+        }
+        finally
         {
-            OriginalText = "test",
-            TargetLanguage = "ja",
-            TenantId = "contoso",
-            UserId = "alice"
-        });
+            File.Delete(dbPath);
+        }
+    }
 
-        Assert.True(record.Id > 0);
-        var drafts = store.ListDrafts("alice");
-        Assert.Single(drafts);
-        Assert.Equal("test", drafts[0].OriginalText);
+    [Fact]
+    public void MarkFailedTransitionsBetweenStates()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var options = Options.Create(new PluginOptions
+            {
+                OfflineDraftConnectionString = $"Data Source={dbPath}"
+            });
 
-        store.Cleanup();
+            var store = new OfflineDraftStore(options);
+            var record = store.SaveDraft(new OfflineDraftRequest
+            {
+                OriginalText = "需要重试",
+                TargetLanguage = "zh",
+                TenantId = "contoso",
+                UserId = "user"
+            });
+
+            store.MarkProcessing(record.Id);
+            store.BeginProcessing(record.Id);
+
+            store.MarkFailed(record.Id, "temporary", finalFailure: false);
+            var pending = Assert.Single(store.ListDrafts("user"));
+            Assert.Equal(OfflineDraftStatus.Pending, pending.Status);
+            Assert.Equal("temporary", pending.ErrorReason);
+            Assert.Null(pending.CompletedAt);
+
+            store.MarkFailed(record.Id, "permanent", finalFailure: true);
+            var failed = Assert.Single(store.ListDrafts("user"));
+            Assert.Equal(OfflineDraftStatus.Failed, failed.Status);
+            Assert.Equal("permanent", failed.ErrorReason);
+            Assert.NotNull(failed.CompletedAt);
+        }
+        finally
+        {
+            File.Delete(dbPath);
+        }
     }
 }

--- a/tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj
+++ b/tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.20" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.20" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- add a hosted DraftReplayService that replays queued offline drafts and records results or failures
- extend the offline draft schema and model to track attempts, completion timestamps, and error information
- update pipeline consumers to use a shared interface and expose the richer draft metadata via the API
- add integration tests for the draft replay workflow and enhanced draft store behavior

## Testing
- ⚠️ `dotnet test` *(not run: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7523260c832f8a13d8a123df9539