### PR TITLE
Serve webapp assets from plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
+    "build": "npm run build:webapp",
+    "build:webapp": "node ./scripts/build-webapp.js",
     "test": "node --test",
     "test:jest": "jest --config jest.config.cjs",
     "test:playwright": "playwright test"

--- a/scripts/build-webapp.js
+++ b/scripts/build-webapp.js
@@ -1,0 +1,71 @@
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const sourceWebappDir = path.join(repoRoot, "src", "webapp");
+const sourceTeamsClientDir = path.join(repoRoot, "src", "teamsClient");
+const outputRoot = path.join(repoRoot, "src", "TlaPlugin", "wwwroot");
+
+async function ensureEmptyDirectory(directory) {
+  await fs.rm(directory, { recursive: true, force: true });
+  await fs.mkdir(directory, { recursive: true });
+}
+
+async function copyDirectory(source, destination) {
+  const entries = await fs.readdir(source, { withFileTypes: true });
+  await fs.mkdir(destination, { recursive: true });
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      const sourcePath = path.join(source, entry.name);
+      const destinationPath = path.join(destination, entry.name);
+      if (entry.isDirectory()) {
+        await copyDirectory(sourcePath, destinationPath);
+      } else if (entry.isFile()) {
+        await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+        await fs.copyFile(sourcePath, destinationPath);
+      }
+    })
+  );
+}
+
+function rewriteRelativeAssetReferences(html) {
+  return html.replace(/(href|src)=["'](?!(?:https?:|\/\/|\/))(.?\/)?([^"']+)["']/g, (_match, attribute, _prefix, file) => {
+    return `${attribute}="../webapp/${file}"`;
+  });
+}
+
+async function createRouteIndex(routeFolder, sourceFile) {
+  const sourcePath = path.join(sourceWebappDir, sourceFile);
+  const destinationPath = path.join(outputRoot, routeFolder, "index.html");
+  const original = await fs.readFile(sourcePath, "utf8");
+  const rewritten = rewriteRelativeAssetReferences(original);
+  await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+  await fs.writeFile(destinationPath, rewritten, "utf8");
+}
+
+async function build() {
+  await ensureEmptyDirectory(outputRoot);
+
+  await copyDirectory(sourceWebappDir, path.join(outputRoot, "webapp"));
+  await copyDirectory(sourceTeamsClientDir, path.join(outputRoot, "teamsClient"));
+
+  const routes = [
+    { folder: "dashboard", source: "index.html" },
+    { folder: "settings", source: "settings.html" },
+    { folder: "compose", source: "compose.html" },
+    { folder: "dialog", source: "dialog.html" }
+  ];
+
+  for (const route of routes) {
+    await createRouteIndex(route.folder, route.source);
+  }
+}
+
+build().catch((error) => {
+  console.error("Failed to build webapp assets:", error);
+  process.exitCode = 1;
+});

--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -116,6 +116,9 @@ builder.Services.AddHealthChecks().AddCheck<DraftReplayHealthCheck>("draft_repla
 
 var app = builder.Build();
 
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
 var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 static bool TryAuthorize(HttpRequest request, out IResult? unauthorized)
 {
@@ -702,6 +705,11 @@ static bool LooksLikeHeader(string[] cells)
         || (first.Contains("term") && second.Contains("translation"));
 }
 
+
+app.MapFallbackToFile("/dashboard/{*path}", "dashboard/index.html");
+app.MapFallbackToFile("/settings/{*path}", "settings/index.html");
+app.MapFallbackToFile("/compose/{*path}", "compose/index.html");
+app.MapFallbackToFile("/dialog/{*path}", "dialog/index.html");
 
 app.Run();
 

--- a/src/TlaPlugin/TlaPlugin.csproj
+++ b/src/TlaPlugin/TlaPlugin.csproj
@@ -8,4 +8,10 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.20" />
     <PackageReference Include="Microsoft.Graph" Version="5.53.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="wwwroot\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/src/TlaPlugin/wwwroot/compose/index.html
+++ b/src/TlaPlugin/wwwroot/compose/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BOBTLA Compose 插件</title>
+    <link rel="stylesheet" href="../webapp/styles.css" />
+  </head>
+  <body class="compose" data-compose-root>
+    <header class="compose__header">
+      <h1>内联翻译助手</h1>
+      <p>在撰写消息时快速生成译文预览。</p>
+    </header>
+    <main class="compose__main">
+      <label>
+        目标语言
+        <select data-compose-target aria-label="目标语言"></select>
+      </label>
+      <label class="toggle">
+        <input type="checkbox" data-terminology-toggle checked /> 使用术语表
+      </label>
+      <label class="toggle">
+        <input type="checkbox" data-tone-toggle /> 正式语气
+      </label>
+      <p class="compose__cost" data-compose-cost></p>
+      <label class="compose__editor">
+        原文
+        <textarea rows="5" data-compose-input placeholder="输入要翻译的消息"></textarea>
+      </label>
+      <label class="compose__editor">
+        译文预览
+        <textarea rows="5" data-compose-preview readonly></textarea>
+      </label>
+    </main>
+    <footer class="compose__footer">
+      <button type="button" class="btn" data-compose-suggest>生成建议</button>
+      <button type="button" class="btn btn--primary" data-compose-apply>应用译文</button>
+    </footer>
+    <script type="module" src="../webapp/composePlugin.js"></script>
+  </body>
+</html>

--- a/src/TlaPlugin/wwwroot/dashboard/index.html
+++ b/src/TlaPlugin/wwwroot/dashboard/index.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TLA 团队前端仪表盘</title>
+    <link rel="stylesheet" href="../webapp/styles.css" />
+  </head>
+  <body>
+    <main class="dashboard">
+      <section class="summary">
+        <h1>Teams 翻译助手 · 前端仪表盘</h1>
+        <div class="summary__grid">
+          <article class="card">
+            <h2>整体进度</h2>
+            <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" data-overall-progress>
+              <span>0%</span>
+            </div>
+            <p data-overall-text>整体完成度 0%</p>
+          </article>
+          <article class="card">
+            <h2>前端完成度</h2>
+            <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" data-frontend-progress>
+              <span>0%</span>
+            </div>
+            <p data-frontend-text>前端完成度 0%</p>
+            <ul class="readiness" data-readiness></ul>
+          </article>
+          <article class="card">
+            <h2>当前阶段</h2>
+            <h3 data-active-stage-title>阶段加载中</h3>
+            <p data-active-stage-body>正在同步阶段目标...</p>
+            <h4>下一步</h4>
+            <ul class="next-steps" data-next-steps></ul>
+          </article>
+          <article class="card">
+            <h2>可用界面语言</h2>
+            <ul class="locale-list" data-locale-list></ul>
+          </article>
+          <article class="card">
+            <h2>支持翻译语言</h2>
+            <p data-language-count>正在载入...</p>
+            <ul class="language-list" data-language-list></ul>
+          </article>
+          <article class="card card--metrics" data-metrics-card>
+            <header class="metrics__header">
+              <h2>使用指标</h2>
+              <button type="button" class="metrics__refresh" data-metrics-refresh>刷新</button>
+            </header>
+            <div class="metrics__grid">
+              <div class="metrics__stat" data-metric-usage>
+                <span class="metrics__label">24 小时调用</span>
+                <strong class="metrics__value" data-metric-usage-value>--</strong>
+                <span class="metrics__detail" data-metric-usage-detail>成功率 --</span>
+              </div>
+              <div class="metrics__stat" data-metric-cost>
+                <span class="metrics__label">月度成本</span>
+                <strong class="metrics__value" data-metric-cost-value>--</strong>
+                <span class="metrics__detail" data-metric-cost-detail>日均 --</span>
+              </div>
+              <div class="metrics__stat" data-metric-failure-summary>
+                <span class="metrics__label">失败次数</span>
+                <strong class="metrics__value" data-metric-failure-total>--</strong>
+                <span class="metrics__detail" data-metric-failure-detail>主要原因 --</span>
+              </div>
+            </div>
+            <div class="metrics__failures">
+              <h3>高频失败原因</h3>
+              <ul class="metrics__failure-list" data-failure-reasons>
+                <li class="metrics__empty">正在统计...</li>
+              </ul>
+            </div>
+            <p class="metrics__updated" data-metrics-updated>最近更新：--</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>阶段时间线</h2>
+        <div class="timeline" data-timeline></div>
+      </section>
+
+      <section class="section">
+        <h2>测试覆盖</h2>
+        <ul class="test-list" data-test-list></ul>
+      </section>
+
+      <section class="section glossary">
+        <h2>术语表管理</h2>
+        <form class="glossary__form" data-glossary-form>
+          <label>
+            作用域
+            <select data-glossary-scope>
+              <option value="tenant">租户</option>
+              <option value="channel">团队频道</option>
+              <option value="user">个人</option>
+            </select>
+          </label>
+          <label>
+            术语文件（CSV/TBX）
+            <input
+              type="file"
+              accept=".csv,.tbx,text/csv,application/xml"
+              data-glossary-file
+              required
+            />
+          </label>
+          <label class="glossary__toggle">
+            <input type="checkbox" data-glossary-override />
+            覆盖现有术语
+          </label>
+          <button type="submit">上传术语</button>
+        </form>
+
+        <p class="glossary__status" data-glossary-status></p>
+
+        <div class="glossary__results" data-glossary-results hidden>
+          <h3>上传结果</h3>
+          <p data-glossary-summary>尚未上传术语。</p>
+          <dl class="glossary__metrics">
+            <div>
+              <dt>新增</dt>
+              <dd data-glossary-imported>0</dd>
+            </div>
+            <div>
+              <dt>更新</dt>
+              <dd data-glossary-updated>0</dd>
+            </div>
+            <div>
+              <dt>冲突</dt>
+              <dd data-glossary-conflict-count>0</dd>
+            </div>
+            <div>
+              <dt>错误</dt>
+              <dd data-glossary-error-count>0</dd>
+            </div>
+          </dl>
+          <div class="glossary__conflicts" data-glossary-conflicts hidden>
+            <h4>冲突条目</h4>
+            <ul data-glossary-conflict-list></ul>
+          </div>
+          <div class="glossary__errors" data-glossary-errors hidden>
+            <h4>解析/导入错误</h4>
+            <ul data-glossary-error-list></ul>
+          </div>
+        </div>
+
+        <div class="glossary__list">
+          <h3>当前术语</h3>
+          <ul data-glossary-items></ul>
+        </div>
+      </section>
+    </main>
+    <script type="module" src="../webapp/app.js"></script>
+  </body>
+</html>

--- a/src/TlaPlugin/wwwroot/dialog/index.html
+++ b/src/TlaPlugin/wwwroot/dialog/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BOBTLA 消息扩展对话框</title>
+    <link rel="stylesheet" href="../webapp/styles.css" />
+  </head>
+  <body class="dialog" data-dialog-root>
+    <header class="dialog__header">
+      <h1>翻译助手</h1>
+      <p>选择模型、语言与术语策略，生成可编辑译文。</p>
+    </header>
+    <main class="dialog__main">
+      <section class="dialog__controls">
+        <label>
+          模型
+          <select data-model-select aria-label="模型选择"></select>
+        </label>
+        <label>
+          源语言
+          <select data-source-select aria-label="源语言选择"></select>
+        </label>
+        <p class="dialog__detected" data-detected-language></p>
+        <label>
+          目标语言
+          <select data-target-select aria-label="目标语言选择"></select>
+        </label>
+        <label class="toggle">
+          <input type="checkbox" data-terminology-toggle checked /> 使用术语表
+        </label>
+        <label class="toggle">
+          <input type="checkbox" data-tone-toggle /> 正式语气
+        </label>
+        <label class="toggle">
+          <input type="checkbox" data-rag-toggle /> 启用检索增强
+        </label>
+        <label>
+          上下文提示（每行一条）
+          <textarea
+            rows="3"
+            data-context-hints
+            placeholder="例如：预算审批；合同草案；团队代号"
+          ></textarea>
+        </label>
+        <p class="dialog__cost" data-cost-hint></p>
+      </section>
+      <section class="dialog__editor">
+        <label class="editor__label">
+          原文
+          <textarea rows="6" data-source-text placeholder="请输入要翻译的文本"></textarea>
+        </label>
+        <label class="editor__label">
+          译文（可编辑）
+          <textarea rows="6" data-translation-text placeholder="点击生成译文后可编辑"></textarea>
+        </label>
+      </section>
+      <p class="dialog__error" data-error-banner hidden></p>
+      <section class="dialog__offline" data-offline-draft-section hidden>
+        <h2>离线草稿</h2>
+        <p class="dialog__status" data-offline-draft-status hidden></p>
+        <ul class="dialog__drafts" data-offline-draft-list></ul>
+      </section>
+    </main>
+    <footer class="dialog__footer">
+      <button type="button" class="btn" data-preview-translation>生成译文</button>
+      <button type="button" class="btn" data-save-offline-draft hidden>保存离线草稿</button>
+      <button type="button" class="btn btn--primary" data-submit-translation>插入消息</button>
+    </footer>
+    <script type="module" src="../webapp/dialog.js"></script>
+  </body>
+</html>

--- a/src/TlaPlugin/wwwroot/settings/index.html
+++ b/src/TlaPlugin/wwwroot/settings/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BOBTLA 设置页</title>
+    <link rel="stylesheet" href="../webapp/styles.css" />
+  </head>
+  <body class="settings" data-settings-root>
+    <header class="settings__header">
+      <h1>租户配置</h1>
+      <p>管理允许的模型、默认目标语言与术语策略。</p>
+    </header>
+    <main class="settings__main">
+      <section>
+        <h2>允许模型</h2>
+        <div class="settings__models" data-model-list></div>
+      </section>
+      <section>
+        <h2>默认目标语言</h2>
+        <select data-default-language aria-label="默认目标语言"></select>
+      </section>
+      <section>
+        <h2>默认语气</h2>
+        <select data-default-tone aria-label="默认语气"></select>
+      </section>
+      <section>
+        <label class="toggle">
+          <input type="checkbox" data-terminology-toggle checked /> 启用术语库
+        </label>
+      </section>
+      <section class="glossary">
+        <h2>术语库管理</h2>
+        <form class="glossary__form" data-glossary-form>
+          <div class="field">
+            <label>作用域
+              <select name="scopeType" data-glossary-scope>
+                <option value="tenant">租户</option>
+                <option value="channel">频道</option>
+                <option value="user">用户</option>
+              </select>
+            </label>
+          </div>
+          <div class="field">
+            <label>标识
+              <input type="text" name="scopeId" data-glossary-scope-id placeholder="例如 contoso" />
+            </label>
+          </div>
+          <div class="field">
+            <label>术语文件
+              <input type="file" name="file" data-glossary-file accept=".csv,.tbx,.xml" required />
+            </label>
+          </div>
+          <label class="toggle">
+            <input type="checkbox" name="overwrite" data-glossary-overwrite /> 覆盖冲突条目
+          </label>
+          <button type="submit" class="btn" data-glossary-submit>上传术语表</button>
+        </form>
+        <div class="glossary__progress" data-glossary-progress hidden>
+          <progress max="100" value="0"></progress>
+          <span data-glossary-progress-label>等待上传</span>
+        </div>
+        <div class="glossary__errors" data-glossary-errors hidden>
+          <h3>上传警告</h3>
+          <ul data-glossary-error-list></ul>
+        </div>
+        <div class="glossary__conflicts" data-glossary-conflicts hidden>
+          <h3>冲突条目</h3>
+          <ul data-glossary-conflict-list></ul>
+        </div>
+        <div class="glossary__list">
+          <h3>现有术语</h3>
+          <ul data-glossary-list></ul>
+        </div>
+        <div class="glossary__policies">
+          <h3>禁译库</h3>
+          <ul data-banned-term-list></ul>
+          <h3>风格模板</h3>
+          <ul data-style-template-list></ul>
+        </div>
+      </section>
+      <p class="settings__status" data-settings-status></p>
+    </main>
+    <footer class="settings__footer">
+      <button type="button" class="btn btn--primary" data-settings-save>保存配置</button>
+    </footer>
+    <script type="module" src="../webapp/settingsTab.js"></script>
+  </body>
+</html>

--- a/src/TlaPlugin/wwwroot/teamsClient/api.js
+++ b/src/TlaPlugin/wwwroot/teamsClient/api.js
@@ -1,0 +1,133 @@
+const FALLBACK_METADATA = {
+  models: [
+    { id: "azureOpenAI:gpt-4o", displayName: "Azure OpenAI GPT-4o", costPerCharUsd: 0.00002, latencyTargetMs: 1800 },
+    { id: "anthropic:claude-3", displayName: "Anthropic Claude 3", costPerCharUsd: 0.000018, latencyTargetMs: 2200 },
+    { id: "ollama:llama3", displayName: "Ollama Llama 3", costPerCharUsd: 0.000005, latencyTargetMs: 2500 }
+  ],
+  languages: [
+    { id: "auto", name: "自动检测", isDefault: true },
+    { id: "en", name: "English" },
+    { id: "zh-Hans", name: "简体中文" },
+    { id: "ja", name: "日本語" },
+    { id: "fr", name: "Français" }
+  ],
+  features: {
+    terminologyToggle: true,
+    offlineDraft: true,
+    toneToggle: true
+  },
+  pricing: {
+    currency: "USD",
+    dailyBudgetUsd: 20
+  }
+};
+
+async function parseJsonResponse(response, errorMessage) {
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`${errorMessage}: ${response.status} ${text}`);
+  }
+  return response.json();
+}
+
+export async function fetchMetadata(fetchImpl = fetch) {
+  try {
+    const response = await fetchImpl("/api/metadata", { method: "GET" });
+    return await parseJsonResponse(response, "metadata request failed");
+  } catch (error) {
+    console.warn("使用本地消息扩展元数据", error.message);
+    return FALLBACK_METADATA;
+  }
+}
+
+export async function detectLanguage(payload, fetchImpl = fetch) {
+  const response = await fetchImpl("/api/detect", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  return await parseJsonResponse(response, "语言检测失败");
+}
+
+export async function translateText(payload, fetchImpl = fetch) {
+  const response = await fetchImpl("/api/translate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  return await parseJsonResponse(response, "翻译接口失败");
+}
+
+export async function rewriteTranslation(payload, fetchImpl = fetch) {
+  const response = await fetchImpl("/api/rewrite", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  return await parseJsonResponse(response, "译文润色失败");
+}
+
+export async function sendReply(payload, fetchImpl = fetch) {
+  const response = await fetchImpl("/api/reply", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  return await parseJsonResponse(response, "发送回帖失败");
+}
+
+function buildAuthorizationHeader(authorization) {
+  if (!authorization) {
+    return undefined;
+  }
+  if (authorization.startsWith("Bearer ")) {
+    return authorization;
+  }
+  return `Bearer ${authorization}`;
+}
+
+export async function saveOfflineDraft(payload, fetchImpl = fetch, { authorization } = {}) {
+  const headers = {
+    "Content-Type": "application/json"
+  };
+  const headerValue = buildAuthorizationHeader(authorization);
+  if (headerValue) {
+    headers.Authorization = headerValue;
+  }
+  const response = await fetchImpl("/api/offline-draft", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload)
+  });
+  return await parseJsonResponse(response, "保存离线草稿失败");
+}
+
+export async function listOfflineDrafts({ userId }, fetchImpl = fetch, { authorization } = {}) {
+  if (!userId) {
+    throw new Error("缺少用户标识，无法获取离线草稿");
+  }
+  const headers = {};
+  const headerValue = buildAuthorizationHeader(authorization);
+  if (headerValue) {
+    headers.Authorization = headerValue;
+  }
+  const url = `/api/offline-draft?userId=${encodeURIComponent(userId)}`;
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers
+  });
+  return await parseJsonResponse(response, "获取离线草稿失败");
+}
+
+export { FALLBACK_METADATA };
+
+export default {
+  fetchMetadata,
+  detectLanguage,
+  translateText,
+  rewriteTranslation,
+  sendReply,
+  saveOfflineDraft,
+  listOfflineDrafts,
+  FALLBACK_METADATA
+};

