### PR TITLE
Implement token-aware Graph context retrieval

### DIFF
--- a/src/TlaPlugin/Models/ContextRetrievalModels.cs
+++ b/src/TlaPlugin/Models/ContextRetrievalModels.cs
@@ -9,6 +9,7 @@ namespace TlaPlugin.Models;
 public class ContextRetrievalRequest
 {
     public string TenantId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
     public string? ChannelId { get; set; }
         = null;
     public string? ThreadId { get; set; }

--- a/src/TlaPlugin/Services/BrokeredGraphAuthenticationProvider.cs
+++ b/src/TlaPlugin/Services/BrokeredGraphAuthenticationProvider.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Graph;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// Authentication provider that sources access tokens from the <see cref="ITokenBroker"/> using the ambient Graph context.
+/// </summary>
+public sealed class BrokeredGraphAuthenticationProvider : IAuthenticationProvider
+{
+    private readonly ITokenBroker _tokenBroker;
+    private readonly IGraphRequestContextAccessor _contextAccessor;
+
+    public BrokeredGraphAuthenticationProvider(ITokenBroker tokenBroker, IGraphRequestContextAccessor contextAccessor)
+    {
+        _tokenBroker = tokenBroker ?? throw new ArgumentNullException(nameof(tokenBroker));
+        _contextAccessor = contextAccessor ?? throw new ArgumentNullException(nameof(contextAccessor));
+    }
+
+    public async Task AuthenticateRequestAsync(
+        HttpRequestMessage request,
+        IDictionary<string, object>? additionalAuthenticationContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var context = _contextAccessor.Current
+            ?? throw new AuthenticationException("Graph request context is unavailable.");
+
+        var token = context.AccessToken;
+        if (token is null || token.ExpiresOn <= DateTimeOffset.UtcNow.AddMinutes(-1))
+        {
+            if (string.IsNullOrWhiteSpace(context.UserId))
+            {
+                throw new AuthenticationException("User context is required to authorize Graph requests.");
+            }
+
+            token = await _tokenBroker
+                .ExchangeOnBehalfOfAsync(context.TenantId, context.UserId, cancellationToken)
+                .ConfigureAwait(false);
+
+            context.UpdateToken(token);
+        }
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
+    }
+}

--- a/src/TlaPlugin/Services/GraphRequestContextAccessor.cs
+++ b/src/TlaPlugin/Services/GraphRequestContextAccessor.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// Maintains ambient Graph request context so authentication providers can access per-request tokens.
+/// </summary>
+public interface IGraphRequestContextAccessor
+{
+    GraphRequestContext? Current { get; }
+
+    IDisposable Push(GraphRequestContext context);
+}
+
+/// <summary>
+/// Default AsyncLocal-based implementation of <see cref="IGraphRequestContextAccessor"/>.
+/// </summary>
+public sealed class GraphRequestContextAccessor : IGraphRequestContextAccessor
+{
+    private readonly AsyncLocal<GraphRequestContext?> _current = new();
+
+    public GraphRequestContext? Current => _current.Value;
+
+    public IDisposable Push(GraphRequestContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var previous = _current.Value;
+        _current.Value = context;
+        return new Scope(this, previous);
+    }
+
+    private void Restore(GraphRequestContext? previous)
+    {
+        _current.Value = previous;
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private readonly GraphRequestContextAccessor _accessor;
+        private readonly GraphRequestContext? _previous;
+        private bool _disposed;
+
+        public Scope(GraphRequestContextAccessor accessor, GraphRequestContext? previous)
+        {
+            _accessor = accessor;
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _accessor.Restore(_previous);
+        }
+    }
+}
+
+/// <summary>
+/// Represents the context required to authorize Graph requests.
+/// </summary>
+public sealed class GraphRequestContext
+{
+    public GraphRequestContext(string tenantId, string? userId, AccessToken? accessToken)
+    {
+        TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
+        UserId = userId;
+        AccessToken = accessToken;
+    }
+
+    public string TenantId { get; }
+
+    public string? UserId { get; }
+
+    public AccessToken? AccessToken { get; private set; }
+
+    public void UpdateToken(AccessToken token)
+    {
+        AccessToken = token ?? throw new ArgumentNullException(nameof(token));
+    }
+}

--- a/src/TlaPlugin/Services/ITeamsMessageClient.cs
+++ b/src/TlaPlugin/Services/ITeamsMessageClient.cs
@@ -25,4 +25,24 @@ public interface ITeamsMessageClient
         string? threadId,
         int maxMessages,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 获取并允许自定义访问令牌的重载。
+    /// </summary>
+    /// <param name="tenantId">目标团队或租户标识。</param>
+    /// <param name="channelId">频道标识。</param>
+    /// <param name="threadId">线程标识。</param>
+    /// <param name="maxMessages">最大返回消息数量。</param>
+    /// <param name="accessToken">Graph 访问令牌。</param>
+    /// <param name="userId">与令牌关联的用户标识。</param>
+    /// <param name="cancellationToken">取消标记。</param>
+    Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
+        string tenantId,
+        string? channelId,
+        string? threadId,
+        int maxMessages,
+        AccessToken? accessToken,
+        string? userId,
+        CancellationToken cancellationToken)
+        => GetRecentMessagesAsync(tenantId, channelId, threadId, maxMessages, cancellationToken);
 }

