### PR TITLE
Register Teams reply client via HttpClient factory

### DIFF
--- a/src/TlaPlugin/Configuration/PluginOptions.cs
+++ b/src/TlaPlugin/Configuration/PluginOptions.cs
@@ -262,6 +262,9 @@ public class SecurityOptions
     {
         ["tla-client-secret"] = "local-dev-secret"
     };
+    public string? GraphBaseUrl { get; set; }
+    public TimeSpan GraphTimeout { get; set; } = TimeSpan.FromSeconds(100);
+    public string? GraphProxy { get; set; }
     public IList<string> AllowedReplyChannels { get; set; } = new List<string>();
 }
 


### PR DESCRIPTION
## Summary
- register the Teams reply client through the HttpClient factory so ReplyService resolves the default implementation
- extend security options to allow configuring Graph base URL, timeout, and proxy for the typed client
- add minimal API tests that verify ReplyService sends replies and surfaces 403/402 results with a stubbed HttpMessageHandler

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd0a098c0832fb371dfcd876058c3