--- a/src/TlaPlugin/wwwroot/teamsClient/composePlugin.js
+++ b/src/TlaPlugin/wwwroot/teamsClient/composePlugin.js
@@ -1,0 +1,178 @@
+import { ensureTeamsContext } from "./teamsContext.js";
+import { fetchMetadata, translateText, sendReply } from "./api.js";
+import {
+  buildDialogState,
+  buildTranslatePayload,
+  buildReplyPayload,
+  calculateCostHint,
+  updateStateWithResponse
+} from "./state.js";
+
+function resolveComposeUi(root = typeof document !== "undefined" ? document : undefined) {
+  if (!root) {
+    return {};
+  }
+  return {
+    input: root.querySelector?.("[data-compose-input]"),
+    targetSelect: root.querySelector?.("[data-compose-target]") ?? root.querySelector?.("[data-target-select]"),
+    suggestButton: root.querySelector?.("[data-compose-suggest]"),
+    applyButton: root.querySelector?.("[data-compose-apply]"),
+    preview: root.querySelector?.("[data-compose-preview]"),
+    terminologyToggle: root.querySelector?.("[data-terminology-toggle]"),
+    toneToggle: root.querySelector?.("[data-tone-toggle]"),
+    costHint: root.querySelector?.("[data-compose-cost]")
+  };
+}
+
+function setPreview(previewElement, text) {
+  if (!previewElement) {
+    return;
+  }
+  if ("value" in previewElement) {
+    previewElement.value = text;
+    return;
+  }
+  previewElement.textContent = text;
+}
+
+export async function initComposePlugin({ ui = resolveComposeUi(), teams, fetcher } = {}) {
+  const { teams: sdk, context } = await ensureTeamsContext({ teams });
+  const metadata = await fetchMetadata(fetcher);
+  const state = buildDialogState({ models: metadata.models, languages: metadata.languages, context });
+  state.text = "";
+  state.translation = "";
+
+  const targetLanguages = metadata.languages.filter((lang) => lang.id !== "auto");
+
+  if (ui.targetSelect && typeof ui.targetSelect.replaceChildren === "function" && typeof document !== "undefined") {
+    const nodes = targetLanguages.map((lang) => {
+      const option = document.createElement("option");
+      option.value = lang.id;
+      option.textContent = lang.name;
+      return option;
+    });
+    ui.targetSelect.replaceChildren(...nodes);
+  } else if (ui.targetSelect) {
+    ui.targetSelect.optionsData = targetLanguages;
+  }
+
+  const availableTargetIds = targetLanguages.map((lang) => lang.id);
+  const fallbackTarget = availableTargetIds[0] ?? "";
+  if (!availableTargetIds.includes(state.targetLanguage)) {
+    state.targetLanguage = fallbackTarget;
+  }
+
+  if (ui.targetSelect) {
+    if (!availableTargetIds.includes(ui.targetSelect.value)) {
+      ui.targetSelect.value = fallbackTarget;
+    }
+    ui.targetSelect.value = state.targetLanguage;
+    ui.targetSelect.addEventListener?.("change", (event) => {
+      state.targetLanguage = event.target.value;
+    });
+  }
+
+  if (ui.terminologyToggle) {
+    ui.terminologyToggle.checked = state.useTerminology;
+    ui.terminologyToggle.addEventListener?.("change", (event) => {
+      state.useTerminology = Boolean(event.target.checked);
+    });
+  }
+
+  if (ui.toneToggle) {
+    ui.toneToggle.checked = state.tone === "formal";
+    ui.toneToggle.addEventListener?.("change", (event) => {
+      state.tone = event.target.checked ? "formal" : "neutral";
+    });
+  }
+
+  const updateCost = () => {
+    if (ui.costHint && ui.input) {
+      state.text = ui.input.value ?? "";
+      state.charCount = state.text.length;
+      ui.costHint.textContent = calculateCostHint(state, metadata.models, metadata.pricing);
+    }
+  };
+
+  ui.input?.addEventListener?.("input", updateCost);
+  updateCost();
+
+  async function requestSuggestion() {
+    if (!ui.input) {
+      return;
+    }
+    state.text = ui.input.value ?? "";
+    if (!state.text.trim()) {
+      setPreview(ui.preview, "请输入要翻译的文本");
+      return;
+    }
+    const payload = buildTranslatePayload({ ...state }, context);
+    try {
+      const response = await translateText(payload, fetcher);
+      const nextState = updateStateWithResponse(state, response);
+      Object.assign(state, nextState);
+      if (ui.toneToggle) {
+        ui.toneToggle.checked = state.tone === "formal";
+      }
+      setPreview(ui.preview, state.translation ?? "");
+    } catch (error) {
+      setPreview(ui.preview, `翻译失败：${error.message}`);
+    }
+  }
+
+  ui.suggestButton?.addEventListener?.("click", () => requestSuggestion());
+
+  ui.applyButton?.addEventListener?.("click", async () => {
+    if (!state.translation) {
+      await requestSuggestion();
+    }
+    const finalText = state.translation;
+    if (!finalText) {
+      return;
+    }
+    const replyPayload = buildReplyPayload(state, context, finalText);
+    let replyResult;
+    try {
+      replyResult = await sendReply(replyPayload, fetcher);
+    } catch (error) {
+      setPreview(ui.preview, `发送失败：${error.message}`);
+      return;
+    }
+    if (sdk.conversations?.sendMessageToConversation) {
+      const message = {
+        conversationId: context?.channel?.id
+      };
+      if (replyResult?.card) {
+        message.attachments = [
+          {
+            contentType: "application/vnd.microsoft.card.adaptive",
+            content: replyResult.card
+          }
+        ];
+        message.type = "card";
+      } else {
+        message.content = finalText;
+        message.type = "text";
+      }
+      await sdk.conversations.sendMessageToConversation(message);
+    } else if (ui.input) {
+      ui.input.value = finalText;
+    }
+    setPreview(ui.preview, replyResult?.card ? "已发送 Adaptive Card 回贴" : finalText);
+  });
+
+  return { state, metadata, context };
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", () => {
+    const composeRoot = document.querySelector?.("[data-compose-root]");
+    if (composeRoot) {
+      initComposePlugin().catch((error) => console.error("初始化 Compose 插件失败", error));
+    }
+  });
+}
+
+export default {
+  initComposePlugin
+};

