### PR TITLE
Add metadata endpoint and client fallback coverage

### DIFF
--- a/src/TlaPlugin/Models/MetadataResponse.cs
+++ b/src/TlaPlugin/Models/MetadataResponse.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+
+namespace TlaPlugin.Models;
+
+/// <summary>
+/// Aggregated metadata exposed to the Teams front-end.
+/// </summary>
+public record MetadataResponse(
+    IReadOnlyList<ModelMetadata> Models,
+    IReadOnlyList<LanguageMetadata> Languages,
+    MetadataFeatureFlags Features,
+    MetadataPricing Pricing);
+
+/// <summary>
+/// Model summary exposed to the front-end.
+/// </summary>
+public record ModelMetadata(
+    string Id,
+    string DisplayName,
+    decimal CostPerCharUsd,
+    int LatencyTargetMs);
+
+/// <summary>
+/// Language metadata describing supported target languages.
+/// </summary>
+public record LanguageMetadata(
+    string Id,
+    string Name,
+    bool IsDefault);
+
+/// <summary>
+/// Feature toggles that enable or disable optional UX flows.
+/// </summary>
+public record MetadataFeatureFlags(
+    bool TerminologyToggle,
+    bool OfflineDraft,
+    bool ToneToggle,
+    bool Rag);
+
+/// <summary>
+/// Pricing details for cost estimation UI.
+/// </summary>
+public record MetadataPricing(
+    string Currency,
+    decimal DailyBudgetUsd);

--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -65,6 +65,7 @@ builder.Services.AddSingleton<RewriteService>();
 builder.Services.AddSingleton<CostEstimatorService>();
 builder.Services.AddSingleton<McpToolRegistry>();
 builder.Services.AddSingleton<McpServer>();
+builder.Services.AddSingleton<MetadataService>();
 
 var app = builder.Build();
 
