### PR TITLE
Add additional target language selection for Teams dialog

### DIFF
--- a/src/webapp/dialog.html
+++ b/src/webapp/dialog.html
@@ -26,6 +26,10 @@
           目标语言
           <select data-target-select aria-label="目标语言选择"></select>
         </label>
+        <label>
+          额外目标语言（可多选）
+          <select data-additional-target-select aria-label="额外目标语言选择" multiple></select>
+        </label>
         <label class="toggle">
           <input type="checkbox" data-terminology-toggle checked /> 使用术语表
         </label>

--- a/tests/messageExtensionDialogState.test.js
+++ b/tests/messageExtensionDialogState.test.js
@@ -23,6 +23,7 @@ test("buildDialogState chooses default language from context locale", () => {
   assert.equal(state.modelId, "model-a");
   assert.equal(state.useRag, false);
   assert.deepEqual(state.contextHints, []);
+  assert.deepEqual(state.additionalTargetLanguages, []);
 });
 
 test("calculateCostHint multiplies characters and cost", () => {
@@ -39,7 +40,8 @@ test("buildTranslatePayload forwards metadata and context", () => {
     targetLanguage: "zh-Hans",
     modelId: "model-a",
     useTerminology: false,
-    tone: "formal"
+    tone: "formal",
+    additionalTargetLanguages: ["ja", "zh-Hans", "en", "ja"]
   };
   const context = { tenant: { id: "tenant1" }, user: { id: "user1" }, channel: { id: "channel1" } };
   const payload = buildTranslatePayload(state, context);
@@ -47,6 +49,7 @@ test("buildTranslatePayload forwards metadata and context", () => {
   assert.equal(payload.sourceLanguage, undefined);
   assert.equal(payload.useRag, false);
   assert.deepEqual(payload.contextHints, []);
+  assert.deepEqual(payload.additionalTargetLanguages, ["ja", "en"]);
   assert.deepEqual(payload.metadata, {
     origin: "messageExtension",
     modelId: "model-a",
@@ -82,12 +85,14 @@ test("buildReplyPayload reuses rag preferences", () => {
     useTerminology: true,
     tone: "neutral",
     useRag: true,
-    contextHints: ["pricing"]
+    contextHints: ["pricing"],
+    additionalTargetLanguages: ["en", "ja", "fr"]
   };
   const context = { tenant: { id: "tenant" }, user: { id: "user" }, channel: { id: "channel" } };
   const payload = buildReplyPayload(state, context, "こんにちは");
   assert.equal(payload.useRag, true);
   assert.deepEqual(payload.contextHints, ["pricing"]);
+  assert.deepEqual(payload.additionalTargetLanguages, ["en", "fr"]);
 });
 
 test("updateStateWithResponse stores translation text", () => {


### PR DESCRIPTION
## Summary
- add support for tracking additional target languages in the Teams dialog state and API payloads
- expose a multi-select control for extra target languages in the message extension dialog UI and include the values when submitting replies
- extend node-test and jest suites to cover multi-language payload handling and dialog behaviour

## Testing
- npm test *(fails: src/webapp/app.js does not export handleGlossaryUpload, existing issue in tests/glossaryUpload.test.js)*
- npm run test:jest *(fails: jest configuration rejects extensionsToTreatAsEsm setting)*

------
https://chatgpt.com/codex/tasks/task_e_68dd533fc230832f8a2672541042a21d