### PR TITLE
Configure OpenAI provider for translation plugin

### DIFF
--- a/src/TlaPlugin/appsettings.json
+++ b/src/TlaPlugin/appsettings.json
@@ -173,35 +173,74 @@
       "fy-NL",
       "af-ZA"
     ],
-    "DefaultTargetLanguages": ["ja-JP", "en-US"],
+    "DefaultTargetLanguages": [
+      "ja-JP",
+      "en-US"
+    ],
     "Providers": [
+      {
+        "Id": "openai-gpt-4o",
+        "Kind": "OpenAi",
+        "CostPerCharUsd": 0.00012,
+        "LatencyTargetMs": 350,
+        "Reliability": 0.995,
+        "Regions": [
+          "global"
+        ],
+        "Certifications": [
+          "iso27001"
+        ],
+        "Endpoint": "https://api.openai.com/v1/chat/completions",
+        "Model": "gpt-4o-mini",
+        "ApiKeySecretName": "openai-api-key",
+        "Organization": "example-openai-org",
+        "DefaultHeaders": {
+          "OpenAI-Beta": "assistants=v2"
+        }
+      },
       {
         "Id": "mock-primary",
         "Kind": "Mock",
-        "CostPerCharUsd": 0.00002,
+        "CostPerCharUsd": 2e-05,
         "LatencyTargetMs": 250,
         "Reliability": 0.98,
-        "Regions": ["japan", "global"],
-        "Certifications": ["iso27001"],
+        "Regions": [
+          "japan",
+          "global"
+        ],
+        "Certifications": [
+          "iso27001"
+        ],
         "TranslationPrefix": "[MockJP]"
       },
       {
         "Id": "mock-backup",
         "Kind": "Mock",
-        "CostPerCharUsd": 0.000015,
+        "CostPerCharUsd": 1.5e-05,
         "LatencyTargetMs": 400,
         "Reliability": 0.95,
-        "Regions": ["global"],
+        "Regions": [
+          "global"
+        ],
         "Certifications": [],
         "TranslationPrefix": "[MockBackup]",
         "SimulatedFailures": 1
       }
     ],
     "Compliance": {
-      "RequiredRegionTags": ["japan"],
-      "AllowedRegionFallbacks": ["global"],
-      "RequiredCertifications": ["iso27001"],
-      "BannedPhrases": ["secret", "forbidden"]
+      "RequiredRegionTags": [
+        "japan"
+      ],
+      "AllowedRegionFallbacks": [
+        "global"
+      ],
+      "RequiredCertifications": [
+        "iso27001"
+      ],
+      "BannedPhrases": [
+        "secret",
+        "forbidden"
+      ]
     },
     "Security": {
       "KeyVaultUri": "https://localhost.vault.azure.net/",
@@ -211,7 +250,8 @@
       "AccessTokenLifetime": "00:30:00",
       "SecretCacheTtl": "00:05:00",
       "SeedSecrets": {
-        "tla-client-secret": "local-dev-secret"
+        "tla-client-secret": "local-dev-secret",
+        "openai-api-key": "test-openai-api-key"
       }
     }
   }


### PR DESCRIPTION
## Summary
- add an OpenAI chat completion provider configuration with endpoint, model, organization, and headers
- seed the corresponding OpenAI API key secret for local development

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd4d1ec55c832faf6d735ed90ff9df