@@ -295,6 +296,12 @@ app.MapPost("/api/reply", async (ReplyRequest request, ReplyService service, Can
     {
         return Results.BadRequest(new { error = ex.Message });
     }
+});
+
+app.MapGet("/api/metadata", (MetadataService metadataService) =>
+{
+    var metadata = metadataService.CreateMetadata();
+    return Results.Json(metadata, options: jsonOptions);
 });
 
 app.MapGet("/api/cost-latency", (int payloadSize, string modelId, CostEstimatorService estimator) =>

--- a/src/TlaPlugin/Services/MetadataService.cs
+++ b/src/TlaPlugin/Services/MetadataService.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// Builds the metadata payload consumed by the Teams front-end.
+/// </summary>
+public class MetadataService
+{
+    private readonly IOptions<PluginOptions> _options;
+    private readonly LocalizationCatalogService _localization;
+    private readonly ToneTemplateService _tones;
+    private readonly GlossaryService _glossary;
+
+    public MetadataService(
+        IOptions<PluginOptions> options,
+        LocalizationCatalogService localization,
+        ToneTemplateService tones,
+        GlossaryService glossary)
+    {
+        _options = options;
+        _localization = localization;
+        _tones = tones;
+        _glossary = glossary;
+    }
+
+    /// <summary>
+    /// Creates the metadata response sent to the client.
+    /// </summary>
+    public MetadataResponse CreateMetadata()
+    {
+        var options = _options.Value;
+        var models = BuildModelMetadata(options);
+        var languages = BuildLanguageMetadata(options);
+        var features = BuildFeatureFlags(options);
+        var pricing = new MetadataPricing("USD", options.DailyBudgetUsd);
+
+        return new MetadataResponse(models, languages, features, pricing);
+    }
+
+    private IReadOnlyList<ModelMetadata> BuildModelMetadata(PluginOptions options)
+    {
+        if (options.Providers is null || options.Providers.Count == 0)
+        {
+            return Array.Empty<ModelMetadata>();
+        }
+
+        return options.Providers
+            .Select(provider => new ModelMetadata(
+                provider.Id,
+                ResolveModelDisplayName(provider),
+                provider.CostPerCharUsd,
+                provider.LatencyTargetMs))
+            .ToList();
+    }
+
+    private IReadOnlyList<LanguageMetadata> BuildLanguageMetadata(PluginOptions options)
+    {
+        var languages = new List<LanguageMetadata>
+        {
+            new("auto", "自动检测", true)
+        };
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "auto"
+        };
+
+        var defaultTarget = options.DefaultTargetLanguages?.FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(defaultTarget))
+        {
+            languages.Add(new LanguageMetadata(
+                defaultTarget!,
+                ResolveLanguageName(defaultTarget!),
+                true));
+            seen.Add(defaultTarget!);
+        }
+
+        if (options.DefaultTargetLanguages != null)
+        {
+            foreach (var language in options.DefaultTargetLanguages.Skip(1))
+            {
+                if (string.IsNullOrWhiteSpace(language) || !seen.Add(language))
+                {
+                    continue;
+                }
+
+                languages.Add(new LanguageMetadata(language, ResolveLanguageName(language), false));
+            }
+        }
+
+        foreach (var locale in _localization.GetAvailableLocales())
+        {
+            if (!seen.Add(locale.Locale))
+            {
+                if (locale.IsDefault)
+                {
+                    var existingIndex = languages.FindIndex(lang =>
+                        string.Equals(lang.Id, locale.Locale, StringComparison.OrdinalIgnoreCase));
+                    if (existingIndex >= 0)
+                    {
+                        var entry = languages[existingIndex];
+                        languages[existingIndex] = entry with { IsDefault = true };
+                    }
+                }
+
+                continue;
+            }
+
+            languages.Add(new LanguageMetadata(locale.Locale, locale.DisplayName, locale.IsDefault));
+        }
+
+        if (!languages.Any(lang => lang.Id != "auto" && lang.IsDefault))
+        {
+            var fallbackIndex = languages.FindIndex(lang => lang.Id != "auto");
+            if (fallbackIndex >= 0)
+            {
+                var entry = languages[fallbackIndex];
+                languages[fallbackIndex] = entry with { IsDefault = true };
+            }
+        }
+
+        return languages;
+    }
+
+    private MetadataFeatureFlags BuildFeatureFlags(PluginOptions options)
+    {
+        var hasTerminology = _glossary.GetEntries().Count > 0;
+        var offlineDraftEnabled = !string.IsNullOrWhiteSpace(options.OfflineDraftConnectionString);
+        var toneAvailable = _tones.GetAvailableTones().Count > 0;
+        return new MetadataFeatureFlags(
+            hasTerminology,
+            offlineDraftEnabled,
+            toneAvailable,
+            options.Rag?.Enabled ?? false);
+    }
+
+    private static string ResolveModelDisplayName(ModelProviderOptions provider)
+    {
+        var kindName = provider.Kind switch
+        {
+            ModelProviderKind.OpenAi => "OpenAI",
+            ModelProviderKind.Anthropic => "Anthropic",
+            ModelProviderKind.Groq => "Groq",
+            ModelProviderKind.OpenWebUi => "Open WebUI",
+            ModelProviderKind.Ollama => "Ollama",
+            ModelProviderKind.Custom => "Custom",
+            _ => "Mock"
+        };
+
+        if (!string.IsNullOrWhiteSpace(provider.Model))
+        {
+            return $"{kindName} {provider.Model}";
+        }
+
+        if (!string.IsNullOrWhiteSpace(provider.Id))
+        {
+            return $"{kindName} ({provider.Id})";
+        }
+
+        return kindName;
+    }
+
+    private static string ResolveLanguageName(string language)
+    {
+        if (string.IsNullOrWhiteSpace(language))
+        {
+            return language;
+        }
+
+        try
+        {
+            var culture = CultureInfo.GetCultureInfo(language);
+            return culture.NativeName;
+        }
+        catch (CultureNotFoundException)
+        {
+            var normalized = language.Replace('_', '-');
+            var dashIndex = normalized.IndexOf('-');
+            if (dashIndex > 0)
+            {
+                var parent = normalized[..dashIndex];
+                try
+                {
+                    var culture = CultureInfo.GetCultureInfo(parent);
+                    return culture.NativeName;
+                }
+                catch (CultureNotFoundException)
+                {
+                    // Ignore and fallback below.
+                }
+            }
+        }
+
+        return language;
+    }
+}

--- a/tests/TlaPlugin.Tests/MetadataEndpointTests.cs
+++ b/tests/TlaPlugin.Tests/MetadataEndpointTests.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using TlaPlugin.Models;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class MetadataEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public MetadataEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task MetadataEndpoint_ExposesModelsLanguagesAndFeatures()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/metadata");
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<MetadataResponse>();
+        Assert.NotNull(payload);
+
+        Assert.NotEmpty(payload!.Models);
+        Assert.All(payload.Models, model =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(model.Id));
+            Assert.False(string.IsNullOrWhiteSpace(model.DisplayName));
+            Assert.True(model.CostPerCharUsd >= 0);
+        });
+
+        Assert.Contains(payload.Languages, lang => lang.Id == "auto");
+        Assert.Contains(payload.Languages, lang => lang.IsDefault && lang.Id != "auto");
+
+        Assert.True(payload.Features.TerminologyToggle);
+        Assert.True(payload.Features.OfflineDraft);
+        Assert.True(payload.Features.ToneToggle);
+        Assert.Equal("USD", payload.Pricing.Currency);
+        Assert.True(payload.Pricing.DailyBudgetUsd > 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add response models and a metadata service that aggregates providers, languages, features, and pricing
- expose a new `/api/metadata` endpoint with unit tests to validate the payload
- refactor Playwright specs to configure metadata routes and cover the offline fallback path

## Testing
- dotnet test tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj *(fails: `dotnet` is not available in the execution environment)*
- npm run test:playwright *(fails: Playwright browsers are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc75219f14832fba90cec9452c249c