--- a/src/TlaPlugin/wwwroot/teamsClient/messageExtensionDialog.js
+++ b/src/TlaPlugin/wwwroot/teamsClient/messageExtensionDialog.js
@@ -1,0 +1,501 @@
+import { ensureTeamsContext } from "./teamsContext.js";
+import { fetchMetadata, detectLanguage, translateText, rewriteTranslation, sendReply, saveOfflineDraft, listOfflineDrafts } from "./api.js";
+import {
+  buildDialogState,
+  calculateCostHint,
+  buildTranslatePayload,
+  buildDetectPayload,
+  buildRewritePayload,
+  buildReplyPayload,
+  updateStateWithResponse,
+  resolveThreadId
+} from "./state.js";
+
+function resolveDialogUi(root = typeof document !== "undefined" ? document : undefined) {
+  if (!root) {
+    return {};
+  }
+  return {
+    modelSelect: root.querySelector?.("[data-model-select]"),
+    sourceSelect: root.querySelector?.("[data-source-select]"),
+    targetSelect: root.querySelector?.("[data-target-select]"),
+    terminologyToggle: root.querySelector?.("[data-terminology-toggle]"),
+    toneToggle: root.querySelector?.("[data-tone-toggle]"),
+    ragToggle: root.querySelector?.("[data-rag-toggle]"),
+    contextHintsInput: root.querySelector?.("[data-context-hints]"),
+    costHint: root.querySelector?.("[data-cost-hint]"),
+    detectedLabel: root.querySelector?.("[data-detected-language]"),
+    input: root.querySelector?.("[data-source-text]"),
+    translation: root.querySelector?.("[data-translation-text]"),
+    previewButton: root.querySelector?.("[data-preview-translation]"),
+    submitButton: root.querySelector?.("[data-submit-translation]"),
+    errorBanner: root.querySelector?.("[data-error-banner]"),
+    offlineSection: root.querySelector?.("[data-offline-draft-section]"),
+    offlineStatus: root.querySelector?.("[data-offline-draft-status]"),
+    offlineList: root.querySelector?.("[data-offline-draft-list]"),
+    offlineButton: root.querySelector?.("[data-save-offline-draft]")
+  };
+}
+
+function parseContextHints(input) {
+  if (typeof input !== "string") {
+    return [];
+  }
+  return input
+    .split(/\r?\n/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function applySelectOptions(element, options, { valueKey, labelKey }) {
+  if (!element || !Array.isArray(options)) {
+    return;
+  }
+  const entries = options.map((item) => ({ value: item[valueKey], label: item[labelKey] ?? item[valueKey] }));
+  if (typeof element.replaceChildren === "function" && typeof document !== "undefined" && document?.createElement) {
+    const nodes = entries.map((entry) => {
+      const option = document.createElement("option");
+      option.value = entry.value;
+      option.textContent = entry.label;
+      return option;
+    });
+    element.replaceChildren(...nodes);
+  } else {
+    element.optionsData = entries;
+  }
+  if (entries.length && element.value === undefined) {
+    element.value = entries[0].value;
+  }
+}
+
+function bindCostHint(ui, state, metadata) {
+  if (!ui.costHint) {
+    return;
+  }
+  ui.costHint.textContent = calculateCostHint(state, metadata.models, metadata.pricing);
+}
+
+function updateError(ui, message) {
+  if (!ui.errorBanner) {
+    return;
+  }
+  if (!message) {
+    ui.errorBanner.textContent = "";
+    ui.errorBanner.hidden = true;
+    return;
+  }
+  ui.errorBanner.hidden = false;
+  ui.errorBanner.textContent = message;
+}
+
+function updateDetectedLanguageLabel(ui, state, languages) {
+  if (!ui.detectedLabel) {
+    return;
+  }
+  if (!state.detectedLanguage) {
+    ui.detectedLabel.textContent = "自动检测：--";
+    ui.detectedLabel.hidden = false;
+    return;
+  }
+  const matched = languages.find((lang) => lang.id === state.detectedLanguage);
+  const display = matched?.name ?? state.detectedLanguage;
+  const confidenceValue = state.detectionConfidence ?? 0;
+  const confidence = confidenceValue ? `（置信度 ${(confidenceValue * 100).toFixed(0)}%）` : "";
+  ui.detectedLabel.textContent = `自动检测：${display}${confidence}`;
+  ui.detectedLabel.hidden = false;
+}
+
+function updateOfflineStatus(ui, message, { isError = false } = {}) {
+  if (!ui.offlineStatus) {
+    return;
+  }
+  if (!message) {
+    ui.offlineStatus.textContent = "";
+    ui.offlineStatus.hidden = true;
+    if (ui.offlineStatus.dataset) {
+      ui.offlineStatus.dataset.variant = "";
+    }
+    return;
+  }
+  ui.offlineStatus.hidden = false;
+  ui.offlineStatus.textContent = message;
+  if (!ui.offlineStatus.dataset) {
+    ui.offlineStatus.dataset = {};
+  }
+  ui.offlineStatus.dataset.variant = isError ? "error" : "";
+}
+
+function describeDraft(draft) {
+  const id = draft.id ?? draft.Id ?? "--";
+  const status = draft.status ?? draft.Status ?? "未知";
+  const target = draft.targetLanguage ?? draft.TargetLanguage ?? "--";
+  const attempts = draft.attempts ?? draft.Attempts ?? 0;
+  const result = draft.resultText ?? draft.ResultText;
+  const error = draft.errorReason ?? draft.ErrorReason;
+  const parts = [`#${id}`, status, `目标 ${target}`, `重试 ${attempts}`];
+  if (status === "SUCCEEDED" && result) {
+    const preview = String(result).slice(0, 40);
+    parts.push(`结果：${preview}${result.length > 40 ? "…" : ""}`);
+  }
+  if (status === "FAILED" && error) {
+    parts.push(`原因：${error}`);
+  }
+  return parts.join(" · ");
+}
+
+function renderOfflineDrafts(ui, drafts) {
+  if (!ui.offlineList) {
+    return;
+  }
+  if (!Array.isArray(drafts) || drafts.length === 0) {
+    if (typeof ui.offlineList.replaceChildren === "function" && typeof document !== "undefined" && document?.createElement) {
+      ui.offlineList.replaceChildren();
+    }
+    ui.offlineList.items = [];
+    return;
+  }
+  const entries = drafts.map((draft) => {
+    const label = describeDraft(draft);
+    if (typeof document !== "undefined" && typeof document?.createElement === "function") {
+      const item = document.createElement("li");
+      item.textContent = label;
+      return item;
+    }
+    return { textContent: label, draft };
+  });
+  if (typeof ui.offlineList.replaceChildren === "function" && typeof document !== "undefined" && document?.createElement) {
+    ui.offlineList.replaceChildren(...entries);
+  } else {
+    ui.offlineList.items = entries;
+  }
+}
+
+export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams, fetcher } = {}) {
+  const { teams: sdk, context } = await ensureTeamsContext({ teams });
+  const metadata = await fetchMetadata(fetcher);
+  const state = buildDialogState({ models: metadata.models, languages: metadata.languages, context });
+  state.threadId = state.threadId ?? resolveThreadId(context);
+
+  applySelectOptions(ui.modelSelect, metadata.models, { valueKey: "id", labelKey: "displayName" });
+  applySelectOptions(ui.sourceSelect, metadata.languages, { valueKey: "id", labelKey: "name" });
+
+  const targetLanguages = metadata.languages.filter((lang) => lang.id !== "auto");
+  applySelectOptions(ui.targetSelect, targetLanguages, {
+    valueKey: "id",
+    labelKey: "name"
+  });
+
+  const availableTargetIds = targetLanguages.map((lang) => lang.id);
+  const fallbackTarget = availableTargetIds[0] ?? "";
+  if (!availableTargetIds.includes(state.targetLanguage)) {
+    state.targetLanguage = fallbackTarget;
+  }
+
+  if (ui.modelSelect) {
+    ui.modelSelect.value = state.modelId;
+    ui.modelSelect.addEventListener?.("change", (event) => {
+      state.modelId = event.target.value;
+      bindCostHint(ui, state, metadata);
+    });
+  }
+  if (ui.sourceSelect) {
+    ui.sourceSelect.value = state.sourceLanguage;
+    ui.sourceSelect.addEventListener?.("change", (event) => {
+      state.sourceLanguage = event.target.value;
+      if (state.sourceLanguage !== "auto") {
+        state.detectedLanguage = undefined;
+        state.detectionConfidence = 0;
+      }
+      updateDetectedLanguageLabel(ui, state, metadata.languages);
+    });
+  }
+  if (ui.targetSelect) {
+    if (!availableTargetIds.includes(ui.targetSelect.value)) {
+      ui.targetSelect.value = fallbackTarget;
+    }
+    ui.targetSelect.value = state.targetLanguage;
+    ui.targetSelect.addEventListener?.("change", (event) => {
+      state.targetLanguage = event.target.value;
+    });
+  }
+  if (ui.terminologyToggle) {
+    ui.terminologyToggle.checked = state.useTerminology;
+    ui.terminologyToggle.addEventListener?.("change", (event) => {
+      state.useTerminology = Boolean(event.target.checked);
+    });
+  }
+  if (ui.toneToggle) {
+    ui.toneToggle.checked = state.tone === "formal";
+    ui.toneToggle.addEventListener?.("change", (event) => {
+      state.tone = event.target.checked ? "formal" : "neutral";
+    });
+  }
+  if (ui.ragToggle) {
+    ui.ragToggle.checked = Boolean(state.useRag);
+    ui.ragToggle.addEventListener?.("change", (event) => {
+      state.useRag = Boolean(event.target.checked);
+    });
+  }
+  if (ui.contextHintsInput) {
+    ui.contextHintsInput.value = (state.contextHints ?? []).join("\n");
+    ui.contextHintsInput.addEventListener?.("input", (event) => {
+      const value = event.target.value ?? "";
+      state.contextHints = parseContextHints(value);
+    });
+  }
+
+  bindCostHint(ui, state, metadata);
+  updateDetectedLanguageLabel(ui, state, metadata.languages);
+
+  let detectToken = 0;
+  async function triggerDetection() {
+    if (!state.text.trim() || state.sourceLanguage !== "auto") {
+      return;
+    }
+    const currentToken = ++detectToken;
+    try {
+      const detectPayload = buildDetectPayload(state, context);
+      const detection = await detectLanguage(detectPayload, fetcher);
+      if (currentToken !== detectToken) {
+        return;
+      }
+      state.detectedLanguage = detection.language;
+      state.detectionConfidence = detection.confidence ?? 0;
+      updateDetectedLanguageLabel(ui, state, metadata.languages);
+    } catch (error) {
+      if (currentToken === detectToken) {
+        updateDetectedLanguageLabel(ui, { detectedLanguage: undefined, detectionConfidence: 0 }, metadata.languages);
+        console.warn("语言检测失败", error);
+      }
+    }
+  }
+
+  if (ui.input) {
+    ui.input.addEventListener?.("input", (event) => {
+      state.text = event.target.value ?? "";
+      state.charCount = state.text.length;
+      bindCostHint(ui, state, metadata);
+      triggerDetection();
+    });
+  }
+
+  async function requestTranslation() {
+    try {
+      updateError(ui, "");
+      const payload = buildTranslatePayload(state, context);
+      const response = await translateText(payload, fetcher);
+      if (response?.type === "glossaryConflict") {
+        sdk.dialog?.submit?.({
+          type: "glossaryConflict",
+          card: response.attachments?.[0]?.content ?? null,
+          attachments: response.attachments ?? [],
+          metadata: response.metadata ?? {}
+        });
+        return state;
+      }
+      const nextState = updateStateWithResponse(state, response);
+      state.translation = nextState.translation;
+      state.modelId = nextState.modelId;
+      if (response.metadata?.tone) {
+        state.tone = response.metadata.tone;
+        if (ui.toneToggle) {
+          ui.toneToggle.checked = state.tone === "formal";
+        }
+      }
+      if (response.detectedLanguage) {
+        state.detectedLanguage = response.detectedLanguage;
+        updateDetectedLanguageLabel(ui, state, metadata.languages);
+      }
+      if (ui.translation) {
+        ui.translation.value = nextState.translation ?? "";
+      }
+      bindCostHint(ui, state, metadata);
+      return nextState;
+    } catch (error) {
+      updateError(ui, error.message);
+      throw error;
+    }
+  }
+
+  ui.previewButton?.addEventListener?.("click", () => requestTranslation());
+
+  const supportsOfflineDraft = Boolean(metadata.features?.offlineDraft);
+  if (ui.offlineSection) {
+    ui.offlineSection.hidden = !supportsOfflineDraft;
+  }
+  if (ui.offlineButton) {
+    ui.offlineButton.hidden = !supportsOfflineDraft;
+  }
+
+  let cachedAuthorization;
+  async function resolveAuthorization() {
+    if (cachedAuthorization !== undefined) {
+      return cachedAuthorization;
+    }
+    if (sdk?.authentication?.getAuthToken) {
+      try {
+        const token = await sdk.authentication.getAuthToken();
+        if (token) {
+          cachedAuthorization = `Bearer ${token}`;
+          return cachedAuthorization;
+        }
+      } catch (error) {
+        console.warn("获取 Teams OAuth 令牌失败", error);
+      }
+    }
+    const fallback = context?.user?.id ?? context?.user?.aadObjectId;
+    cachedAuthorization = fallback ? `Bearer ${fallback}` : undefined;
+    return cachedAuthorization;
+  }
+
+  async function refreshOfflineDrafts() {
+    if (!supportsOfflineDraft || !context?.user?.id) {
+      return;
+    }
+    try {
+      const authorization = await resolveAuthorization();
+      const response = await listOfflineDrafts({ userId: context.user.id }, fetcher, { authorization });
+      const draftsPayload = response?.drafts ?? response?.Drafts;
+      const drafts = Array.isArray(draftsPayload) ? draftsPayload : [];
+      renderOfflineDrafts(ui, drafts);
+      const completed = drafts.find((draft) => (draft.status ?? draft.Status) === "SUCCEEDED");
+      if (completed) {
+        const id = completed.id ?? completed.Id ?? "--";
+        updateOfflineStatus(ui, `草稿 #${id} 已完成翻译，可直接回贴或在 Teams 活动提要查看。`);
+        return;
+      }
+      const failed = drafts.find((draft) => (draft.status ?? draft.Status) === "FAILED");
+      if (failed) {
+        const id = failed.id ?? failed.Id ?? "--";
+        const reason = failed.errorReason ?? failed.ErrorReason ?? "未知原因";
+        updateOfflineStatus(ui, `草稿 #${id} 多次失败：${reason}`, { isError: true });
+        return;
+      }
+      if (drafts.length > 0) {
+        const waiting = drafts.some((draft) => (draft.status ?? draft.Status) === "PROCESSING");
+        const pending = drafts.some((draft) => (draft.status ?? draft.Status) === "PENDING");
+        if (waiting || pending) {
+          updateOfflineStatus(ui, "草稿正在后台翻译，稍后将通过 Teams 提醒您。");
+          return;
+        }
+      }
+      updateOfflineStatus(ui, "");
+    } catch (error) {
+      console.warn("获取离线草稿失败", error);
+      updateOfflineStatus(ui, `草稿列表更新失败：${error.message ?? error}`, { isError: true });
+    }
+  }
+
+  if (supportsOfflineDraft) {
+    await refreshOfflineDrafts();
+  }
+
+  ui.offlineButton?.addEventListener?.("click", async () => {
+    if (!supportsOfflineDraft) {
+      return;
+    }
+    const originalText = ui.input?.value ?? state.text ?? "";
+    if (!originalText.trim()) {
+      updateOfflineStatus(ui, "请输入要保存的原文", { isError: true });
+      return;
+    }
+    const payload = {
+      originalText,
+      targetLanguage: state.targetLanguage,
+      tenantId: context?.tenant?.id,
+      userId: context?.user?.id,
+      sourceLanguage: state.sourceLanguage,
+      channelId: context?.channel?.id,
+      metadata: { modelId: state.modelId },
+      threadId: state.threadId ?? resolveThreadId(context)
+    };
+    updateOfflineStatus(ui, "正在保存离线草稿…");
+    try {
+      const authorization = await resolveAuthorization();
+      const response = await saveOfflineDraft(payload, fetcher, { authorization });
+      if (response?.type === "offlineDraftSaved") {
+        const draftPayload = response.draft ?? {};
+        const draftId = response.draftId ?? draftPayload.id ?? response.id ?? "--";
+        const status = response.status ?? draftPayload.status ?? "PENDING";
+        updateOfflineStatus(ui, `草稿 #${draftId} 已保存，当前状态：${status}`);
+        await refreshOfflineDrafts();
+      } else {
+        updateOfflineStatus(ui, "草稿保存结果未知", { isError: true });
+      }
+    } catch (error) {
+      updateOfflineStatus(ui, `保存草稿失败：${error.message ?? error}`, { isError: true });
+    }
+  });
+
+  ui.submitButton?.addEventListener?.("click", async () => {
+    if (!state.translation && state.text) {
+      try {
+        await requestTranslation();
+      } catch (error) {
+        return;
+      }
+    }
+    const edited = ui.translation?.value ?? state.translation;
+    let finalText = edited;
+    if (edited?.trim()) {
+      try {
+        const rewritePayload = buildRewritePayload(state, context, edited);
+        const rewriteResult = await rewriteTranslation(rewritePayload, fetcher);
+        finalText = rewriteResult.text ?? edited;
+        state.translation = finalText;
+        if (rewriteResult.metadata?.tone) {
+          state.tone = rewriteResult.metadata.tone;
+          if (ui.toneToggle) {
+            ui.toneToggle.checked = state.tone === "formal";
+          }
+        }
+        if (ui.translation) {
+          ui.translation.value = finalText;
+        }
+      } catch (error) {
+        updateError(ui, error.message);
+        return;
+      }
+    }
+    if (finalText?.trim()) {
+      try {
+        const replyPayload = buildReplyPayload(state, context, finalText);
+        const replyResult = await sendReply(replyPayload, fetcher);
+        sdk.dialog?.submit?.({
+          translation: finalText,
+          targetLanguage: state.targetLanguage,
+          modelId: state.modelId,
+          useTerminology: state.useTerminology,
+          tone: state.tone,
+          detectedLanguage: state.detectedLanguage,
+          card: replyResult?.card,
+          replyStatus: replyResult?.status
+        });
+      } catch (error) {
+        updateError(ui, error.message);
+        return;
+      }
+      return;
+    }
+    sdk.dialog?.submit?.({
+      translation: finalText,
+      targetLanguage: state.targetLanguage,
+      modelId: state.modelId,
+      useTerminology: state.useTerminology,
+      tone: state.tone,
+      detectedLanguage: state.detectedLanguage
+    });
+  });
+
+  return { state, metadata, context };
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", () => {
+    initMessageExtensionDialog().catch((error) => console.error("初始化消息扩展对话框失败", error));
+  });
+}
+
+export default {
+  initMessageExtensionDialog
+};

