### PR TITLE
Add glossary upload controls to dashboard

### DIFF
--- a/src/webapp/index.html
+++ b/src/webapp/index.html
@@ -54,6 +54,72 @@
         <h2>测试覆盖</h2>
         <ul class="test-list" data-test-list></ul>
       </section>
+
+      <section class="section glossary">
+        <h2>术语表管理</h2>
+        <form class="glossary__form" data-glossary-form>
+          <label>
+            作用域
+            <select data-glossary-scope>
+              <option value="tenant">租户</option>
+              <option value="channel">团队频道</option>
+              <option value="user">个人</option>
+            </select>
+          </label>
+          <label>
+            术语文件（CSV/TBX）
+            <input
+              type="file"
+              accept=".csv,.tbx,text/csv,application/xml"
+              data-glossary-file
+              required
+            />
+          </label>
+          <label class="glossary__toggle">
+            <input type="checkbox" data-glossary-override />
+            覆盖现有术语
+          </label>
+          <button type="submit">上传术语</button>
+        </form>
+
+        <p class="glossary__status" data-glossary-status></p>
+
+        <div class="glossary__results" data-glossary-results hidden>
+          <h3>上传结果</h3>
+          <p data-glossary-summary>尚未上传术语。</p>
+          <dl class="glossary__metrics">
+            <div>
+              <dt>新增</dt>
+              <dd data-glossary-imported>0</dd>
+            </div>
+            <div>
+              <dt>更新</dt>
+              <dd data-glossary-updated>0</dd>
+            </div>
+            <div>
+              <dt>冲突</dt>
+              <dd data-glossary-conflict-count>0</dd>
+            </div>
+            <div>
+              <dt>错误</dt>
+              <dd data-glossary-error-count>0</dd>
+            </div>
+          </dl>
+          <div class="glossary__conflicts" data-glossary-conflicts hidden>
+            <h4>冲突条目</h4>
+            <ul data-glossary-conflict-list></ul>
+          </div>
+          <div class="glossary__errors" data-glossary-errors hidden>
+            <h4>解析/导入错误</h4>
+            <ul data-glossary-error-list></ul>
+          </div>
+        </div>
+
+        <div class="glossary__list">
+          <h3>当前术语</h3>
+          <ul data-glossary-items></ul>
+        </div>
+      </section>
     </main>
     <script type="module" src="./app.js"></script>
   </body>