--- a/src/TlaPlugin/Services/TranslationPipeline.cs
+++ b/src/TlaPlugin/Services/TranslationPipeline.cs
@@ -217,6 +217,7 @@ public class TranslationPipeline
             retrieval = await _contextRetrieval.GetContextAsync(new ContextRetrievalRequest
             {
                 TenantId = request.TenantId,
+                UserId = request.UserId,
                 ChannelId = request.ChannelId,
                 ThreadId = request.ChannelId,
                 MaxMessages = _options.Rag.MaxMessages,

--- a/tests/TlaPlugin.Tests/ContextRetrievalIntegrationTests.cs
+++ b/tests/TlaPlugin.Tests/ContextRetrievalIntegrationTests.cs
@@ -133,22 +133,100 @@ public class ContextRetrievalIntegrationTests
         Assert.Equal(1, graph.CallCount);
     }
 
+    [Fact]
+    public async Task RetrievesMessagesWithValidToken()
+    {
+        var options = CreateOptions();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var token = new AccessToken("valid-token", DateTimeOffset.UtcNow.AddMinutes(5), "api://audience");
+        var broker = new RecordingTokenBroker(token);
+        var graph = new TokenAwareTeamsMessageClient();
+        graph.Messages.Add(new ContextMessage
+        {
+            Author = "Alex",
+            Text = "Budget approval pending",
+            Timestamp = DateTimeOffset.UtcNow
+        });
+
+        var service = new ContextRetrievalService(graph, cache, broker, options);
+
+        var result = await service.GetContextAsync(new ContextRetrievalRequest
+        {
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "general",
+            MaxMessages = 3
+        }, CancellationToken.None);
+
+        Assert.True(result.HasContext);
+        Assert.Equal("valid-token", graph.LastAccessToken?.Value);
+        Assert.Equal("user", graph.LastUserId);
+        Assert.Equal(1, broker.CallCount);
+    }
+
+    [Fact]
+    public async Task ReturnsEmptyWhenTokenExpired()
+    {
+        var options = CreateOptions();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var broker = new RecordingTokenBroker(new AccessToken("expired", DateTimeOffset.UtcNow.AddMinutes(-5), "aud"));
+        var graph = new TokenAwareTeamsMessageClient { TreatExpiredAsUnauthorized = true };
+
+        var service = new ContextRetrievalService(graph, cache, broker, options);
+
+        var result = await service.GetContextAsync(new ContextRetrievalRequest
+        {
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "general",
+            MaxMessages = 3
+        }, CancellationToken.None);
+
+        Assert.False(result.HasContext);
+        Assert.Equal(1, graph.UnauthorizedCount);
+        Assert.Equal(1, broker.CallCount);
+    }
+
+    [Fact]
+    public async Task ReturnsEmptyWhenAccessDenied()
+    {
+        var options = CreateOptions();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var broker = new RecordingTokenBroker(new AccessToken("valid", DateTimeOffset.UtcNow.AddMinutes(5), "aud"));
+        var graph = new TokenAwareTeamsMessageClient { SimulateForbidden = true };
+
+        var service = new ContextRetrievalService(graph, cache, broker, options);
+
+        var result = await service.GetContextAsync(new ContextRetrievalRequest
+        {
+            TenantId = "contoso",
+            UserId = "user",
+            ChannelId = "general",
+            MaxMessages = 3
+        }, CancellationToken.None);
+
+        Assert.False(result.HasContext);
+        Assert.Equal(1, graph.ForbiddenCount);
+        Assert.Equal(1, broker.CallCount);
+    }
+
     private static TranslationPipeline BuildPipeline(IOptions<PluginOptions> options, ITeamsMessageClient graph, IMemoryCache cache)
     {
         var glossary = new GlossaryService();
         var localization = new LocalizationCatalogService();
+        var tokenBroker = new TokenBroker(new KeyVaultSecretResolver(options), options);
         var router = new TranslationRouter(
             new ModelProviderFactory(options),
             new ComplianceGateway(options),
             new BudgetGuard(options.Value),
             new AuditLogger(),
             new ToneTemplateService(),
-            new TokenBroker(new KeyVaultSecretResolver(options), options),
+            tokenBroker,
             new UsageMetricsService(),
             localization,
             options);
 
-        var context = new ContextRetrievalService(graph, cache, options);
+        var context = new ContextRetrievalService(graph, cache, tokenBroker, options);
         var cacheStore = new TranslationCache(options);
         var throttle = new TranslationThrottle(options);
         var rewrite = new RewriteService(router, throttle);
@@ -205,6 +283,8 @@ public class ContextRetrievalIntegrationTests
         public List<ContextMessage> Messages { get; } = new();
         public int CallCount { get; private set; }
         public bool ShouldThrow { get; set; }
+        public AccessToken? LastToken { get; private set; }
+        public string? LastUserId { get; private set; }
 
         public Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
             string tenantId,
@@ -234,6 +314,103 @@ public class ContextRetrievalIntegrationTests
 
             IReadOnlyList<ContextMessage> snapshot = ordered;
             return Task.FromResult(snapshot);
+        }
+
+        public Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
+            string tenantId,
+            string? channelId,
+            string? threadId,
+            int maxMessages,
+            AccessToken? accessToken,
+            string? userId,
+            CancellationToken cancellationToken)
+        {
+            LastToken = accessToken;
+            LastUserId = userId;
+            return GetRecentMessagesAsync(tenantId, channelId, threadId, maxMessages, cancellationToken);
+        }
+    }
+
+    private sealed class TokenAwareTeamsMessageClient : ITeamsMessageClient
+    {
+        public List<ContextMessage> Messages { get; } = new();
+        public AccessToken? LastAccessToken { get; private set; }
+        public string? LastUserId { get; private set; }
+        public bool TreatExpiredAsUnauthorized { get; set; }
+        public bool SimulateForbidden { get; set; }
+        public int UnauthorizedCount { get; private set; }
+        public int ForbiddenCount { get; private set; }
+
+        public Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
+            string tenantId,
+            string? channelId,
+            string? threadId,
+            int maxMessages,
+            CancellationToken cancellationToken)
+        {
+            return GetRecentMessagesAsync(tenantId, channelId, threadId, maxMessages, null, null, cancellationToken);
+        }
+
+        public Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
+            string tenantId,
+            string? channelId,
+            string? threadId,
+            int maxMessages,
+            AccessToken? accessToken,
+            string? userId,
+            CancellationToken cancellationToken)
+        {
+            LastAccessToken = accessToken;
+            LastUserId = userId;
+
+            if (TreatExpiredAsUnauthorized && accessToken is not null && accessToken.ExpiresOn <= DateTimeOffset.UtcNow)
+            {
+                UnauthorizedCount++;
+                return Task.FromResult<IReadOnlyList<ContextMessage>>(Array.Empty<ContextMessage>());
+            }
+
+            if (SimulateForbidden)
+            {
+                ForbiddenCount++;
+                return Task.FromResult<IReadOnlyList<ContextMessage>>(Array.Empty<ContextMessage>());
+            }
+
+            IReadOnlyList<ContextMessage> snapshot = Messages
+                .OrderByDescending(message => message.Timestamp)
+                .Take(Math.Max(1, maxMessages))
+                .ToList();
+
+            return Task.FromResult(snapshot);
+        }
+    }
+
+    private sealed class RecordingTokenBroker : ITokenBroker
+    {
+        private readonly List<AccessToken> _tokens;
+        private int _index;
+
+        public RecordingTokenBroker(params AccessToken[] tokens)
+        {
+            if (tokens is null || tokens.Length == 0)
+            {
+                throw new ArgumentException("At least one token must be provided.", nameof(tokens));
+            }
+
+            _tokens = new List<AccessToken>(tokens);
+        }
+
+        public int CallCount { get; private set; }
+
+        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            var token = _tokens[Math.Min(_index, _tokens.Count - 1)];
+            if (_index < _tokens.Count - 1)
+            {
+                _index++;
+            }
+
+            return Task.FromResult(token);
         }
     }
 }

