### PR TITLE
Support thread-aware context retrieval

### DIFF
--- a/src/TlaPlugin/Models/PipelineExecutionResult.cs
+++ b/src/TlaPlugin/Models/PipelineExecutionResult.cs
@@ -102,6 +102,7 @@ public class PipelineExecutionResult
             TenantId = request.TenantId,
             UserId = request.UserId,
             ChannelId = request.ChannelId,
+            ThreadId = request.ThreadId,
             Tone = request.Tone,
             UseGlossary = request.UseGlossary,
             UiLocale = request.UiLocale,

--- a/src/TlaPlugin/Models/TranslationRequest.cs
+++ b/src/TlaPlugin/Models/TranslationRequest.cs
@@ -20,6 +20,8 @@ public class TranslationRequest
     public string UserId { get; set; } = string.Empty;
     public string? ChannelId { get; set; }
         = null;
+    public string? ThreadId { get; set; }
+        = null;
     public string Tone { get; set; } = DefaultTone;
     public bool UseGlossary { get; set; } = true;
     public bool UseRag { get; set; } = false;

--- a/src/TlaPlugin/Services/ContextRetrievalService.cs
+++ b/src/TlaPlugin/Services/ContextRetrievalService.cs
@@ -48,7 +48,7 @@ public class ContextRetrievalService
             return new ContextRetrievalResult();
         }
 
-        var cacheKey = BuildChannelKey(request.TenantId, request.ChannelId ?? request.ThreadId ?? string.Empty);
+        var cacheKey = BuildChannelKey(request.TenantId, request.ThreadId ?? request.ChannelId ?? string.Empty);
         var hints = request.ContextHints ?? new List<string>();
         var candidates = await GetOrFetchMessagesAsync(cacheKey, request, cancellationToken).ConfigureAwait(false);
 

--- a/src/TlaPlugin/Services/GlossaryConflictException.cs
+++ b/src/TlaPlugin/Services/GlossaryConflictException.cs
@@ -23,6 +23,7 @@ public class GlossaryConflictException : TranslationException
             TenantId = request.TenantId,
             UserId = request.UserId,
             ChannelId = request.ChannelId,
+            ThreadId = request.ThreadId,
             Tone = request.Tone,
             UseGlossary = request.UseGlossary,
             UiLocale = request.UiLocale,

--- a/src/TlaPlugin/Services/TranslationPipeline.cs
+++ b/src/TlaPlugin/Services/TranslationPipeline.cs
@@ -189,6 +189,7 @@ public class TranslationPipeline : ITranslationPipeline
             TenantId = request.TenantId,
             UserId = request.UserId,
             ChannelId = request.ChannelId,
+            ThreadId = request.ThreadId,
             Tone = request.Tone,
             AdditionalTargetLanguages = new List<string>(additionalTargets),
             UseGlossary = request.UseGlossary,
@@ -219,7 +220,7 @@ public class TranslationPipeline : ITranslationPipeline
                 TenantId = request.TenantId,
                 UserId = request.UserId,
                 ChannelId = request.ChannelId,
-                ThreadId = request.ChannelId,
+                ThreadId = request.ThreadId,
                 MaxMessages = _options.Rag.MaxMessages,
                 ContextHints = new List<string>(request.ContextHints)
             }, cancellationToken);

--- a/src/TlaPlugin/Teams/MessageExtensionHandler.cs
+++ b/src/TlaPlugin/Teams/MessageExtensionHandler.cs
@@ -179,6 +179,7 @@ public class MessageExtensionHandler
                 TenantId = request.TenantId,
                 UserId = request.UserId,
                 ChannelId = request.ChannelId,
+                ThreadId = request.ThreadId,
                 Tone = TranslationRequest.DefaultTone,
                 UiLocale = request.UiLocale,
                 UseGlossary = false,

--- a/src/teamsClient/messageExtensionDialog.js
+++ b/src/teamsClient/messageExtensionDialog.js
@@ -7,7 +7,8 @@ import {
   buildDetectPayload,
   buildRewritePayload,
   buildReplyPayload,
-  updateStateWithResponse
+  updateStateWithResponse,
+  resolveThreadId
 } from "./state.js";
 
 function resolveDialogUi(root = typeof document !== "undefined" ? document : undefined) {
@@ -173,6 +174,7 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
   const { teams: sdk, context } = await ensureTeamsContext({ teams });
   const metadata = await fetchMetadata(fetcher);
   const state = buildDialogState({ models: metadata.models, languages: metadata.languages, context });
+  state.threadId = state.threadId ?? resolveThreadId(context);
 
   applySelectOptions(ui.modelSelect, metadata.models, { valueKey: "id", labelKey: "displayName" });
   applySelectOptions(ui.sourceSelect, metadata.languages, { valueKey: "id", labelKey: "name" });
@@ -404,7 +406,8 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
       userId: context?.user?.id,
       sourceLanguage: state.sourceLanguage,
       channelId: context?.channel?.id,
-      metadata: { modelId: state.modelId }
+      metadata: { modelId: state.modelId },
+      threadId: state.threadId ?? resolveThreadId(context)
     };
     updateOfflineStatus(ui, "正在保存离线草稿…");
     try {


### PR DESCRIPTION
## Summary
- add a ThreadId field to translation requests and propagate it through pipeline cloning, glossary conflicts, and Teams reply handling
- update context retrieval and the Graph Teams client to prefer thread messages with channel fallback and cover the new behavior with integration tests
- capture the current thread from the Teams dialog context on the frontend and include it in translate, rewrite, reply, and offline draft payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcd09e1974832f9fd16590a034164e