--- a/tests/glossaryUpload.test.js
+++ b/tests/glossaryUpload.test.js
@@ -1,0 +1,185 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  handleGlossaryUpload,
+  renderGlossaryUploadFeedback,
+  renderGlossaryEntries
+} from "../src/webapp/app.js";
+
+class StubFormData {
+  constructor() {
+    this.store = new Map();
+  }
+
+  set(name, value) {
+    this.store.set(name, value);
+  }
+
+  append(name, value) {
+    this.store.set(name, value);
+  }
+
+  get(name) {
+    return this.store.get(name);
+  }
+}
+
+function createElements() {
+  return {
+    form: { addEventListener() {} },
+    scopeInput: { value: "tenant" },
+    fileInput: { files: [] },
+    overrideInput: { checked: false },
+    submitButton: { disabled: false },
+    resultsContainer: { hidden: true },
+    summaryLabel: { textContent: "" },
+    importedCount: { textContent: "" },
+    updatedCount: { textContent: "" },
+    conflictCount: { textContent: "" },
+    errorCount: { textContent: "" },
+    conflictContainer: { hidden: true },
+    conflictList: { innerHTML: "" },
+    errorContainer: { hidden: true },
+    errorList: { innerHTML: "" },
+    statusLabel: { textContent: "" },
+    glossaryList: { innerHTML: "" }
+  };
+}
+
+test("renderGlossaryUploadFeedback populates metrics and toggles sections", () => {
+  const elements = createElements();
+  renderGlossaryUploadFeedback(elements, {
+    imported: 2,
+    updated: 1,
+    conflicts: [
+      { source: "CPU", existingTarget: "中央处理器", incomingTarget: "处理器", scope: "tenant:contoso" }
+    ],
+    errors: ["行 1: 缺少源词"]
+  });
+
+  assert.equal(elements.resultsContainer.hidden, false);
+  assert.equal(elements.importedCount.textContent, "2");
+  assert.equal(elements.updatedCount.textContent, "1");
+  assert.equal(elements.conflictCount.textContent, "1");
+  assert.equal(elements.errorCount.textContent, "1");
+  assert.equal(elements.conflictContainer.hidden, false);
+  assert.equal(elements.errorContainer.hidden, false);
+  assert.ok(elements.conflictList.innerHTML.includes("CPU"));
+  assert.ok(elements.errorList.innerHTML.includes("缺少源词"));
+});
+
+test("handleGlossaryUpload sends form data and refreshes glossary", async () => {
+  const elements = createElements();
+  const file = { name: "terms.csv" };
+  elements.fileInput.files = [file];
+
+  const requests = [];
+  const formDataInstances = [];
+  const fetchMock = async (url, options = {}) => {
+    requests.push({ url, options });
+    if (url === "/api/glossary/upload") {
+      return {
+        ok: true,
+        json: async () => ({ imported: 2, updated: 1, conflicts: [], errors: [] })
+      };
+    }
+    if (url === "/api/glossary") {
+      return {
+        ok: true,
+        json: async () => [{ source: "CPU", target: "处理器", scope: "tenant:contoso" }]
+      };
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  };
+
+  await handleGlossaryUpload({
+    elements,
+    fetchImpl: fetchMock,
+    formDataFactory: () => {
+      const fd = new StubFormData();
+      formDataInstances.push(fd);
+      return fd;
+    }
+  });
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].url, "/api/glossary/upload");
+  assert.equal(requests[1].url, "/api/glossary");
+  assert.equal(formDataInstances[0].get("scope"), "tenant");
+  assert.equal(formDataInstances[0].get("overwrite"), "false");
+  assert.equal(formDataInstances[0].get("file"), file);
+  assert.equal(elements.submitButton.disabled, false);
+  assert.equal(elements.resultsContainer.hidden, false);
+  assert.ok(elements.summaryLabel.textContent.includes("2"));
+  assert.ok(elements.glossaryList.innerHTML.includes("CPU"));
+  assert.ok(elements.statusLabel.textContent.includes("已导入"));
+});
+
+test("handleGlossaryUpload reports conflicts and keeps glossary refreshed", async () => {
+  const elements = createElements();
+  const file = { name: "terms.csv" };
+  elements.fileInput.files = [file];
+
+  const requests = [];
+  const fetchMock = async (url, options = {}) => {
+    requests.push({ url, options });
+    if (url === "/api/glossary/upload") {
+      return {
+        ok: true,
+        json: async () => ({
+          imported: 1,
+          updated: 0,
+          conflicts: [
+            { source: "CPU", existingTarget: "中央处理器", incomingTarget: "处理器", scope: "tenant:contoso" }
+          ],
+          errors: []
+        })
+      };
+    }
+    if (url === "/api/glossary") {
+      return {
+        ok: true,
+        json: async () => []
+      };
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  };
+
+  await handleGlossaryUpload({ elements, fetchImpl: fetchMock, formDataFactory: () => new StubFormData() });
+
+  assert.equal(requests.length, 2);
+  assert.equal(elements.conflictContainer.hidden, false);
+  assert.ok(elements.conflictList.innerHTML.includes("CPU"));
+});
+
+test("handleGlossaryUpload surfaces server validation errors", async () => {
+  const elements = createElements();
+  const file = { name: "terms.csv" };
+  elements.fileInput.files = [file];
+
+  const requests = [];
+  const fetchMock = async (url, options = {}) => {
+    requests.push({ url, options });
+    if (url === "/api/glossary/upload") {
+      return {
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "文件无效", errors: ["行 2: 缺少译文"] })
+      };
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  };
+
+  await handleGlossaryUpload({ elements, fetchImpl: fetchMock, formDataFactory: () => new StubFormData() });
+
+  assert.equal(requests.length, 1);
+  assert.equal(elements.errorContainer.hidden, false);
+  assert.ok(elements.errorList.innerHTML.includes("行 2"));
+  assert.ok(elements.statusLabel.textContent.includes("文件无效"));
+});
+
+test("renderGlossaryEntries prints placeholder when list empty", () => {
+  const listElement = { innerHTML: "" };
+  renderGlossaryEntries(listElement, []);
+  assert.ok(listElement.innerHTML.includes("暂无术语条目"));
+});


### PR DESCRIPTION
## Summary
- add glossary upload form, results, and list placeholders to the dashboard
- implement fetch-based upload handler with status feedback and glossary refresh
- cover upload success, conflict, and error scenarios with node:test cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd4d1febac832f9e8d0fc57d790d17