--- a/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
+++ b/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
@@ -476,7 +476,7 @@ public class MessageExtensionHandlerTests
         var throttle = new TranslationThrottle(options);
         var rewrite = new RewriteService(router, throttle);
         var reply = new ReplyService(rewrite, options);
-        var context = contextOverride ?? new ContextRetrievalService(new NullTeamsMessageClient(), new MemoryCache(new MemoryCacheOptions()), options);
+        var context = contextOverride ?? new ContextRetrievalService(new NullTeamsMessageClient(), new MemoryCache(new MemoryCacheOptions()), tokenBroker, options);
         var pipeline = new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, context, rewrite, reply, options);
         return new MessageExtensionHandler(pipeline, localization, options);
     }

--- a/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
@@ -967,7 +967,7 @@ public class TranslationPipelineTests
         var rewrite = new RewriteService(router, throttle);
         var reply = new ReplyService(rewrite, new NoopTeamsReplyClient(), tokenBroker, metrics, options);
 
-        var context = new ContextRetrievalService(new NullTeamsMessageClient(), new MemoryCache(new MemoryCacheOptions()), options);
+        var context = new ContextRetrievalService(new NullTeamsMessageClient(), new MemoryCache(new MemoryCacheOptions()), tokenBroker, options);
 
         var pipeline = new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, context, rewrite, reply, options);
 
@@ -1003,7 +1003,7 @@ public class TranslationPipelineTests
         var throttle = new TranslationThrottle(options);
         var rewrite = new RewriteService(router, throttle);
         var reply = new ReplyService(rewrite, options);
-        var context = contextOverride ?? new ContextRetrievalService(teamsClient ?? new NullTeamsMessageClient(), memoryCache ?? new MemoryCache(new MemoryCacheOptions()), options);
+        var context = contextOverride ?? new ContextRetrievalService(teamsClient ?? new NullTeamsMessageClient(), memoryCache ?? new MemoryCache(new MemoryCacheOptions()), tokenBroker, options);
         return new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, context, rewrite, reply, options);
     }
 


### PR DESCRIPTION
## Summary
- replace the anonymous Graph authentication setup with a broker-backed provider and AsyncLocal request context accessors
- update context retrieval and Graph Teams client to request per-user tokens, propagate them on each call, and gracefully handle authorization failures
- extend integration coverage for token expiry and access errors while updating helpers to supply the shared token broker

## Testing
- dotnet test *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7521f504832fb39bc340114fcf16