--- a/src/TlaPlugin/wwwroot/teamsClient/settingsTab.js
+++ b/src/TlaPlugin/wwwroot/teamsClient/settingsTab.js
@@ -1,0 +1,176 @@
+import { ensureTeamsContext } from "./teamsContext.js";
+import { fetchMetadata } from "./api.js";
+import { buildDialogState } from "./state.js";
+
+function resolveSettingsUi(root = typeof document !== "undefined" ? document : undefined) {
+  if (!root) {
+    return {};
+  }
+  return {
+    modelContainer: root.querySelector?.("[data-model-list]"),
+    defaultLanguageSelect: root.querySelector?.("[data-default-language]"),
+    terminologyToggle: root.querySelector?.("[data-terminology-toggle]"),
+    toneSelect: root.querySelector?.("[data-default-tone]"),
+    statusLabel: root.querySelector?.("[data-settings-status]"),
+    saveButton: root.querySelector?.("[data-settings-save]")
+  };
+}
+
+function renderModelList(container, models, state) {
+  if (!container) {
+    return;
+  }
+  if (typeof container.replaceChildren === "function" && typeof document !== "undefined") {
+    const nodes = models.map((model) => {
+      const label = document.createElement("label");
+      label.className = "model-item";
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.value = model.id;
+      checkbox.checked = state.allowedModels.has(model.id);
+      checkbox.addEventListener("change", (event) => {
+        if (event.target.checked) {
+          state.allowedModels.add(model.id);
+        } else {
+          state.allowedModels.delete(model.id);
+        }
+      });
+      const span = document.createElement("span");
+      span.textContent = `${model.displayName ?? model.id}（${model.costPerCharUsd} USD/char）`;
+      label.append(checkbox, span);
+      return label;
+    });
+    container.replaceChildren(...nodes);
+  } else {
+    container.items = models;
+  }
+}
+
+function renderDefaultLanguage(select, languages, state) {
+  if (!select) {
+    return;
+  }
+  const candidates = languages.filter((lang) => lang.id !== "auto");
+  const candidateIds = candidates.map((lang) => lang.id);
+  const fallbackTarget = candidateIds[0] ?? "";
+  if (!candidateIds.includes(state.targetLanguage)) {
+    state.targetLanguage = fallbackTarget;
+  }
+  if (typeof select.replaceChildren === "function" && typeof document !== "undefined") {
+    const options = candidates.map((lang) => {
+      const option = document.createElement("option");
+      option.value = lang.id;
+      option.textContent = lang.name;
+      return option;
+    });
+    select.replaceChildren(...options);
+  } else {
+    select.optionsData = candidates;
+  }
+  if (!candidateIds.includes(select.value)) {
+    select.value = fallbackTarget;
+  }
+  select.value = state.targetLanguage;
+  select.addEventListener?.("change", (event) => {
+    state.targetLanguage = event.target.value;
+  });
+}
+
+function renderToneOptions(select, state) {
+  if (!select) {
+    return;
+  }
+  const options = [
+    { value: "neutral", label: "默认语气" },
+    { value: "formal", label: "正式语气" }
+  ];
+  if (typeof select.replaceChildren === "function" && typeof document !== "undefined") {
+    const nodes = options.map((option) => {
+      const node = document.createElement("option");
+      node.value = option.value;
+      node.textContent = option.label;
+      return node;
+    });
+    select.replaceChildren(...nodes);
+  } else {
+    select.optionsData = options;
+  }
+  select.value = state.tone;
+  select.addEventListener?.("change", (event) => {
+    state.tone = event.target.value;
+  });
+}
+
+export function buildTenantConfig(state, context) {
+  return {
+    tenantId: context?.tenant?.id,
+    defaultTargetLanguage: state.targetLanguage,
+    allowedModels: Array.from(state.allowedModels),
+    features: {
+      terminology: Boolean(state.useTerminology),
+      tone: state.tone
+    }
+  };
+}
+
+export async function initSettingsTab({ ui = resolveSettingsUi(), teams, fetcher } = {}) {
+  const { teams: sdk, context } = await ensureTeamsContext({ teams });
+  const metadata = await fetchMetadata(fetcher);
+  const baseState = buildDialogState({ models: metadata.models, languages: metadata.languages, context });
+  const state = {
+    targetLanguage: baseState.targetLanguage,
+    allowedModels: new Set(metadata.models.map((model) => model.id)),
+    useTerminology: true,
+    tone: baseState.tone
+  };
+
+  renderModelList(ui.modelContainer, metadata.models, state);
+  renderDefaultLanguage(ui.defaultLanguageSelect, metadata.languages, state);
+  renderToneOptions(ui.toneSelect, state);
+
+  if (ui.terminologyToggle) {
+    ui.terminologyToggle.checked = state.useTerminology;
+    ui.terminologyToggle.addEventListener?.("change", (event) => {
+      state.useTerminology = Boolean(event.target.checked);
+    });
+  }
+
+  sdk.pages?.config?.setValidityState?.(true);
+  let saveHandler;
+  sdk.pages?.config?.registerOnSaveHandler?.((event) => {
+    saveHandler = event;
+  });
+
+  async function persistSettings() {
+    const config = buildTenantConfig(state, context);
+    const currentUrl = typeof window !== "undefined" ? window.location?.href : "";
+    await sdk.pages?.config?.setConfig?.({
+      entityId: "bobtla-settings",
+      contentUrl: config.contentUrl ?? currentUrl ?? "",
+      suggestedDisplayName: "BOBTLA 设置",
+      state: JSON.stringify(config)
+    });
+    saveHandler?.notifySuccess?.();
+    if (ui.statusLabel) {
+      ui.statusLabel.textContent = "已保存";
+    }
+  }
+
+  ui.saveButton?.addEventListener?.("click", () => persistSettings());
+
+  return { state, metadata, context };
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", () => {
+    const settingsRoot = document.querySelector?.("[data-settings-root]");
+    if (settingsRoot) {
+      initSettingsTab().catch((error) => console.error("初始化设置页失败", error));
+    }
+  });
+}
+
+export default {
+  initSettingsTab,
+  buildTenantConfig
+};

--- a/src/TlaPlugin/wwwroot/teamsClient/state.js
+++ b/src/TlaPlugin/wwwroot/teamsClient/state.js
@@ -1,0 +1,212 @@
+import { FALLBACK_METADATA } from "./api.js";
+
+function isSelectableLanguage(language) {
+  return Boolean(language?.id) && language.id !== "auto";
+}
+
+function resolveDefaultTargetLanguage(languages = [], locale = "") {
+  if (!Array.isArray(languages) || languages.length === 0) {
+    return "en";
+  }
+  const exactLocale = languages.find((lang) => lang.id === locale);
+  if (isSelectableLanguage(exactLocale)) {
+    return exactLocale.id;
+  }
+  const normalized = locale?.split?.("-")?.[0];
+  if (normalized) {
+    const match = languages.find((lang) => lang.id === normalized);
+    if (isSelectableLanguage(match)) {
+      return match.id;
+    }
+  }
+  const defaultLocale = languages.find((lang) => lang.isDefault && isSelectableLanguage(lang));
+  if (defaultLocale) {
+    return defaultLocale.id;
+  }
+  const firstSelectable = languages.find((lang) => isSelectableLanguage(lang));
+  if (firstSelectable) {
+    return firstSelectable.id;
+  }
+  return languages[0]?.id ?? "en";
+}
+
+export function resolveThreadId(context) {
+  return (
+    context?.message?.threadId ??
+    context?.message?.replyToId ??
+    context?.message?.id ??
+    context?.conversation?.id ??
+    context?.chat?.id ??
+    undefined
+  );
+}
+
+export function buildDialogState({ models, languages, context } = {}) {
+  const metadata = {
+    models: models?.length ? models : FALLBACK_METADATA.models,
+    languages: languages?.length ? languages : FALLBACK_METADATA.languages
+  };
+  const defaultModel = metadata.models[0];
+  const targetLanguage = resolveDefaultTargetLanguage(metadata.languages, context?.app?.locale ?? "");
+  return {
+    text: "",
+    translation: "",
+    modelId: defaultModel?.id ?? "",
+    sourceLanguage: metadata.languages[0]?.id ?? "auto",
+    targetLanguage,
+    threadId: resolveThreadId(context),
+    useTerminology: true,
+    useRag: false,
+    contextHints: [],
+    tone: "neutral",
+    charCount: 0,
+    detectedLanguage: undefined,
+    detectionConfidence: 0
+  };
+}
+
+function normalizeContextHints(hints) {
+  if (!hints) {
+    return [];
+  }
+  const list = Array.isArray(hints) ? hints : [hints];
+  return list
+    .map((item) => (typeof item === "string" ? item.trim() : ""))
+    .filter(Boolean);
+}
+
+function applyRagPreferences(payload, state) {
+  if (!payload || !state) {
+    return payload;
+  }
+  const contextHints = normalizeContextHints(state.contextHints);
+  payload.useRag = Boolean(state.useRag);
+  payload.contextHints = contextHints;
+  return payload;
+}
+
+export function calculateCostHint({ charCount, modelId }, models = [], pricing = {}) {
+  const model = models.find((item) => item.id === modelId);
+  if (!model) {
+    return "";
+  }
+  const cost = Number(model.costPerCharUsd ?? 0) * (charCount ?? 0);
+  const currency = pricing.currency ?? "USD";
+  const formatted = cost ? cost.toFixed(6) : "0";
+  return `预计成本：${currency} ${formatted}（${charCount ?? 0} 字符 @ ${model.id}）`;
+}
+
+export function buildTranslatePayload(state, context) {
+  if (!state?.text?.trim()) {
+    throw new Error("缺少要翻译的文本");
+  }
+  if (!state.targetLanguage) {
+    throw new Error("缺少目标语言");
+  }
+  const payload = {
+    text: state.text,
+    sourceLanguage: state.sourceLanguage === "auto" ? undefined : state.sourceLanguage,
+    targetLanguage: state.targetLanguage,
+    tenantId: context?.tenant?.id,
+    userId: context?.user?.id,
+    channelId: context?.channel?.id,
+    metadata: {
+      origin: "messageExtension",
+      modelId: state.modelId,
+      useTerminology: Boolean(state.useTerminology),
+      tone: state.tone
+    }
+  };
+  const threadId = state?.threadId ?? resolveThreadId(context);
+  if (threadId) {
+    payload.threadId = threadId;
+  }
+  return applyRagPreferences(payload, state);
+}
+
+export function buildDetectPayload(state, context) {
+  return {
+    text: state.text,
+    tenantId: context?.tenant?.id,
+    userId: context?.user?.id
+  };
+}
+
+export function buildRewritePayload(state, context, text) {
+  if (!text?.trim()) {
+    throw new Error("缺少润色文本");
+  }
+  const payload = {
+    text,
+    targetLanguage: state.targetLanguage,
+    tone: state.tone,
+    tenantId: context?.tenant?.id,
+    userId: context?.user?.id,
+    channelId: context?.channel?.id,
+    metadata: {
+      origin: "messageExtension",
+      modelId: state.modelId,
+      useTerminology: Boolean(state.useTerminology)
+    }
+  };
+  const threadId = state?.threadId ?? resolveThreadId(context);
+  if (threadId) {
+    payload.threadId = threadId;
+  }
+  return payload;
+}
+
+export function buildReplyPayload(state, context, text) {
+  if (!text?.trim()) {
+    throw new Error("缺少回帖文本");
+  }
+  const payload = {
+    translation: text,
+    sourceLanguage: state.sourceLanguage === "auto" ? state.detectedLanguage : state.sourceLanguage,
+    targetLanguage: state.targetLanguage,
+    tenantId: context?.tenant?.id,
+    userId: context?.user?.id,
+    channelId: context?.channel?.id,
+    metadata: {
+      modelId: state.modelId,
+      tone: state.tone,
+      useTerminology: Boolean(state.useTerminology)
+    }
+  };
+  const threadId = state?.threadId ?? resolveThreadId(context);
+  if (threadId) {
+    payload.threadId = threadId;
+  }
+  return applyRagPreferences(payload, state);
+}
+
+export function updateStateWithResponse(state, response) {
+  if (!state || !response) {
+    return state;
+  }
+  const next = { ...state };
+  if (typeof response.text === "string") {
+    next.translation = response.text;
+  }
+  if (response.metadata?.modelId) {
+    next.modelId = response.metadata.modelId;
+  }
+  if (response.metadata?.tone) {
+    next.tone = response.metadata.tone;
+  }
+  if (response.detectedLanguage) {
+    next.detectedLanguage = response.detectedLanguage;
+  }
+  return next;
+}
+
+export default {
+  buildDialogState,
+  calculateCostHint,
+  buildTranslatePayload,
+  buildDetectPayload,
+  buildRewritePayload,
+  buildReplyPayload,
+  updateStateWithResponse,
+  resolveThreadId
+};

--- a/src/TlaPlugin/wwwroot/teamsClient/teamsContext.js
+++ b/src/TlaPlugin/wwwroot/teamsClient/teamsContext.js
@@ -1,0 +1,1 @@
+export { resolveTeamsSdk, ensureTeamsContext, DEFAULT_CONTEXT } from "../webapp/teamsContext.js";

--- a/src/TlaPlugin/wwwroot/webapp/apiClient.js
+++ b/src/TlaPlugin/wwwroot/webapp/apiClient.js
@@ -1,0 +1,12 @@
+export {
+  FALLBACK_METADATA,
+  fetchMetadata,
+  detectLanguage,
+  translateText,
+  rewriteTranslation,
+  sendReply,
+  saveOfflineDraft,
+  listOfflineDrafts
+} from "../teamsClient/api.js";
+
+export { default } from "../teamsClient/api.js";

