### PR TITLE
Add hosted draft replay service and integration tests

### DIFF
--- a/src/TlaPlugin/Configuration/PluginOptions.cs
+++ b/src/TlaPlugin/Configuration/PluginOptions.cs
@@ -14,6 +14,8 @@ public class PluginOptions
     public TimeSpan CacheTtl { get; set; } = TimeSpan.FromHours(24);
     public int MaxConcurrentTranslations { get; set; } = 4;
     public int RequestsPerMinute { get; set; } = 120;
+    public TimeSpan DraftReplayPollingInterval { get; set; } = TimeSpan.FromSeconds(3);
+    public int DraftReplayMaxAttempts { get; set; } = 3;
     public string OfflineDraftConnectionString { get; set; } = "Data Source=tla-offline.db";
     public IList<string> SupportedLanguages { get; set; } = new List<string>
     {

--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -67,6 +67,7 @@ builder.Services.AddSingleton<LocalizationCatalogService>();
 builder.Services.AddSingleton<ContextRetrievalService>();
 builder.Services.AddSingleton<TranslationRouter>();
 builder.Services.AddSingleton<ITranslationPipeline, TranslationPipeline>();
+builder.Services.AddHostedService<DraftReplayService>();
 builder.Services.AddSingleton<MessageExtensionHandler>();
 builder.Services.AddSingleton<ConfigurationSummaryService>();
 builder.Services.AddSingleton<ProjectStatusService>();
@@ -77,6 +78,7 @@ builder.Services.AddSingleton<CostEstimatorService>();
 builder.Services.AddSingleton<McpToolRegistry>();
 builder.Services.AddSingleton<McpServer>();
 builder.Services.AddSingleton<MetadataService>();
+builder.Services.AddHealthChecks().AddCheck<DraftReplayHealthCheck>("draft_replay");
 
 var app = builder.Build();
 
@@ -441,6 +443,8 @@ app.MapGet("/api/localization/catalog/{locale?}", (string? locale, LocalizationC
     var catalog = localization.GetCatalog(locale);
     return Results.Json(catalog, options: jsonOptions);
 });
+
+app.MapHealthChecks("/healthz");
 
 app.MapGet("/api/roadmap", (DevelopmentRoadmapService roadmapService) =>
 {

--- a/src/TlaPlugin/Services/DraftReplayHealthCheck.cs
+++ b/src/TlaPlugin/Services/DraftReplayHealthCheck.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace TlaPlugin.Services;
+
+/// <summary>
+/// Health check that validates the draft replay infrastructure is operational.
+/// </summary>
+public class DraftReplayHealthCheck : IHealthCheck
+{
+    private readonly OfflineDraftStore _store;
+    private readonly ILogger<DraftReplayHealthCheck> _logger;
+
+    public DraftReplayHealthCheck(OfflineDraftStore store, ILogger<DraftReplayHealthCheck> logger)
+    {
+        _store = store;
+        _logger = logger;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var pending = _store.GetPendingDrafts(10);
+            if (pending.Count == 0)
+            {
+                return Task.FromResult(HealthCheckResult.Healthy("No pending drafts."));
+            }
+
+            return Task.FromResult(HealthCheckResult.Degraded(
+                description: $"There are {pending.Count} drafts waiting to be replayed."));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Draft replay health check failed.");
+            return Task.FromResult(HealthCheckResult.Unhealthy("Unable to query offline drafts.", ex));
+        }
+    }
+}

--- a/tests/TlaPlugin.Tests/DraftReplayIntegrationTests.cs
+++ b/tests/TlaPlugin.Tests/DraftReplayIntegrationTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class DraftReplayIntegrationTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    private sealed record OfflineDraftListResponse(List<OfflineDraftRecord> Drafts);
+
+    public DraftReplayIntegrationTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task BackgroundServiceProcessesDraftSuccessfully()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"draft-success-{Guid.NewGuid():N}.db");
+        try
+        {
+            var factory = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    services.PostConfigure<PluginOptions>(options =>
+                    {
+                        options.OfflineDraftConnectionString = $"Data Source={dbPath}";
+                        options.DraftReplayPollingInterval = TimeSpan.FromMilliseconds(100);
+                        options.DraftReplayMaxAttempts = 5;
+                    });
+
+                    services.RemoveAll<ITranslationPipeline>();
+                    services.AddSingleton<ITranslationPipeline>(sp => new TestTranslationPipeline(sp.GetRequiredService<OfflineDraftStore>())
+                    {
+                        TranslateFactory = (_, request) => PipelineExecutionResult.FromTranslation(new TranslationResult
+                        {
+                            RawTranslatedText = request.Text,
+                            TranslatedText = $"{request.Text}-完成",
+                            SourceLanguage = request.SourceLanguage ?? "en",
+                            TargetLanguage = request.TargetLanguage
+                        })
+                    });
+                });
+            });
+
+            using var client = factory.CreateClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "token");
+
+            var draftRequest = new OfflineDraftRequest
+            {
+                OriginalText = "待翻译文本",
+                TargetLanguage = "ja",
+                TenantId = "contoso",
+                UserId = "integration-success"
+            };
+
+            var createResponse = await client.PostAsJsonAsync("/api/offline-draft", draftRequest);
+            createResponse.EnsureSuccessStatusCode();
+
+            var completed = await WaitForDraftAsync(
+                client,
+                draftRequest.UserId,
+                record => record.Status == OfflineDraftStatus.Completed,
+                TimeSpan.FromSeconds(5));
+
+            Assert.Equal(OfflineDraftStatus.Completed, completed.Status);
+            Assert.Equal("integration-success", completed.UserId);
+            Assert.Equal("待翻译文本-完成", completed.ResultText);
+            Assert.NotNull(completed.CompletedAt);
+
+            var pipeline = factory.Services.GetRequiredService<ITranslationPipeline>() as TestTranslationPipeline;
+            Assert.NotNull(pipeline);
+            Assert.True(pipeline!.CallCount >= 1);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+            {
+                File.Delete(dbPath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task BackgroundServiceRetriesUntilDraftFails()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"draft-failure-{Guid.NewGuid():N}.db");
+        try
+        {
+            var factory = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    services.PostConfigure<PluginOptions>(options =>
+                    {
+                        options.OfflineDraftConnectionString = $"Data Source={dbPath}";
+                        options.DraftReplayPollingInterval = TimeSpan.FromMilliseconds(100);
+                        options.DraftReplayMaxAttempts = 2;
+                    });
+
+                    services.RemoveAll<ITranslationPipeline>();
+                    services.AddSingleton<ITranslationPipeline>(sp => new TestTranslationPipeline(sp.GetRequiredService<OfflineDraftStore>())
+                    {
+                        ExceptionFactory = attempt => new InvalidOperationException($"boom-{attempt}")
+                    });
+                });
+            });
+
+            using var client = factory.CreateClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "token");
+
+            var draftRequest = new OfflineDraftRequest
+            {
+                OriginalText = "失败文本",
+                TargetLanguage = "fr",
+                TenantId = "contoso",
+                UserId = "integration-failure"
+            };
+
+            var createResponse = await client.PostAsJsonAsync("/api/offline-draft", draftRequest);
+            createResponse.EnsureSuccessStatusCode();
+
+            var failed = await WaitForDraftAsync(
+                client,
+                draftRequest.UserId,
+                record => record.Status == OfflineDraftStatus.Failed,
+                TimeSpan.FromSeconds(5));
+
+            Assert.Equal(OfflineDraftStatus.Failed, failed.Status);
+            Assert.Equal(2, failed.Attempts);
+            Assert.Equal("boom-2", failed.ErrorReason);
+            Assert.NotNull(failed.CompletedAt);
+
+            var pipeline = factory.Services.GetRequiredService<ITranslationPipeline>() as TestTranslationPipeline;
+            Assert.NotNull(pipeline);
+            Assert.Equal(2, pipeline!.CallCount);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+            {
+                File.Delete(dbPath);
+            }
+        }
+    }
+
+    private static async Task<OfflineDraftRecord> WaitForDraftAsync(
+        HttpClient client,
+        string userId,
+        Func<OfflineDraftRecord, bool> predicate,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var response = await client.GetAsync($"/api/offline-draft?userId={Uri.EscapeDataString(userId)}");
+            response.EnsureSuccessStatusCode();
+
+            var payload = await response.Content.ReadFromJsonAsync<OfflineDraftListResponse>();
+            var draft = payload?.Drafts.Count > 0 ? payload.Drafts[0] : null;
+            if (draft is not null && predicate(draft))
+            {
+                return draft;
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Draft for user '{userId}' did not reach the expected state in time.");
+    }
+
+    private sealed class TestTranslationPipeline : ITranslationPipeline
+    {
+        private readonly OfflineDraftStore _store;
+        private int _callCount;
+
+        public TestTranslationPipeline(OfflineDraftStore store)
+        {
+            _store = store;
+        }
+
+        public int CallCount => _callCount;
+
+        public Func<int, TranslationRequest, PipelineExecutionResult>? TranslateFactory { get; init; }
+        public Func<int, Exception>? ExceptionFactory { get; init; }
+
+        public Task<DetectionResult> DetectAsync(LanguageDetectionRequest request, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<PipelineExecutionResult> TranslateAsync(TranslationRequest request, CancellationToken cancellationToken)
+            => TranslateAsync(request, null, cancellationToken);
+
+        public Task<PipelineExecutionResult> TranslateAsync(TranslationRequest request, DetectionResult? detection, CancellationToken cancellationToken)
+        {
+            _callCount++;
+            if (ExceptionFactory is not null)
+            {
+                throw ExceptionFactory(_callCount);
+            }
+
+            var factory = TranslateFactory ?? ((_, r) => PipelineExecutionResult.FromTranslation(new TranslationResult
+            {
+                RawTranslatedText = r.Text,
+                TranslatedText = r.Text,
+                SourceLanguage = r.SourceLanguage ?? "en",
+                TargetLanguage = r.TargetLanguage
+            }));
+
+            return Task.FromResult(factory(_callCount, request));
+        }
+
+        public OfflineDraftRecord SaveDraft(OfflineDraftRequest request) => _store.SaveDraft(request);
+
+        public OfflineDraftRecord MarkDraftProcessing(long draftId) => _store.MarkProcessing(draftId);
+
+        public Task<RewriteResult> RewriteAsync(RewriteRequest request, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<ReplyResult> PostReplyAsync(ReplyRequest request, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<ReplyResult> PostReplyAsync(ReplyRequest request, string finalText, string? toneApplied, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
## Summary
- register `DraftReplayService` as a hosted background worker and expose a `/healthz` endpoint backed by a draft replay health check
- allow polling interval and max retry attempts to be configured via `PluginOptions`
- add integration coverage that exercises successful and failure replay scenarios using the background service

## Testing
- `dotnet test` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd0a03274832fad71768666eeafa7