--- a/src/TlaPlugin/wwwroot/webapp/app.js
+++ b/src/TlaPlugin/wwwroot/webapp/app.js
@@ -1,0 +1,755 @@
+import { buildStatusCards, formatLocaleOptions } from "./viewModel.js";
+
+const FALLBACK_STATUS = {
+  currentStageId: "phase4",
+  overallCompletionPercent: 60,
+  nextSteps: [
+    "完善设置页组件并补全前端校验",
+    "串联状态/路标 API 与实时刷新机制",
+    "安排跨团队联调与上线验收"
+  ],
+  stages: [
+    { id: "phase1", name: "阶段 1：平台基线", completed: true },
+    { id: "phase2", name: "阶段 2：安全与合规", completed: true },
+    { id: "phase3", name: "阶段 3：性能与可观测", completed: true },
+    { id: "phase4", name: "阶段 4：前端体验", completed: false },
+    { id: "phase5", name: "阶段 5：上线准备", completed: false }
+  ],
+  frontend: {
+    completionPercent: 55,
+    dataPlaneReady: true,
+    uiImplemented: true,
+    integrationReady: false
+  }
+};
+
+const FALLBACK_ROADMAP = {
+  activeStageId: "phase4",
+  stages: [
+    {
+      id: "phase1",
+      name: "阶段 1：平台基线",
+      objective: "完成需求吸收、Minimal API 与消息扩展骨架。",
+      completed: true,
+      deliverables: [
+        "梳理 BOBTLA 需求说明书",
+        "搭建 .NET Minimal API + SQLite 基础设施",
+        "交付消息扩展与 Adaptive Card 主流程"
+      ]
+    },
+    {
+      id: "phase2",
+      name: "阶段 2：安全与合规",
+      objective: "上线合规网关、预算守卫与密钥/OBO 管理。",
+      completed: true,
+      deliverables: [
+        "ComplianceGateway 区域与禁译策略",
+        "BudgetGuard 成本追踪",
+        "KeyVaultSecretResolver 与 TokenBroker 一体化"
+      ]
+    },
+    {
+      id: "phase3",
+      name: "阶段 3：性能与可观测",
+      objective: "优化缓存、速率与多模型互联并沉淀指标。",
+      completed: true,
+      deliverables: [
+        "TranslationCache 去重",
+        "TranslationThrottle 并发与速率限制",
+        "UsageMetricsService 聚合监控"
+      ]
+    },
+    {
+      id: "phase4",
+      name: "阶段 4：前端体验",
+      objective: "构建 Teams 设置页与前端仪表盘，统一本地化。",
+      completed: false,
+      deliverables: [
+        "LocalizationCatalogService 推送日文默认 UI",
+        "/api/status 与 /api/roadmap 汇总阶段数据",
+        "新增 src/webapp 仪表盘页面与视图模型"
+      ]
+    },
+    {
+      id: "phase5",
+      name: "阶段 5：上线准备",
+      objective: "串联真实模型、端到端联调并准备发布验收。",
+      completed: false,
+      deliverables: [
+        "接入生产模型与监控",
+        "前后端联调脚本",
+        "发布清单与回滚预案"
+      ]
+    }
+  ],
+  tests: [
+    { id: "compliance", name: "ComplianceGatewayTests", description: "验证禁译词与区域白名单逻辑", automated: true },
+    { id: "router", name: "TranslationRouterTests", description: "覆盖多模型回退与多语广播", automated: true },
+    { id: "dashboard", name: "dashboardViewModel.test.js", description: "验证仪表盘阶段聚合与进度计算", automated: true }
+  ]
+};
+
+const FALLBACK_LOCALES = [
+  { id: "ja-JP", displayName: "日本語", isDefault: true },
+  { id: "zh-CN", displayName: "简体中文" }
+];
+
+const FALLBACK_LANGUAGES = [
+  "ja-JP",
+  "en-US",
+  "en-GB",
+  "en-AU",
+  "en-CA",
+  "en-IN",
+  "en-SG",
+  "zh-CN",
+  "zh-TW",
+  "zh-HK",
+  "zh-SG",
+  "ko-KR",
+  "fr-FR",
+  "fr-CA",
+  "fr-BE",
+  "fr-CH",
+  "de-DE",
+  "de-AT",
+  "de-CH",
+  "es-ES",
+  "es-MX",
+  "es-AR",
+  "es-CL",
+  "es-CO",
+  "es-US",
+  "pt-BR",
+  "pt-PT",
+  "pt-AO",
+  "it-IT",
+  "it-CH",
+  "nl-NL",
+  "nl-BE",
+  "sv-SE",
+  "da-DK",
+  "fi-FI",
+  "nb-NO",
+  "nn-NO",
+  "is-IS",
+  "fo-FO",
+  "pl-PL",
+  "cs-CZ",
+  "sk-SK",
+  "hu-HU",
+  "ro-RO",
+  "bg-BG",
+  "hr-HR",
+  "sr-RS",
+  "bs-BA",
+  "sl-SI",
+  "mk-MK",
+  "el-GR",
+  "tr-TR",
+  "tk-TM",
+  "az-AZ",
+  "kk-KZ",
+  "ky-KG",
+  "tt-RU",
+  "ba-RU",
+  "tg-TJ",
+  "uz-UZ",
+  "mn-MN",
+  "uk-UA",
+  "ru-RU",
+  "be-BY",
+  "ka-GE",
+  "hy-AM",
+  "he-IL",
+  "yi-001",
+  "ar-SA",
+  "ar-EG",
+  "ar-AE",
+  "fa-IR",
+  "ur-PK",
+  "ur-IN",
+  "ps-AF",
+  "ku-TR",
+  "ckb-IQ",
+  "ug-CN",
+  "sd-PK",
+  "dv-MV",
+  "hi-IN",
+  "bn-IN",
+  "bn-BD",
+  "mr-IN",
+  "ne-NP",
+  "sa-IN",
+  "ta-IN",
+  "ta-SG",
+  "te-IN",
+  "ml-IN",
+  "kn-IN",
+  "pa-IN",
+  "gu-IN",
+  "or-IN",
+  "as-IN",
+  "si-LK",
+  "th-TH",
+  "lo-LA",
+  "km-KH",
+  "my-MM",
+  "bo-CN",
+  "dz-BT",
+  "vi-VN",
+  "id-ID",
+  "ms-MY",
+  "ms-SG",
+  "jv-ID",
+  "su-ID",
+  "fil-PH",
+  "tl-PH",
+  "ceb-PH",
+  "ilo-PH",
+  "war-PH",
+  "pam-PH",
+  "sm-WS",
+  "fj-FJ",
+  "mi-NZ",
+  "mg-MG",
+  "rw-RW",
+  "lg-UG",
+  "sw-KE",
+  "sw-TZ",
+  "yo-NG",
+  "ha-NG",
+  "ig-NG",
+  "am-ET",
+  "ti-ER",
+  "so-SO",
+  "om-ET",
+  "rwk-TZ",
+  "wo-SN",
+  "ff-SN",
+  "bm-ML",
+  "kj-NA",
+  "rn-BI",
+  "sn-ZW",
+  "st-ZA",
+  "tn-ZA",
+  "ts-ZA",
+  "ve-ZA",
+  "xh-ZA",
+  "zu-ZA",
+  "nso-ZA",
+  "pap-CW",
+  "crs-SC",
+  "gl-ES",
+  "ca-ES",
+  "eu-ES",
+  "oc-FR",
+  "ast-ES",
+  "sc-IT",
+  "vec-IT",
+  "rm-CH",
+  "br-FR",
+  "cy-GB",
+  "ga-IE",
+  "gd-GB",
+  "mt-MT",
+  "fy-NL",
+  "af-ZA"
+];
+
+const FALLBACK_METRICS = {
+  usage: { totalRequests: 15872, successRate: 0.982, window: "24h" },
+  cost: { monthlyUsd: 312.45, dailyUsd: 12.68 },
+  failures: [
+    { reason: "RateLimitExceeded", count: 12 },
+    { reason: "AuthenticationFailed", count: 5 },
+    { reason: "ModelTimeout", count: 3 }
+  ],
+  tests: {
+    failing: [
+      {
+        id: "translationRouter",
+        name: "TranslationRouterTests",
+        failures: 2,
+        reason: "限流策略回退路径未命中"
+      }
+    ]
+  },
+  updatedAt: "2024-03-15T08:00:00Z"
+};
+
+const NORMALIZED_METRICS_TOKEN = Symbol("normalizedMetrics");
+const METRICS_REFRESH_INTERVAL = 60_000;
+
+const numberFormatter = new Intl.NumberFormat("zh-CN");
+const currencyFormatter = new Intl.NumberFormat("zh-CN", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2
+});
+const percentFormatter = new Intl.NumberFormat("zh-CN", {
+  style: "percent",
+  maximumFractionDigits: 1
+});
+const updatedFormatter = new Intl.DateTimeFormat("zh-CN", {
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false
+});
+
+let latestCards = null;
+let latestMetrics = null;
+let metricsTimer = null;
+let metricsRefreshBound = false;
+
+export function normalizeMetrics(metrics) {
+  if (metrics && metrics[NORMALIZED_METRICS_TOKEN]) {
+    return metrics;
+  }
+
+  const safe = metrics ?? {};
+  const usageSource = safe.usage ?? {};
+  const costSource = safe.cost ?? {};
+  const testsSource = safe.tests ?? {};
+
+  const totalRequestsRaw = Number(usageSource.totalRequests ?? usageSource.requests ?? usageSource.total ?? 0);
+  const totalRequests = Number.isFinite(totalRequestsRaw) ? Math.max(0, Math.round(totalRequestsRaw)) : 0;
+
+  const successRateRaw = Number(usageSource.successRate ?? usageSource.success_ratio ?? usageSource.successRatio ?? usageSource.successPercentage ?? usageSource.success_percent ?? NaN);
+  let successRate = Number.isFinite(successRateRaw) ? successRateRaw : null;
+  if (typeof successRate === "number") {
+    successRate = successRate > 1 ? successRate / 100 : successRate;
+    successRate = Math.max(0, Math.min(1, successRate));
+  }
+
+  const windowLabel = usageSource.window ?? usageSource.range ?? usageSource.period ?? null;
+
+  const monthlyRaw = Number(costSource.monthlyUsd ?? costSource.monthToDateUsd ?? costSource.monthly ?? 0);
+  const monthlyUsd = Number.isFinite(monthlyRaw) ? Math.max(0, monthlyRaw) : 0;
+  const dailyRaw = Number(costSource.dailyUsd ?? costSource.dailyAverageUsd ?? costSource.daily ?? NaN);
+  const dailyUsd = Number.isFinite(dailyRaw) ? Math.max(0, dailyRaw) : null;
+
+  const failures = (Array.isArray(safe.failures) ? safe.failures : [])
+    .filter((item) => item && typeof item === "object")
+    .map((item, index) => {
+      const countRaw = Number(item.count ?? item.total ?? item.times ?? 0);
+      const count = Number.isFinite(countRaw) ? Math.max(0, Math.round(countRaw)) : 0;
+      return {
+        reason: item.reason ?? item.code ?? item.message ?? `未知原因 ${index + 1}`,
+        count
+      };
+    })
+    .sort((a, b) => b.count - a.count);
+
+  const failing = Array.isArray(testsSource.failing) ? testsSource.failing : [];
+  const normalizedFailing = failing
+    .filter((item) => item && typeof item === "object" && item.id)
+    .map((item) => {
+      const failuresRaw = Number(item.failures ?? item.count ?? item.total ?? 1);
+      const failures = Number.isFinite(failuresRaw) ? Math.max(1, Math.round(failuresRaw)) : 1;
+      return {
+        id: item.id,
+        name: item.name ?? "",
+        failures,
+        reason: item.reason ?? item.lastFailureReason ?? ""
+      };
+    })
+    .sort((a, b) => b.failures - a.failures);
+
+  const normalized = {
+    usage: {
+      totalRequests,
+      successRate,
+      window: windowLabel
+    },
+    cost: {
+      monthlyUsd,
+      dailyUsd
+    },
+    failures,
+    tests: {
+      failing: normalizedFailing
+    },
+    updatedAt: safe.updatedAt ?? safe.timestamp ?? safe.generatedAt ?? null
+  };
+
+  normalized[NORMALIZED_METRICS_TOKEN] = true;
+  return normalized;
+}
+
+latestMetrics = normalizeMetrics(FALLBACK_METRICS);
+
+async function fetchJson(url) {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`请求 ${url} 失败: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.warn("获取数据失败，使用本地样例:", error.message);
+    return null;
+  }
+}
+
+function updateProgress(element, percent) {
+  if (!element) return;
+  const safePercent = Number.isFinite(percent) ? Math.max(0, Math.min(100, percent)) : 0;
+  element.style.setProperty("--value", `${safePercent}%`);
+  element.setAttribute("aria-valuenow", String(safePercent));
+  const textNode = element.querySelector("span");
+  if (textNode) {
+    textNode.textContent = `${safePercent}%`;
+  }
+}
+
+export function renderSummary(cards, metricsInput = latestMetrics) {
+  const cardData = cards ?? {};
+  const metrics = metricsInput ? normalizeMetrics(metricsInput) : latestMetrics;
+
+  if (metrics && metrics !== latestMetrics) {
+    latestMetrics = metrics;
+  }
+
+  const overallPercent = Number.isFinite(cardData.overallPercent) ? cardData.overallPercent : 0;
+  const overall = document.querySelector("[data-overall-progress]");
+  const overallText = document.querySelector("[data-overall-text]");
+  updateProgress(overall, overallPercent);
+  if (overallText) {
+    overallText.textContent = `整体完成度 ${overallPercent}%`;
+  }
+
+  const frontendData = cardData.frontend ?? {};
+  const frontendPercent = Number.isFinite(frontendData.completionPercent) ? frontendData.completionPercent : 0;
+  const frontend = document.querySelector("[data-frontend-progress]");
+  const frontendText = document.querySelector("[data-frontend-text]");
+  updateProgress(frontend, frontendPercent);
+  if (frontendText) {
+    frontendText.textContent = `前端完成度 ${frontendPercent}%`;
+  }
+
+  const readinessList = document.querySelector("[data-readiness]");
+  if (readinessList) {
+    readinessList.innerHTML = "";
+    const items = [
+      { label: "数据面", ready: Boolean(frontendData.dataPlaneReady) },
+      { label: "界面实现", ready: Boolean(frontendData.uiImplemented) },
+      { label: "联调", ready: Boolean(frontendData.integrationReady) }
+    ];
+    items.forEach((item) => {
+      const li = document.createElement("li");
+      li.className = item.ready ? "ready" : "pending";
+      li.textContent = `${item.label}: ${item.ready ? "已就绪" : "待完成"}`;
+      readinessList.appendChild(li);
+    });
+  }
+
+  const nextSteps = document.querySelector("[data-next-steps]");
+  const steps = Array.isArray(cardData.nextSteps) ? cardData.nextSteps : [];
+  if (nextSteps) {
+    nextSteps.innerHTML = "";
+    steps.forEach((step) => {
+      const li = document.createElement("li");
+      li.textContent = step;
+      nextSteps.appendChild(li);
+    });
+  }
+
+  const activeStageHeading = document.querySelector("[data-active-stage-title]");
+  const activeStageBody = document.querySelector("[data-active-stage-body]");
+  const activeStage = cardData.activeStage ?? null;
+  if (activeStage && activeStageHeading && activeStageBody) {
+    activeStageHeading.textContent = `${activeStage.name}`;
+    activeStageBody.textContent = activeStage.objective ?? "";
+  }
+
+  if (!metrics) {
+    return;
+  }
+
+  const usageValue = document.querySelector("[data-metric-usage-value]");
+  if (usageValue) {
+    usageValue.textContent = numberFormatter.format(metrics.usage.totalRequests ?? 0);
+  }
+
+  const usageDetail = document.querySelector("[data-metric-usage-detail]");
+  if (usageDetail) {
+    const usageParts = [];
+    if (typeof metrics.usage.successRate === "number") {
+      usageParts.push(`成功率 ${percentFormatter.format(metrics.usage.successRate)}`);
+    }
+    if (metrics.usage.window) {
+      usageParts.push(`窗口 ${metrics.usage.window}`);
+    }
+    usageDetail.textContent = usageParts.length > 0 ? usageParts.join(" · ") : "暂无统计";
+  }
+
+  const costValue = document.querySelector("[data-metric-cost-value]");
+  if (costValue) {
+    costValue.textContent = currencyFormatter.format(metrics.cost.monthlyUsd ?? 0);
+  }
+
+  const costDetail = document.querySelector("[data-metric-cost-detail]");
+  if (costDetail) {
+    costDetail.textContent = typeof metrics.cost.dailyUsd === "number"
+      ? `日均 ${currencyFormatter.format(metrics.cost.dailyUsd)}`
+      : "日均 --";
+  }
+
+  const totalFailureCount = metrics.failures.reduce((sum, item) => sum + (Number.isFinite(item.count) ? item.count : 0), 0);
+  const failureTotal = document.querySelector("[data-metric-failure-total]");
+  if (failureTotal) {
+    failureTotal.textContent = numberFormatter.format(totalFailureCount);
+  }
+
+  const failureDetail = document.querySelector("[data-metric-failure-detail]");
+  if (failureDetail) {
+    const topFailure = metrics.failures[0];
+    failureDetail.textContent = topFailure ? `主要原因 ${topFailure.reason}` : "暂无失败记录";
+  }
+
+  const failureList = document.querySelector("[data-failure-reasons]");
+  if (failureList) {
+    failureList.innerHTML = "";
+    const topFailures = metrics.failures.slice(0, 5);
+    if (topFailures.length === 0) {
+      const empty = document.createElement("li");
+      empty.className = "metrics__empty";
+      empty.textContent = "最近窗口内没有失败记录";
+      failureList.appendChild(empty);
+    } else {
+      topFailures.forEach((failure) => {
+        const item = document.createElement("li");
+        const reason = document.createElement("span");
+        reason.className = "metrics__reason";
+        reason.textContent = failure.reason;
+        const count = document.createElement("span");
+        count.className = "metrics__count";
+        count.textContent = numberFormatter.format(failure.count);
+        item.append(reason, count);
+        failureList.appendChild(item);
+      });
+    }
+  }
+
+  const metricsUpdated = document.querySelector("[data-metrics-updated]");
+  if (metricsUpdated) {
+    metricsUpdated.textContent = `最近更新：${formatUpdatedLabel(metrics.updatedAt)}`;
+  }
+}
+
+function renderTimeline(timeline) {
+  const container = document.querySelector("[data-timeline]");
+  if (!container) return;
+  container.innerHTML = "";
+  timeline.forEach((stage) => {
+    const card = document.createElement("article");
+    card.className = `timeline-card ${stage.completed ? "timeline-card--done" : stage.isActive ? "timeline-card--active" : ""}`;
+
+    const header = document.createElement("header");
+    header.innerHTML = `<span class="badge">${stage.order}</span><h3>${stage.name}</h3>`;
+    card.appendChild(header);
+
+    const objective = document.createElement("p");
+    objective.className = "timeline-card__objective";
+    objective.textContent = stage.objective;
+    card.appendChild(objective);
+
+    if (Array.isArray(stage.deliverables) && stage.deliverables.length > 0) {
+      const list = document.createElement("ul");
+      list.className = "timeline-card__list";
+      stage.deliverables.forEach((item) => {
+        const li = document.createElement("li");
+        li.textContent = item;
+        list.appendChild(li);
+      });
+      card.appendChild(list);
+    }
+
+    const progressBar = document.createElement("div");
+    progressBar.className = "progress";
+    progressBar.innerHTML = `<span>${stage.progress}%</span>`;
+    updateProgress(progressBar, stage.progress);
+    card.appendChild(progressBar);
+
+    container.appendChild(card);
+  });
+}
+
+export function renderTests(tests, metricsInput = latestMetrics) {
+  const list = document.querySelector("[data-test-list]");
+  if (!list) return;
+  list.innerHTML = "";
+
+  const metrics = metricsInput ? normalizeMetrics(metricsInput) : latestMetrics;
+  if (metrics && metrics !== latestMetrics) {
+    latestMetrics = metrics;
+  }
+
+  const failingMap = new Map();
+  if (metrics) {
+    metrics.tests.failing.forEach((item) => {
+      failingMap.set(item.id, item);
+    });
+  }
+
+  (Array.isArray(tests) ? tests : []).forEach((test) => {
+    if (!test) return;
+
+    const li = document.createElement("li");
+    const failureInfo = test.id ? failingMap.get(test.id) : undefined;
+    if (failureInfo) {
+      li.classList.add("test--failing");
+    }
+
+    const nameEl = document.createElement("strong");
+    nameEl.textContent = test.name ?? test.id ?? "未命名测试";
+    li.appendChild(nameEl);
+
+    const descriptionEl = document.createElement("span");
+    descriptionEl.textContent = test.description ?? "暂无描述";
+    li.appendChild(descriptionEl);
+
+    if (test.automated) {
+      const automatedTag = document.createElement("span");
+      automatedTag.className = "tag";
+      automatedTag.textContent = "自动化";
+      li.appendChild(automatedTag);
+    }
+
+    if (failureInfo) {
+      const failureTag = document.createElement("span");
+      failureTag.className = "tag tag--danger";
+      failureTag.textContent = `失败 ${failureInfo.failures} 次`;
+      li.appendChild(failureTag);
+
+      if (failureInfo.reason) {
+        const reasonEl = document.createElement("span");
+        reasonEl.className = "test__reason";
+        reasonEl.textContent = failureInfo.reason;
+        li.appendChild(reasonEl);
+      }
+    }
+
+    list.appendChild(li);
+  });
+}
+
+function renderLocales(locales) {
+  const list = document.querySelector("[data-locale-list]");
+  if (!list) return;
+  list.innerHTML = "";
+  locales.forEach((locale) => {
+    const li = document.createElement("li");
+    li.textContent = `${locale.name}${locale.isDefault ? "（默认）" : ""}`;
+    list.appendChild(li);
+  });
+}
+
+function renderLanguages(languages) {
+  const list = document.querySelector("[data-language-list]");
+  const count = document.querySelector("[data-language-count]");
+  const items = Array.isArray(languages) ? languages.filter((code) => typeof code === "string") : [];
+  if (count) {
+    count.textContent = `当前支持 ${items.length} 种语言`;
+  }
+  if (!list) return;
+  list.innerHTML = "";
+  items.forEach((code) => {
+    const entry = document.createElement("li");
+    const [language, region] = String(code).split("-");
+    const meta = region ? region.toUpperCase() : language.toUpperCase();
+    entry.innerHTML = `<strong>${code}</strong><span>${meta}</span>`;
+    list.appendChild(entry);
+  });
+}
+
+async function handleMetricsRefresh() {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const refreshButton = document.querySelector("[data-metrics-refresh]");
+  const metricsCard = document.querySelector("[data-metrics-card]");
+
+  if (refreshButton) {
+    refreshButton.disabled = true;
+  }
+  if (metricsCard) {
+    metricsCard.classList.add("is-loading");
+  }
+
+  try {
+    const response = await fetchJson("/api/metrics");
+    const normalized = response ? normalizeMetrics(response) : normalizeMetrics(latestMetrics ?? FALLBACK_METRICS);
+    latestMetrics = normalized;
+    if (latestCards) {
+      renderSummary(latestCards, latestMetrics);
+      renderTests(latestCards.tests, latestMetrics);
+    }
+  } finally {
+    if (refreshButton) {
+      refreshButton.disabled = false;
+    }
+    if (metricsCard) {
+      metricsCard.classList.remove("is-loading");
+    }
+  }
+}
+
+function setupMetricsRefresh() {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const refreshButton = document.querySelector("[data-metrics-refresh]");
+  if (refreshButton && !metricsRefreshBound) {
+    refreshButton.addEventListener("click", () => {
+      handleMetricsRefresh();
+    });
+    metricsRefreshBound = true;
+  }
+
+  if (metricsTimer) {
+    clearInterval(metricsTimer);
+  }
+
+  metricsTimer = setInterval(handleMetricsRefresh, METRICS_REFRESH_INTERVAL);
+}
+
+function formatUpdatedLabel(timestamp) {
+  if (!timestamp) {
+    return "--";
+  }
+  const date = typeof timestamp === "number" ? new Date(timestamp) : new Date(String(timestamp));
+  if (Number.isNaN(date.getTime())) {
+    return "--";
+  }
+  return updatedFormatter.format(date);
+}
+
+async function bootstrap() {
+  const [status, roadmap, locales, configuration, metrics] = await Promise.all([
+    fetchJson("/api/status"),
+    fetchJson("/api/roadmap"),
+    fetchJson("/api/localization/locales"),
+    fetchJson("/api/configuration"),
+    fetchJson("/api/metrics")
+  ]);
+
+  latestCards = buildStatusCards(status ?? FALLBACK_STATUS, roadmap ?? FALLBACK_ROADMAP);
+  latestMetrics = normalizeMetrics(metrics ?? FALLBACK_METRICS);
+
+  renderSummary(latestCards, latestMetrics);
+  renderTimeline(latestCards.timeline);
+  renderTests(latestCards.tests, latestMetrics);
+  renderLocales(formatLocaleOptions(locales ?? FALLBACK_LOCALES));
+  renderLanguages(configuration?.supportedLanguages ?? FALLBACK_LANGUAGES);
+  setupMetricsRefresh();
+}
+
+if (typeof document !== "undefined" && typeof document.addEventListener === "function") {
+  document.addEventListener("DOMContentLoaded", bootstrap);
+}

--- a/src/TlaPlugin/wwwroot/webapp/compose.html
+++ b/src/TlaPlugin/wwwroot/webapp/compose.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BOBTLA Compose 插件</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body class="compose" data-compose-root>
+    <header class="compose__header">
+      <h1>内联翻译助手</h1>
+      <p>在撰写消息时快速生成译文预览。</p>
+    </header>
+    <main class="compose__main">
+      <label>
+        目标语言
+        <select data-compose-target aria-label="目标语言"></select>
+      </label>
+      <label class="toggle">
+        <input type="checkbox" data-terminology-toggle checked /> 使用术语表
+      </label>
+      <label class="toggle">
+        <input type="checkbox" data-tone-toggle /> 正式语气
+      </label>
+      <p class="compose__cost" data-compose-cost></p>
+      <label class="compose__editor">
+        原文
+        <textarea rows="5" data-compose-input placeholder="输入要翻译的消息"></textarea>
+      </label>
+      <label class="compose__editor">
+        译文预览
+        <textarea rows="5" data-compose-preview readonly></textarea>
+      </label>
+    </main>
+    <footer class="compose__footer">
+      <button type="button" class="btn" data-compose-suggest>生成建议</button>
+      <button type="button" class="btn btn--primary" data-compose-apply>应用译文</button>
+    </footer>
+    <script type="module" src="./composePlugin.js"></script>
+  </body>
+</html>

--- a/src/TlaPlugin/wwwroot/webapp/composePlugin.js
+++ b/src/TlaPlugin/wwwroot/webapp/composePlugin.js
@@ -1,0 +1,3 @@
+export { initComposePlugin } from "../teamsClient/composePlugin.js";
+
+export { default } from "../teamsClient/composePlugin.js";

--- a/src/TlaPlugin/wwwroot/webapp/dialog.html
+++ b/src/TlaPlugin/wwwroot/webapp/dialog.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BOBTLA 消息扩展对话框</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body class="dialog" data-dialog-root>
+    <header class="dialog__header">
+      <h1>翻译助手</h1>
+      <p>选择模型、语言与术语策略，生成可编辑译文。</p>
+    </header>
+    <main class="dialog__main">
+      <section class="dialog__controls">
+        <label>
+          模型
+          <select data-model-select aria-label="模型选择"></select>
+        </label>
+        <label>
+          源语言
+          <select data-source-select aria-label="源语言选择"></select>
+        </label>
+        <p class="dialog__detected" data-detected-language></p>
+        <label>
+          目标语言
+          <select data-target-select aria-label="目标语言选择"></select>
+        </label>
+        <label class="toggle">
+          <input type="checkbox" data-terminology-toggle checked /> 使用术语表
+        </label>
+        <label class="toggle">
+          <input type="checkbox" data-tone-toggle /> 正式语气
+        </label>
+        <label class="toggle">
+          <input type="checkbox" data-rag-toggle /> 启用检索增强
+        </label>
+        <label>
+          上下文提示（每行一条）
+          <textarea
+            rows="3"
+            data-context-hints
+            placeholder="例如：预算审批；合同草案；团队代号"
+          ></textarea>
+        </label>
+        <p class="dialog__cost" data-cost-hint></p>
+      </section>
+      <section class="dialog__editor">
+        <label class="editor__label">
+          原文
+          <textarea rows="6" data-source-text placeholder="请输入要翻译的文本"></textarea>
+        </label>
+        <label class="editor__label">
+          译文（可编辑）
+          <textarea rows="6" data-translation-text placeholder="点击生成译文后可编辑"></textarea>
+        </label>
+      </section>
+      <p class="dialog__error" data-error-banner hidden></p>
+      <section class="dialog__offline" data-offline-draft-section hidden>
+        <h2>离线草稿</h2>
+        <p class="dialog__status" data-offline-draft-status hidden></p>
+        <ul class="dialog__drafts" data-offline-draft-list></ul>
+      </section>
+    </main>
+    <footer class="dialog__footer">
+      <button type="button" class="btn" data-preview-translation>生成译文</button>
+      <button type="button" class="btn" data-save-offline-draft hidden>保存离线草稿</button>
+      <button type="button" class="btn btn--primary" data-submit-translation>插入消息</button>
+    </footer>
+    <script type="module" src="./dialog.js"></script>
+  </body>
+</html>

--- a/src/TlaPlugin/wwwroot/webapp/dialog.js
+++ b/src/TlaPlugin/wwwroot/webapp/dialog.js
@@ -1,0 +1,2 @@
+export * from "../teamsClient/messageExtensionDialog.js";
+export { default } from "../teamsClient/messageExtensionDialog.js";

--- a/src/TlaPlugin/wwwroot/webapp/dialogState.js
+++ b/src/TlaPlugin/wwwroot/webapp/dialogState.js
@@ -1,0 +1,2 @@
+export * from "../teamsClient/state.js";
+export { default } from "../teamsClient/state.js";

--- a/src/TlaPlugin/wwwroot/webapp/index.html
+++ b/src/TlaPlugin/wwwroot/webapp/index.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TLA 团队前端仪表盘</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="dashboard">
+      <section class="summary">
+        <h1>Teams 翻译助手 · 前端仪表盘</h1>
+        <div class="summary__grid">
+          <article class="card">
+            <h2>整体进度</h2>
+            <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" data-overall-progress>
+              <span>0%</span>
+            </div>
+            <p data-overall-text>整体完成度 0%</p>
+          </article>
+          <article class="card">
+            <h2>前端完成度</h2>
+            <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" data-frontend-progress>
+              <span>0%</span>
+            </div>
+            <p data-frontend-text>前端完成度 0%</p>
+            <ul class="readiness" data-readiness></ul>
+          </article>
+          <article class="card">
+            <h2>当前阶段</h2>
+            <h3 data-active-stage-title>阶段加载中</h3>
+            <p data-active-stage-body>正在同步阶段目标...</p>
+            <h4>下一步</h4>
+            <ul class="next-steps" data-next-steps></ul>
+          </article>
+          <article class="card">
+            <h2>可用界面语言</h2>
+            <ul class="locale-list" data-locale-list></ul>
+          </article>
+          <article class="card">
+            <h2>支持翻译语言</h2>
+            <p data-language-count>正在载入...</p>
+            <ul class="language-list" data-language-list></ul>
+          </article>
+          <article class="card card--metrics" data-metrics-card>
+            <header class="metrics__header">
+              <h2>使用指标</h2>
+              <button type="button" class="metrics__refresh" data-metrics-refresh>刷新</button>
+            </header>
+            <div class="metrics__grid">
+              <div class="metrics__stat" data-metric-usage>
+                <span class="metrics__label">24 小时调用</span>
+                <strong class="metrics__value" data-metric-usage-value>--</strong>
+                <span class="metrics__detail" data-metric-usage-detail>成功率 --</span>
+              </div>
+              <div class="metrics__stat" data-metric-cost>
+                <span class="metrics__label">月度成本</span>
+                <strong class="metrics__value" data-metric-cost-value>--</strong>
+                <span class="metrics__detail" data-metric-cost-detail>日均 --</span>
+              </div>
+              <div class="metrics__stat" data-metric-failure-summary>
+                <span class="metrics__label">失败次数</span>
+                <strong class="metrics__value" data-metric-failure-total>--</strong>
+                <span class="metrics__detail" data-metric-failure-detail>主要原因 --</span>
+              </div>
+            </div>
+            <div class="metrics__failures">
+              <h3>高频失败原因</h3>
+              <ul class="metrics__failure-list" data-failure-reasons>
+                <li class="metrics__empty">正在统计...</li>
+              </ul>
+            </div>
+            <p class="metrics__updated" data-metrics-updated>最近更新：--</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>阶段时间线</h2>
+        <div class="timeline" data-timeline></div>
+      </section>
+
+      <section class="section">
+        <h2>测试覆盖</h2>
+        <ul class="test-list" data-test-list></ul>
+      </section>
+
+      <section class="section glossary">
+        <h2>术语表管理</h2>
+        <form class="glossary__form" data-glossary-form>
+          <label>
+            作用域
+            <select data-glossary-scope>
+              <option value="tenant">租户</option>
+              <option value="channel">团队频道</option>
+              <option value="user">个人</option>
+            </select>
+          </label>
+          <label>
+            术语文件（CSV/TBX）
+            <input
+              type="file"
+              accept=".csv,.tbx,text/csv,application/xml"
+              data-glossary-file
+              required
+            />
+          </label>
+          <label class="glossary__toggle">
+            <input type="checkbox" data-glossary-override />
+            覆盖现有术语
+          </label>
+          <button type="submit">上传术语</button>
+        </form>
+
+        <p class="glossary__status" data-glossary-status></p>
+
+        <div class="glossary__results" data-glossary-results hidden>
+          <h3>上传结果</h3>
+          <p data-glossary-summary>尚未上传术语。</p>
+          <dl class="glossary__metrics">
+            <div>
+              <dt>新增</dt>
+              <dd data-glossary-imported>0</dd>
+            </div>
+            <div>
+              <dt>更新</dt>
+              <dd data-glossary-updated>0</dd>
+            </div>
+            <div>
+              <dt>冲突</dt>
+              <dd data-glossary-conflict-count>0</dd>
+            </div>
+            <div>
+              <dt>错误</dt>
+              <dd data-glossary-error-count>0</dd>
+            </div>
+          </dl>
+          <div class="glossary__conflicts" data-glossary-conflicts hidden>
+            <h4>冲突条目</h4>
+            <ul data-glossary-conflict-list></ul>
+          </div>
+          <div class="glossary__errors" data-glossary-errors hidden>
+            <h4>解析/导入错误</h4>
+            <ul data-glossary-error-list></ul>
+          </div>
+        </div>
+
+        <div class="glossary__list">
+          <h3>当前术语</h3>
+          <ul data-glossary-items></ul>
+        </div>
+      </section>
+    </main>
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/src/TlaPlugin/wwwroot/webapp/settings.html
+++ b/src/TlaPlugin/wwwroot/webapp/settings.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BOBTLA 设置页</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body class="settings" data-settings-root>
+    <header class="settings__header">
+      <h1>租户配置</h1>
+      <p>管理允许的模型、默认目标语言与术语策略。</p>
+    </header>
+    <main class="settings__main">
+      <section>
+        <h2>允许模型</h2>
+        <div class="settings__models" data-model-list></div>
+      </section>
+      <section>
+        <h2>默认目标语言</h2>
+        <select data-default-language aria-label="默认目标语言"></select>
+      </section>
+      <section>
+        <h2>默认语气</h2>
+        <select data-default-tone aria-label="默认语气"></select>
+      </section>
+      <section>
+        <label class="toggle">
+          <input type="checkbox" data-terminology-toggle checked /> 启用术语库
+        </label>
+      </section>
+      <section class="glossary">
+        <h2>术语库管理</h2>
+        <form class="glossary__form" data-glossary-form>
+          <div class="field">
+            <label>作用域
+              <select name="scopeType" data-glossary-scope>
+                <option value="tenant">租户</option>
+                <option value="channel">频道</option>
+                <option value="user">用户</option>
+              </select>
+            </label>
+          </div>
+          <div class="field">
+            <label>标识
+              <input type="text" name="scopeId" data-glossary-scope-id placeholder="例如 contoso" />
+            </label>
+          </div>
+          <div class="field">
+            <label>术语文件
+              <input type="file" name="file" data-glossary-file accept=".csv,.tbx,.xml" required />
+            </label>
+          </div>
+          <label class="toggle">
+            <input type="checkbox" name="overwrite" data-glossary-overwrite /> 覆盖冲突条目
+          </label>
+          <button type="submit" class="btn" data-glossary-submit>上传术语表</button>
+        </form>
+        <div class="glossary__progress" data-glossary-progress hidden>
+          <progress max="100" value="0"></progress>
+          <span data-glossary-progress-label>等待上传</span>
+        </div>
+        <div class="glossary__errors" data-glossary-errors hidden>
+          <h3>上传警告</h3>
+          <ul data-glossary-error-list></ul>
+        </div>
+        <div class="glossary__conflicts" data-glossary-conflicts hidden>
+          <h3>冲突条目</h3>
+          <ul data-glossary-conflict-list></ul>
+        </div>
+        <div class="glossary__list">
+          <h3>现有术语</h3>
+          <ul data-glossary-list></ul>
+        </div>
+        <div class="glossary__policies">
+          <h3>禁译库</h3>
+          <ul data-banned-term-list></ul>
+          <h3>风格模板</h3>
+          <ul data-style-template-list></ul>
+        </div>
+      </section>
+      <p class="settings__status" data-settings-status></p>
+    </main>
+    <footer class="settings__footer">
+      <button type="button" class="btn btn--primary" data-settings-save>保存配置</button>
+    </footer>
+    <script type="module" src="./settingsTab.js"></script>
+  </body>
+</html>

--- a/src/TlaPlugin/wwwroot/webapp/settingsTab.js
+++ b/src/TlaPlugin/wwwroot/webapp/settingsTab.js
@@ -1,0 +1,274 @@
+const DEFAULT_FETCH = typeof fetch === "function" ? fetch.bind(globalThis) : undefined;
+
+function resolveElements(root = typeof document !== "undefined" ? document : undefined) {
+  if (!root) {
+    return {};
+  }
+  return {
+    form: root.querySelector?.("[data-glossary-form]"),
+    scopeSelect: root.querySelector?.("[data-glossary-scope]"),
+    scopeInput: root.querySelector?.("[data-glossary-scope-id]"),
+    fileInput: root.querySelector?.("[data-glossary-file]"),
+    overwriteCheckbox: root.querySelector?.("[data-glossary-overwrite]"),
+    progressContainer: root.querySelector?.("[data-glossary-progress]"),
+    progressBar: root.querySelector?.("[data-glossary-progress] progress"),
+    progressLabel: root.querySelector?.("[data-glossary-progress-label]"),
+    conflictContainer: root.querySelector?.("[data-glossary-conflicts]"),
+    conflictList: root.querySelector?.("[data-glossary-conflict-list]"),
+    errorContainer: root.querySelector?.("[data-glossary-errors]"),
+    errorList: root.querySelector?.("[data-glossary-error-list]"),
+    glossaryList: root.querySelector?.("[data-glossary-list]"),
+    bannedList: root.querySelector?.("[data-banned-term-list]"),
+    styleList: root.querySelector?.("[data-style-template-list]"),
+    statusLabel: root.querySelector?.("[data-settings-status]")
+  };
+}
+
+async function fetchJson(url, fetchImpl = DEFAULT_FETCH) {
+  if (!fetchImpl) {
+    throw new Error("fetch implementation is not available");
+  }
+  const response = await fetchImpl(url, { method: "GET" });
+  if (!response.ok) {
+    const text = await response.text?.();
+    throw new Error(`Request failed: ${response.status} ${text ?? ""}`);
+  }
+  return response.json();
+}
+
+function renderList(container, items, emptyText) {
+  if (!container) {
+    return;
+  }
+  const values = Array.isArray(items) ? items : [];
+  if (typeof container.replaceChildren === "function" && typeof document !== "undefined") {
+    if (values.length === 0 && emptyText) {
+      const placeholder = document.createElement("li");
+      placeholder.textContent = emptyText;
+      container.replaceChildren(placeholder);
+      return;
+    }
+    const nodes = values.map((value) => {
+      const li = document.createElement("li");
+      li.textContent = typeof value === "string" ? value : String(value ?? "");
+      return li;
+    });
+    container.replaceChildren(...nodes);
+  } else {
+    container.items = values;
+    if (emptyText) {
+      container.emptyText = values.length === 0 ? emptyText : "";
+    }
+  }
+}
+
+export function renderGlossaryList(container, entries) {
+  if (!container) {
+    return;
+  }
+  const items = Array.isArray(entries)
+    ? entries.map((entry) => {
+        const scope = entry?.scope ? `（${entry.scope}）` : "";
+        return `${entry?.source ?? ""} → ${entry?.target ?? ""}${scope}`;
+      })
+    : [];
+  renderList(container, items, "暂无术语");
+}
+
+export function renderConflictList(container, conflicts) {
+  if (!container) {
+    return;
+  }
+  const rows = Array.isArray(conflicts)
+    ? conflicts.map((conflict) =>
+        `${conflict?.source ?? ""}: ${conflict?.existingTarget ?? ""} → ${conflict?.incomingTarget ?? ""}`
+      )
+    : [];
+  renderList(container, rows, "未检测到冲突");
+}
+
+export function renderErrorList(container, errors) {
+  if (!container) {
+    return;
+  }
+  const lines = Array.isArray(errors) ? errors.filter(Boolean) : [];
+  renderList(container, lines, "");
+}
+
+function updateVisibility(element, visible) {
+  if (!element) {
+    return;
+  }
+  if ("hidden" in element) {
+    element.hidden = !visible;
+  } else {
+    element.isVisible = visible;
+  }
+}
+
+function updateProgress(elements, value, label) {
+  if (!elements.progressContainer) {
+    return;
+  }
+  updateVisibility(elements.progressContainer, true);
+  if (elements.progressBar) {
+    elements.progressBar.value = value;
+  } else {
+    elements.progressContainer.value = value;
+  }
+  if (elements.progressLabel) {
+    elements.progressLabel.textContent = label;
+  } else {
+    elements.progressContainer.label = label;
+  }
+}
+
+async function refreshGlossary(elements, fetchImpl) {
+  try {
+    const entries = await fetchJson("/api/glossary", fetchImpl);
+    renderGlossaryList(elements.glossaryList, entries);
+  } catch (error) {
+    console.warn("无法加载术语列表", error);
+    renderGlossaryList(elements.glossaryList, []);
+  }
+}
+
+function renderPolicies(elements, policies) {
+  if (!policies) {
+    renderList(elements.bannedList, [], "暂无禁译词");
+    renderList(elements.styleList, [], "暂无风格模板");
+    return;
+  }
+  renderList(elements.bannedList, policies.bannedTerms ?? [], "暂无禁译词");
+  renderList(elements.styleList, policies.styleTemplates ?? [], "暂无风格模板");
+  if (elements.scopeInput && !elements.scopeInput.value && policies.tenantId) {
+    elements.scopeInput.value = policies.tenantId;
+  }
+}
+
+function buildFormData(form, elements, formDataFactory) {
+  if (!form) {
+    throw new Error("glossary form is required");
+  }
+  const factory = typeof formDataFactory === "function" ? formDataFactory : (current) => new FormData(current);
+  const formData = factory(form);
+
+  const scopeType = elements.scopeSelect?.value ?? formData.get?.("scopeType") ?? "tenant";
+  const scopeId = elements.scopeInput?.value ?? formData.get?.("scopeId") ?? "";
+  const overwrite = Boolean(elements.overwriteCheckbox?.checked);
+
+  if (typeof formData.set === "function") {
+    formData.set("scopeType", scopeType);
+    formData.set("scopeId", scopeId);
+    formData.set("overwrite", overwrite ? "true" : "false");
+  } else if (typeof formData.append === "function") {
+    formData.append("scopeType", scopeType);
+    formData.append("scopeId", scopeId);
+    formData.append("overwrite", overwrite ? "true" : "false");
+  } else {
+    formData.scopeType = scopeType;
+    formData.scopeId = scopeId;
+    formData.overwrite = overwrite ? "true" : "false";
+  }
+
+  return formData;
+}
+
+async function handleUpload(event, elements, fetchImpl, formDataFactory) {
+  event?.preventDefault?.();
+
+  const file = elements.fileInput?.files?.[0];
+  if (!file) {
+    renderErrorList(elements.errorList, ["请先选择 CSV 或 TermBase 文件。"]);
+    updateVisibility(elements.errorContainer, true);
+    return;
+  }
+
+  updateVisibility(elements.errorContainer, false);
+  updateVisibility(elements.conflictContainer, false);
+  updateProgress(elements, 10, "上传中…");
+
+  let formData;
+  try {
+    formData = buildFormData(elements.form, elements, formDataFactory);
+  } catch (error) {
+    renderErrorList(elements.errorList, [error.message]);
+    updateVisibility(elements.errorContainer, true);
+    return;
+  }
+
+  if (typeof formData.append === "function") {
+    formData.append("file", file, file.name ?? "glossary.csv");
+  } else {
+    formData.file = file;
+  }
+
+  updateProgress(elements, 35, "解析文件…");
+
+  try {
+    const response = await (fetchImpl ?? DEFAULT_FETCH)("/api/glossary/upload", {
+      method: "POST",
+      body: formData
+    });
+    if (!response.ok) {
+      const text = await response.text?.();
+      throw new Error(text || `上传失败: ${response.status}`);
+    }
+    const result = await response.json();
+
+    updateProgress(elements, 100, "上传完成");
+    renderConflictList(elements.conflictList, result?.conflicts ?? []);
+    updateVisibility(elements.conflictContainer, Array.isArray(result?.conflicts) && result.conflicts.length > 0);
+
+    renderErrorList(elements.errorList, result?.errors ?? []);
+    updateVisibility(elements.errorContainer, Array.isArray(result?.errors) && result.errors.length > 0);
+
+    if (elements.statusLabel) {
+      const imported = Number(result?.imported ?? 0);
+      const updated = Number(result?.updated ?? 0);
+      elements.statusLabel.textContent = `已导入 ${imported} 条，更新 ${updated} 条。`;
+    }
+
+    await refreshGlossary(elements, fetchImpl ?? DEFAULT_FETCH);
+  } catch (error) {
+    renderErrorList(elements.errorList, [error.message ?? String(error)]);
+    updateVisibility(elements.errorContainer, true);
+  }
+}
+
+export async function initSettingsPage({
+  root,
+  fetchImpl = DEFAULT_FETCH,
+  formDataFactory
+} = {}) {
+  const elements = resolveElements(root);
+
+  try {
+    const configuration = await fetchJson("/api/configuration", fetchImpl);
+    renderPolicies(elements, configuration?.tenantPolicies);
+  } catch (error) {
+    console.warn("加载配置失败", error);
+    renderPolicies(elements, null);
+  }
+
+  await refreshGlossary(elements, fetchImpl);
+
+  if (elements.form && typeof elements.form.addEventListener === "function") {
+    elements.form.addEventListener("submit", (event) => handleUpload(event, elements, fetchImpl, formDataFactory));
+  }
+
+  return elements;
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", () => {
+    initSettingsPage().catch((error) => console.error("初始化设置页面失败", error));
+  });
+}
+
+export default {
+  initSettingsPage,
+  renderGlossaryList,
+  renderConflictList,
+  renderErrorList
+};

--- a/src/TlaPlugin/wwwroot/webapp/styles.css
+++ b/src/TlaPlugin/wwwroot/webapp/styles.css
@@ -1,0 +1,513 @@
+:root {
+  color-scheme: light dark;
+  --bg: #101623;
+  --card-bg: rgba(14, 22, 35, 0.8);
+  --border: rgba(255, 255, 255, 0.08);
+  --accent: #58b2f0;
+  --accent-soft: rgba(88, 178, 240, 0.2);
+  --text-primary: #ffffff;
+  --text-secondary: rgba(255, 255, 255, 0.68);
+  font-family: "Segoe UI", "Microsoft YaHei", system-ui, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(88, 178, 240, 0.25), transparent), var(--bg);
+  color: var(--text-primary);
+}
+
+.dashboard {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 48px 24px 72px;
+  display: grid;
+  gap: 24px;
+}
+
+.summary {
+  display: grid;
+  gap: 16px;
+}
+
+.summary h1 {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.summary__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  display: grid;
+  gap: 12px;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.card--metrics {
+  gap: 16px;
+}
+
+.card--metrics.is-loading {
+  opacity: 0.75;
+}
+
+.metrics__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.metrics__refresh {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.metrics__refresh:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.metrics__refresh[disabled] {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.metrics__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.metrics__stat {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  padding: 12px;
+  display: grid;
+  gap: 6px;
+}
+
+.metrics__label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.metrics__value {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.metrics__detail {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.metrics__failures {
+  display: grid;
+  gap: 8px;
+}
+
+.metrics__failures h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.metrics__failure-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.metrics__failure-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-secondary);
+}
+
+.metrics__reason {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.metrics__count {
+  font-variant-numeric: tabular-nums;
+}
+
+.metrics__empty {
+  justify-content: center;
+  font-style: italic;
+}
+
+.metrics__updated {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  text-align: right;
+}
+
+.progress {
+  position: relative;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  overflow: hidden;
+}
+
+.progress::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: var(--value, 0%);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), #5ee7c1);
+  transition: width 0.5s ease;
+}
+
+.progress span {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.readiness,
+.next-steps,
+.locale-list,
+.language-list,
+.test-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.readiness li.ready::before {
+  content: "✔";
+  color: #76e0a0;
+  margin-right: 8px;
+}
+
+.readiness li.pending::before {
+  content: "⏳";
+  color: #ffc861;
+  margin-right: 8px;
+}
+
+.timeline {
+  display: grid;
+  gap: 16px;
+}
+
+.timeline-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.timeline-card--active {
+  border-color: var(--accent);
+  transform: translateY(-4px);
+  box-shadow: 0 12px 40px rgba(88, 178, 240, 0.35);
+}
+
+.timeline-card--done {
+  opacity: 0.7;
+}
+
+.timeline-card header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.timeline-card header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.badge {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.timeline-card__objective {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.timeline-card__list {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-secondary);
+  display: grid;
+  gap: 6px;
+}
+
+.section {
+  display: grid;
+  gap: 12px;
+}
+
+.section h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.test-list li,
+.locale-list li,
+.language-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-secondary);
+}
+
+.test-list li {
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 6px 12px;
+}
+
+.test-list li strong {
+  flex: 1 1 100%;
+}
+
+.test-list li > span {
+  flex: 1 1 100%;
+}
+
+.test-list li .tag {
+  flex: 0 0 auto;
+}
+
+.test-list li .test__reason {
+  flex: 1 1 100%;
+  color: rgba(255, 181, 181, 0.92);
+  font-size: 12px;
+}
+
+.test--failing {
+  border: 1px solid rgba(255, 136, 136, 0.35);
+  background: rgba(255, 94, 94, 0.08);
+}
+
+.tag--danger {
+  background: rgba(255, 94, 94, 0.2);
+  color: #ffb5b5;
+}
+
+.language-list {
+  max-height: 260px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.language-list li span {
+  font-size: 12px;
+  color: var(--text-primary);
+  background: rgba(88, 178, 240, 0.2);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.test-list li strong {
+  color: var(--text-primary);
+}
+
+.tag {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(118, 224, 160, 0.2);
+  color: #76e0a0;
+  font-size: 12px;
+  margin-left: 8px;
+}
+
+@media (max-width: 720px) {
+  .dashboard {
+    padding: 32px 16px 48px;
+  }
+
+  .summary__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dialog,
+.compose,
+.settings {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+  display: grid;
+  gap: 24px;
+}
+
+.dialog__controls,
+.dialog__editor,
+.compose__main,
+.settings__main {
+  display: grid;
+  gap: 16px;
+}
+
+.dialog__controls label,
+.compose__main label,
+.settings__main label {
+  display: grid;
+  gap: 6px;
+  font-weight: 500;
+}
+
+.dialog__editor,
+.compose__editor {
+  display: grid;
+  gap: 8px;
+}
+
+textarea,
+select,
+input[type="text"] {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--text-primary);
+  padding: 12px;
+  font: inherit;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dialog__footer,
+.compose__footer,
+.settings__footer {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.btn {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  padding: 10px 18px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.btn--primary {
+  background: var(--accent);
+  color: #021a35;
+  border-color: transparent;
+}
+
+.dialog__error {
+  margin: 0;
+  padding: 12px;
+  border-radius: 10px;
+  background: rgba(255, 77, 79, 0.15);
+  color: #ffb3b5;
+}
+
+.dialog__cost {
+  color: var(--text-secondary);
+}
+
+.dialog__offline {
+  display: grid;
+  gap: 8px;
+}
+
+.dialog__offline h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.dialog__status {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.dialog__status[data-variant="error"] {
+  color: #ffb3b5;
+}
+
+.dialog__drafts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.dialog__drafts li {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 8px 12px;
+  color: var(--text-secondary);
+}
+
+.settings__models {
+  display: grid;
+  gap: 10px;
+}
+
+.settings__status {
+  color: var(--text-secondary);
+  min-height: 24px;
+}

--- a/src/TlaPlugin/wwwroot/webapp/teamsContext.js
+++ b/src/TlaPlugin/wwwroot/webapp/teamsContext.js
@@ -1,0 +1,71 @@
+const DEFAULT_CONTEXT = {
+  user: { id: "local-user" },
+  tenant: { id: "local-tenant" },
+  channel: { id: "local-channel" },
+  app: { locale: "en-US" }
+};
+
+function createLocalFallbackSdk() {
+  return {
+    app: {
+      async initialize() {
+        return undefined;
+      },
+      async getContext() {
+        return DEFAULT_CONTEXT;
+      }
+    },
+    dialog: {
+      submit() {
+        return undefined;
+      }
+    },
+    pages: {
+      config: {
+        registerOnSaveHandler() {
+          return undefined;
+        },
+        async setConfig() {
+          return undefined;
+        },
+        setValidityState() {
+          return undefined;
+        }
+      }
+    },
+    conversations: {
+      async sendMessageToConversation() {
+        return undefined;
+      }
+    }
+  };
+}
+
+export function resolveTeamsSdk(override) {
+  if (override) {
+    return override;
+  }
+  if (typeof window !== "undefined" && window.microsoftTeams) {
+    return window.microsoftTeams;
+  }
+  if (typeof globalThis !== "undefined" && globalThis.microsoftTeams) {
+    return globalThis.microsoftTeams;
+  }
+  return createLocalFallbackSdk();
+}
+
+export async function ensureTeamsContext({ teams } = {}) {
+  const sdk = resolveTeamsSdk(teams);
+  if (sdk?.app?.initialize) {
+    await sdk.app.initialize();
+  }
+  const context = (await sdk?.app?.getContext?.()) ?? DEFAULT_CONTEXT;
+  return { teams: sdk ?? createLocalFallbackSdk(), context };
+}
+
+export { DEFAULT_CONTEXT };
+
+export default {
+  resolveTeamsSdk,
+  ensureTeamsContext
+};

--- a/src/TlaPlugin/wwwroot/webapp/viewModel.js
+++ b/src/TlaPlugin/wwwroot/webapp/viewModel.js
@@ -1,0 +1,82 @@
+const ACTIVE_STAGE_FALLBACK_PROGRESS = 50;
+
+function normalizeStages(stages) {
+  if (!Array.isArray(stages)) {
+    return [];
+  }
+  return stages
+    .filter((stage) => stage && typeof stage === "object")
+    .map((stage) => ({
+      id: stage.id ?? stage.Id ?? "",
+      name: stage.name ?? stage.Name ?? "",
+      objective: stage.objective ?? stage.Objective ?? "",
+      completed: Boolean(stage.completed ?? stage.Completed ?? false),
+      deliverables: stage.deliverables ?? stage.Deliverables ?? [],
+      testFocuses: stage.testFocuses ?? stage.TestFocuses ?? []
+    }));
+}
+
+export function groupStagesForTimeline(stages, activeStageId) {
+  const normalized = normalizeStages(stages);
+  return normalized.map((stage, index) => {
+    const isActive = stage.id === activeStageId || (!activeStageId && !stage.completed && normalized.slice(0, index).every((item) => item.completed));
+    let progress = stage.completed ? 100 : 0;
+    if (isActive && !stage.completed) {
+      progress = ACTIVE_STAGE_FALLBACK_PROGRESS;
+    }
+    return {
+      order: index + 1,
+      isActive,
+      progress,
+      ...stage
+    };
+  });
+}
+
+export function buildStatusCards(status, roadmap) {
+  const safeStatus = status ?? {};
+  const safeRoadmap = roadmap ?? {};
+  const stages = safeRoadmap.stages ?? safeStatus.stages ?? [];
+  const activeStageId = safeStatus.currentStageId ?? safeRoadmap.activeStageId;
+  const timeline = groupStagesForTimeline(stages, activeStageId);
+  const completedCount = timeline.filter((stage) => stage.completed).length;
+  const overallPercent = typeof safeStatus.overallCompletionPercent === "number"
+    ? safeStatus.overallCompletionPercent
+    : timeline.length === 0
+      ? 0
+      : Math.round((completedCount / timeline.length) * 100);
+  const frontend = safeStatus.frontend ?? {};
+  const activeStage = timeline.find((stage) => stage.isActive) ?? timeline.find((stage) => !stage.completed) ?? timeline[timeline.length - 1] ?? null;
+
+  return {
+    timeline,
+    overallPercent,
+    activeStage,
+    nextSteps: Array.isArray(safeStatus.nextSteps) ? safeStatus.nextSteps : [],
+    frontend: {
+      completionPercent: typeof frontend.completionPercent === "number" ? frontend.completionPercent : 0,
+      dataPlaneReady: Boolean(frontend.dataPlaneReady),
+      uiImplemented: Boolean(frontend.uiImplemented),
+      integrationReady: Boolean(frontend.integrationReady)
+    },
+    tests: Array.isArray(safeRoadmap.tests) ? safeRoadmap.tests : []
+  };
+}
+
+export function formatLocaleOptions(locales) {
+  if (!Array.isArray(locales)) {
+    return [];
+  }
+  return locales
+    .filter((locale) => locale && typeof locale === "object")
+    .map((locale, index) => ({
+      id: locale.id ?? locale.code ?? `locale-${index}`,
+      name: locale.displayName ?? locale.name ?? locale.id ?? `Locale ${index + 1}`,
+      isDefault: Boolean(locale.isDefault ?? locale.default)
+    }))
+    .sort((a, b) => {
+      if (a.isDefault && !b.isDefault) return -1;
+      if (!a.isDefault && b.isDefault) return 1;
+      return a.name.localeCompare(b.name, "zh-Hans-CN");
+    });
+}


### PR DESCRIPTION
## Summary
- add an npm build step that materializes the webapp and teams client assets into `src/TlaPlugin/wwwroot`
- serve the generated static files via `UseDefaultFiles`, `UseStaticFiles`, and route fallbacks inside the plugin
- package the static assets with the plugin output so they are available at runtime

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd533db4e0832fa1b4da8e77285eb5