### PR TITLE
Add Stage 5 smoke tests and integration runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ TLA 参考实现基于 .NET 7 Minimal API 与 SQLite，支撑 Microsoft Teams �
 2. `dotnet test` – 执行 xUnit 测试套件，覆盖合规、路由、草稿、缓存限流、OBO 令牌与消息扩展场景。【F:tests/TlaPlugin.Tests/TranslationRouterTests.cs†L1-L205】【F:tests/TlaPlugin.Tests/TokenBrokerTests.cs†L1-L39】【F:tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs†L17-L179】
 3. `dotnet run --project src/TlaPlugin/TlaPlugin.csproj` – 启动本地 API，`POST /api/translate` 接受 `TranslationRequest` 负载返回 Adaptive Card。
 4. `npm test` – 使用 Node 测试仪表盘视图模型与消息扩展逻辑，覆盖阶段聚合、本地化排序与 Teams 体验。【F:tests/dashboardViewModel.test.js†L1-L35】【F:tests/messageExtension.test.js†L1-L80】
+5. `dotnet run --project scripts/SmokeTests/Stage5SmokeTests` – 提供 `secrets` 与 `reply` 两个命令，分别校验 Key Vault 密钥映射并模拟 OBO+Teams 回帖，输出与 `/api/metrics`/`/api/audit` 一致的观测结果，详见 Stage 5 Runbook。【F:scripts/SmokeTests/Stage5SmokeTests/Program.cs†L1-L356】【F:docs/stage5-integration-runbook.md†L1-L118】
 
 > 代码注释统一改写为日文，界面默认文案保持日文并提供中文覆盖，避免混用多种语言，符合多语言治理规范。【F:src/TlaPlugin/Services/TranslationRouter.cs†L18-L176】【F:src/TlaPlugin/Teams/MessageExtensionHandler.cs†L9-L94】【F:src/TlaPlugin/Services/LocalizationCatalogService.cs†L1-L122】
 

--- a/bobtla.sln
+++ b/bobtla.sln
@@ -6,12 +6,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TlaPlugin", "src/TlaPlugin/
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TlaPlugin.Tests", "tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj", "{11C90498-322F-4D4F-A52A-728621A08178}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stage5SmokeTests", "scripts/SmokeTests/Stage5SmokeTests/Stage5SmokeTests.csproj", "{51072659-0D04-4935-B4E7-97B85BC04CDE}"
+EndProject
 Global
 GlobalSection(SolutionConfigurationPlatforms) = preSolution
 Debug|Any CPU = Debug|Any CPU
 Release|Any CPU = Release|Any CPU
 EndGlobalSection
 GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{51072659-0D04-4935-B4E7-97B85BC04CDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{51072659-0D04-4935-B4E7-97B85BC04CDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{51072659-0D04-4935-B4E7-97B85BC04CDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{51072659-0D04-4935-B4E7-97B85BC04CDE}.Release|Any CPU.Build.0 = Release|Any CPU
 {8F8CF3EC-9C1C-4D91-B6F3-0EBBA66560C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 {8F8CF3EC-9C1C-4D91-B6F3-0EBBA66560C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {8F8CF3EC-9C1C-4D91-B6F3-0EBBA66560C3}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/docs/stage5-integration-runbook.md
+++ b/docs/stage5-integration-runbook.md
@@ -1,0 +1,87 @@
+# 阶段 5 联调 Runbook
+
+本 Runbook 面向 Stage 5 环境，记录密钥映射、Graph 权限开通与回帖冒烟验证，以及指标与审计的观测方法。所有步骤均基于 `src/TlaPlugin` 项目现有实现，避免与生产数据混用时可复制执行。
+
+## 1. Key Vault 密钥映射与验证
+
+1. **确认需要的机密名称** – `appsettings.json` 中 `Plugin.Security` 与各模型提供方引用的密钥如下：
+
+   | 配置项 | Key Vault Secret Name | 说明 |
+   | --- | --- | --- |
+   | `Plugin.Security.ClientSecretName` | `tla-client-secret` | 用于 OBO Client 凭据，租户覆盖项可复用。 |
+   | `Plugin.Providers[0].ApiKeySecretName` | `openai-api-key` | OpenAI 主模型访问密钥。 |
+   | `Plugin.Security.TenantOverrides["enterprise.onmicrosoft.com"].ClientSecretName` | `enterprise-graph-secret` | Enterprise 租户专属 Graph 客户端机密。 |
+
+2. **在部署租户 Key Vault 中创建/更新机密**（示例使用 Azure CLI，替换 `<vault>` 与 `<secret>` 值）：
+
+   ```bash
+   az keyvault secret set --vault-name <vault> --name tla-client-secret --value <client-secret>
+   az keyvault secret set --vault-name <vault> --name openai-api-key --value <openai-key>
+   az keyvault secret set --vault-name <vault> --name enterprise-graph-secret --value <enterprise-secret>
+   ```
+
+3. **将 Key Vault 引用映射进配置** – 在 Stage 配置（例如 `appsettings.Stage.json`）或部署环境变量中，设置以下键值对，让 `KeyVaultSecretResolver` 能够解析到实际密钥：
+
+   ```bash
+   # 使用环境变量覆盖 SeedSecrets
+   export TLA_Plugin__Security__SeedSecrets__tla-client-secret="<client-secret>"
+   export TLA_Plugin__Security__SeedSecrets__openai-api-key="<openai-key>"
+   export TLA_Plugin__Security__SeedSecrets__enterprise-graph-secret="<enterprise-secret>"
+   ```
+
+4. **运行密钥解析冒烟** – 利用新增的 `Stage5SmokeTests` 工具检查所有密钥是否可被 `KeyVaultSecretResolver` 获取：
+
+   ```bash
+   dotnet run --project scripts/SmokeTests/Stage5SmokeTests -- secrets --appsettings src/TlaPlugin/appsettings.json --override appsettings.Stage.json
+   ```
+
+   输出中的 ✔ 表示成功解析；如遇 ✘ 项目，按错误提示检查 Key Vault 引用或环境变量是否配置正确。【F:scripts/SmokeTests/Stage5SmokeTests/Program.cs†L1-L212】
+
+## 2. Graph 权限与 ReplyService 冒烟
+
+1. **为目标租户开通 Graph 权限** – 确保 Azure AD 应用已获以下委派权限并完成管理员同意：`Chat.ReadWrite`, `ChatMessage.Send`, `ChannelMessage.Send`, `Group.ReadWrite.All`。可通过 Azure Portal 或 CLI：
+
+   ```bash
+   az ad app permission add --id <appId> --api 00000003-0000-0000-c000-000000000000 --api-permissions Chat.ReadWrite delegated
+   az ad app permission grant --id <appId> --api 00000003-0000-0000-c000-000000000000
+   ```
+
+2. **执行 OBO + Teams 回帖冒烟** – 该工具会：
+
+   - 读取配置并调用 `TokenBroker.ExchangeOnBehalfOfAsync`；
+   - 使用内置 `TranslationRouter` 生成译文，触发审计与成本指标；
+   - 通过 `TeamsReplyClient.SendReplyAsync` 发送模拟回帖，并回显 Graph 请求；
+   - 输出 `/api/metrics` 中同源的数据结构与审计日志样例。
+
+   ```bash
+   dotnet run --project scripts/SmokeTests/Stage5SmokeTests -- reply \
+     --tenant contoso.onmicrosoft.com \
+     --user stage-user \
+     --thread 19:stage-thread@thread.tacv2 \
+     --channel 19:stage-channel \
+     --language ja \
+     --tone business \
+     --text "Stage 5 手动联调验证"
+   ```
+
+   命令成功会打印 Graph 调用路径、Authorization 头、请求体，以及指标/审计 JSON 快照；若返回码非零，可按日志排查 Token、权限或配置缺失。【F:scripts/SmokeTests/Stage5SmokeTests/Program.cs†L214-L356】
+
+3. **若需对接真实 Graph** – 将 Stage 服务的反向代理或网络安全组打开至 Graph 端点，并在部署主机上替换 `SeedSecrets` 为 Key Vault 引用。由于当前实现的 Token 为 HMAC 模拟值，若要对接真实 Graph，可在 Stage 环境扩展 `TokenBroker` 以使用 AAD 访问令牌，再复用上述命令验证 `ReplyService` 行为。
+
+## 3. 指标与审计观测
+
+1. **Metrics API** – Stage 环境部署后，可直接访问 `GET /api/metrics` 获取与冒烟输出一致的 `UsageMetricsReport`，字段包含 `overall` 汇总、各租户 `translations/cost/failures` 细分。可将结果接入 Grafana/Workbook 进行可视化。【F:src/TlaPlugin/Program.cs†L454-L474】【F:src/TlaPlugin/Services/UsageMetricsService.cs†L1-L120】
+
+2. **失败原因映射** – `UsageMetricsService` 会将预算、认证、模型、鉴权失败分别记录为「预算不足」「合规拒绝」「模型错误」「认证失败」，确保仪表盘上可直接洞察失败原因比例。【F:src/TlaPlugin/Services/UsageMetricsService.cs†L7-L74】
+
+3. **审计导出** – `/api/audit` 返回由 `AuditLogger` 生成的 JSON 列表，包含租户、模型、成本及消息哈希。冒烟脚本输出的审计快照与线上格式一致，可作为调试模板或 SOX 留档。【F:src/TlaPlugin/Services/AuditLogger.cs†L1-L44】【F:scripts/SmokeTests/Stage5SmokeTests/Program.cs†L314-L332】
+
+4. **Runbook 纳入集成计划** – 将本 Runbook 及命令示例纳入阶段 5 联调计划，执行顺序建议：
+
+   1. 密钥映射并通过 `secrets` 检查；
+   2. 完成 Graph 权限与管理员同意；
+   3. 运行 `reply` 冒烟，保存指标/审计快照；
+   4. 在仪表盘验证 `/api/metrics` 展示的成本、失败原因，确保与 Runbook 输出一致；
+   5. 将脚本与命令记录在变更工单或自动化流水线中，便于回归与成本复核。
+
+通过上述步骤，可在 Stage 环境保证 Key Vault、Graph OBO 与观测指标三项能力全部打通，为后续正式上线提供可重复的联调手册。

--- a/scripts/SmokeTests/Stage5SmokeTests/Program.cs
+++ b/scripts/SmokeTests/Stage5SmokeTests/Program.cs
@@ -1,0 +1,463 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using TlaPlugin.Models;
+using TlaPlugin.Providers;
+using TlaPlugin.Services;
+
+var cancellationToken = CancellationToken.None;
+var command = args.Length > 0 && !args[0].StartsWith("--", StringComparison.Ordinal)
+    ? args[0].ToLowerInvariant()
+    : "help";
+var optionsMap = ParseOptions(args.Skip(command == "help" ? 0 : 1).ToArray());
+
+if (command is "help" or "-h" or "--help")
+{
+    PrintUsage();
+    return 0;
+}
+
+var appsettingsPath = optionsMap.TryGetValue("appsettings", out var configPath) && !string.IsNullOrWhiteSpace(configPath)
+    ? configPath!
+    : Path.Combine(AppContext.BaseDirectory, "../../../../src/TlaPlugin/appsettings.json");
+var additionalConfig = optionsMap.TryGetValue("override", out var overridePath) && !string.IsNullOrWhiteSpace(overridePath)
+    ? overridePath
+    : null;
+
+if (!File.Exists(appsettingsPath))
+{
+    Console.Error.WriteLine($"配置文件 {appsettingsPath} 不存在。");
+    return 1;
+}
+
+var (pluginOptions, configuration) = LoadOptions(appsettingsPath, additionalConfig);
+
+switch (command)
+{
+    case "secrets":
+        return await RunSecretCheckAsync(pluginOptions, cancellationToken).ConfigureAwait(false);
+    case "reply":
+        return await RunReplySmokeAsync(pluginOptions, optionsMap, cancellationToken).ConfigureAwait(false);
+    default:
+        Console.Error.WriteLine($"未知命令: {command}");
+        PrintUsage();
+        return 1;
+}
+
+static Dictionary<string, string?> ParseOptions(string[] arguments)
+{
+    var result = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+    for (var i = 0; i < arguments.Length; i++)
+    {
+        var argument = arguments[i];
+        if (!argument.StartsWith("--", StringComparison.Ordinal))
+        {
+            continue;
+        }
+
+        var trimmed = argument[2..];
+        var separatorIndex = trimmed.IndexOf('=');
+        if (separatorIndex >= 0)
+        {
+            var key = trimmed[..separatorIndex];
+            var value = trimmed[(separatorIndex + 1)..];
+            result[key] = string.IsNullOrWhiteSpace(value) ? null : value;
+            continue;
+        }
+
+        var optionKey = trimmed;
+        string? optionValue = null;
+        if (i + 1 < arguments.Length && !arguments[i + 1].StartsWith("--", StringComparison.Ordinal))
+        {
+            optionValue = arguments[++i];
+        }
+
+        result[optionKey] = optionValue;
+    }
+
+    return result;
+}
+
+static void PrintUsage()
+{
+    Console.WriteLine("Stage 5 冒烟测试工具");
+    Console.WriteLine();
+    Console.WriteLine("命令:");
+    Console.WriteLine("  secrets   校验 appsettings.json 中声明的密钥是否可由 KeyVaultSecretResolver 读取。");
+    Console.WriteLine("  reply     模拟 OBO 令牌与 Teams 回帖调用，输出指标与审计快照。");
+    Console.WriteLine();
+    Console.WriteLine("通用参数:");
+    Console.WriteLine("  --appsettings <path>    指定要加载的 appsettings.json，默认使用 src/TlaPlugin/appsettings.json。");
+    Console.WriteLine("  --override <path>       可选的额外 JSON 配置文件，后加载覆盖主配置。");
+    Console.WriteLine();
+    Console.WriteLine("reply 命令参数:");
+    Console.WriteLine("  --tenant <id>           目标租户 ID，默认为 contoso.onmicrosoft.com。");
+    Console.WriteLine("  --user <id>             模拟的用户 ID，默认为 user1。");
+    Console.WriteLine("  --thread <id>           线程/消息 ID，默认为 message-id。");
+    Console.WriteLine("  --channel <id>          Channel ID，可省略以模拟 1:1 聊天。");
+    Console.WriteLine("  --language <code>       回帖语言，默认为 ja。");
+    Console.WriteLine("  --tone <tone>           语气模板，默认为 polite。");
+    Console.WriteLine("  --text <content>        待翻译并回帖的正文，默认为 'ステージ 5 連携テスト'。");
+    Console.WriteLine();
+    Console.WriteLine("示例:");
+    Console.WriteLine("  dotnet run --project scripts/SmokeTests/Stage5SmokeTests -- secrets");
+    Console.WriteLine("  dotnet run --project scripts/SmokeTests/Stage5SmokeTests -- reply --tenant contoso.onmicrosoft.com --user fiona --thread 19:abc --channel general");
+}
+
+static (PluginOptions Options, IConfigurationRoot Configuration) LoadOptions(string appsettingsPath, string? overridePath)
+{
+    var directory = Path.GetDirectoryName(Path.GetFullPath(appsettingsPath)) ?? Directory.GetCurrentDirectory();
+    var fileName = Path.GetFileName(appsettingsPath);
+    var builder = new ConfigurationBuilder()
+        .SetBasePath(directory)
+        .AddJsonFile(fileName, optional: false, reloadOnChange: false);
+
+    if (!string.IsNullOrWhiteSpace(overridePath))
+    {
+        builder.AddJsonFile(overridePath, optional: false, reloadOnChange: false);
+    }
+
+    var localOverride = Path.Combine(directory, Path.GetFileNameWithoutExtension(fileName) + ".Local.json");
+    if (File.Exists(localOverride))
+    {
+        builder.AddJsonFile(localOverride, optional: true, reloadOnChange: false);
+    }
+
+    builder.AddEnvironmentVariables(prefix: "TLA_");
+    var configuration = builder.Build();
+    var options = new PluginOptions();
+    configuration.GetSection("Plugin").Bind(options);
+    return (options, configuration);
+}
+
+static async Task<int> RunSecretCheckAsync(PluginOptions options, CancellationToken cancellationToken)
+{
+    var resolver = new KeyVaultSecretResolver(Options.Create(options));
+    var secretNames = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    if (!string.IsNullOrWhiteSpace(options.Security.ClientSecretName))
+    {
+        secretNames.Add(options.Security.ClientSecretName);
+    }
+
+    foreach (var provider in options.Providers.Where(p => !string.IsNullOrWhiteSpace(p.ApiKeySecretName)))
+    {
+        secretNames.Add(provider.ApiKeySecretName);
+    }
+
+    foreach (var tenantOverride in options.Security.TenantOverrides.Values)
+    {
+        if (!string.IsNullOrWhiteSpace(tenantOverride.ClientSecretName))
+        {
+            secretNames.Add(tenantOverride.ClientSecretName);
+        }
+    }
+
+    if (secretNames.Count == 0)
+    {
+        Console.WriteLine("未在配置中找到任何需要解析的密钥名称。");
+        return 0;
+    }
+
+    var success = new List<string>();
+    var failures = new List<string>();
+
+    foreach (var name in secretNames)
+    {
+        try
+        {
+            var value = await resolver.GetSecretAsync(name, cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(value))
+            {
+                failures.Add($"{name} => 解析结果为空");
+            }
+            else
+            {
+                success.Add($"{name} => 长度 {value.Length}");
+            }
+        }
+        catch (Exception ex)
+        {
+            failures.Add($"{name} => {ex.Message}");
+        }
+    }
+
+    Console.WriteLine("[KeyVaultSecretResolver] 解析结果:");
+    foreach (var line in success)
+    {
+        Console.WriteLine("  ✔ " + line);
+    }
+
+    foreach (var line in failures)
+    {
+        Console.WriteLine("  ✘ " + line);
+    }
+
+    Console.WriteLine();
+    Console.WriteLine($"成功: {success.Count}, 失败: {failures.Count}");
+    return failures.Count == 0 ? 0 : 2;
+}
+
+static async Task<int> RunReplySmokeAsync(PluginOptions options, IReadOnlyDictionary<string, string?> parameters, CancellationToken cancellationToken)
+{
+    var tenantId = GetValue(parameters, "tenant", "contoso.onmicrosoft.com");
+    var userId = GetValue(parameters, "user", "user1");
+    var threadId = GetValue(parameters, "thread", "message-id");
+    var channelId = GetOptionalValue(parameters, "channel");
+    var language = GetValue(parameters, "language", "ja");
+    var tone = GetValue(parameters, "tone", TranslationRequest.DefaultTone);
+    var text = GetValue(parameters, "text", "ステージ 5 連携テスト");
+
+    var metrics = new UsageMetricsService();
+    var audit = new AuditLogger();
+    var resolver = new KeyVaultSecretResolver(Options.Create(options));
+    var tokenBroker = new TokenBroker(resolver, Options.Create(options));
+    var localization = new LocalizationCatalogService();
+    var budget = new BudgetGuard(options);
+    var compliance = new ComplianceGateway(Options.Create(options));
+    var tones = new ToneTemplateService();
+    var providerTemplate = options.Providers.FirstOrDefault();
+    var providerOptions = providerTemplate is null
+        ? new ModelProviderOptions
+        {
+            Id = "smoke-model",
+            TranslationPrefix = "[Smoke]",
+            Regions = new List<string> { "global" },
+            Certifications = new List<string> { "iso27001" },
+            Endpoint = string.Empty,
+            Model = "smoke"
+        }
+        : new ModelProviderOptions
+        {
+            Id = providerTemplate.Id,
+            Kind = providerTemplate.Kind,
+            CostPerCharUsd = providerTemplate.CostPerCharUsd,
+            LatencyTargetMs = providerTemplate.LatencyTargetMs,
+            Reliability = providerTemplate.Reliability,
+            Regions = new List<string>(providerTemplate.Regions),
+            Certifications = new List<string>(providerTemplate.Certifications),
+            TranslationPrefix = providerTemplate.TranslationPrefix,
+            Endpoint = providerTemplate.Endpoint,
+            Model = providerTemplate.Model,
+            ApiKeySecretName = providerTemplate.ApiKeySecretName,
+            Organization = providerTemplate.Organization,
+            DefaultHeaders = new Dictionary<string, string>(providerTemplate.DefaultHeaders)
+        };
+    if (providerOptions.Regions.Count == 0)
+    {
+        providerOptions.Regions.Add("global");
+    }
+    if (providerOptions.Certifications.Count == 0)
+    {
+        providerOptions.Certifications.Add("iso27001");
+    }
+
+    var stubProvider = new StubModelProvider(providerOptions);
+    var router = new TranslationRouter(
+        new ModelProviderFactory(Options.Create(options)),
+        compliance,
+        budget,
+        audit,
+        tones,
+        tokenBroker,
+        metrics,
+        localization,
+        Options.Create(options),
+        new[] { stubProvider });
+    var throttle = new TranslationThrottle(Options.Create(options));
+    var rewrite = new RewriteService(router, throttle);
+
+    var translationRequest = new TranslationRequest
+    {
+        Text = text,
+        TargetLanguage = language,
+        TenantId = tenantId,
+        UserId = userId,
+        ChannelId = channelId,
+        ThreadId = threadId,
+        Tone = tone,
+        UiLocale = options.DefaultUiLocale
+    };
+
+    TranslationResult translation;
+    try
+    {
+        translation = await router.TranslateAsync(translationRequest, cancellationToken).ConfigureAwait(false);
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine("翻译阶段失败: " + ex.Message);
+        return 3;
+    }
+
+    var handler = new FakeGraphHandler();
+    var httpClient = new HttpClient(handler)
+    {
+        BaseAddress = new Uri("https://graph.microsoft.com/v1.0/", UriKind.Absolute)
+    };
+    var teamsClient = new TeamsReplyClient(httpClient);
+    var replyService = new ReplyService(rewrite, teamsClient, tokenBroker, metrics, Options.Create(options));
+
+    var replyRequest = new ReplyRequest
+    {
+        ThreadId = threadId,
+        ReplyText = translation.TranslatedText,
+        Text = translation.TranslatedText,
+        TenantId = tenantId,
+        UserId = userId,
+        ChannelId = channelId,
+        UiLocale = translation.UiLocale,
+        LanguagePolicy = new ReplyLanguagePolicy
+        {
+            TargetLang = translation.TargetLanguage,
+            Tone = tone
+        }
+    };
+
+    ReplyResult replyResult;
+    try
+    {
+        replyResult = await replyService.SendReplyAsync(replyRequest, translation.TranslatedText, tone, cancellationToken).ConfigureAwait(false);
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine("回帖阶段失败: " + ex.Message);
+        return 4;
+    }
+
+    var metricsReport = metrics.GetReport();
+    var auditLogs = audit.Export();
+
+    Console.WriteLine("[TeamsReplyClient] 调用成功:");
+    Console.WriteLine($"  MessageId: {replyResult.MessageId}");
+    Console.WriteLine($"  Status:    {replyResult.Status}");
+    Console.WriteLine($"  Language:  {replyResult.Language}");
+    Console.WriteLine();
+    Console.WriteLine("Graph 请求回显:");
+    Console.WriteLine($"  Path:        {handler.LastPath}");
+    Console.WriteLine($"  Authorization: {handler.LastAuthorization}");
+    Console.WriteLine($"  Payload:     {handler.LastBody}");
+    Console.WriteLine();
+
+    Console.WriteLine("使用指标摘要:");
+    Console.WriteLine(JsonSerializer.Serialize(metricsReport, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine();
+
+    Console.WriteLine("审计记录样例:");
+    foreach (var log in auditLogs)
+    {
+        Console.WriteLine(log.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    if (metricsReport.Tenants.Count == 0)
+    {
+        Console.Error.WriteLine("未捕获任何指标，请检查配置。");
+        return 5;
+    }
+
+    if (auditLogs.Count == 0)
+    {
+        Console.Error.WriteLine("未生成审计记录，请检查翻译结果。");
+        return 6;
+    }
+
+    if (handler.CallCount == 0)
+    {
+        Console.Error.WriteLine("未触发 TeamsReplyClient 调用。");
+        return 7;
+    }
+
+    return 0;
+}
+
+static string GetValue(IReadOnlyDictionary<string, string?> parameters, string key, string fallback)
+    => parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
+        ? value!
+        : fallback;
+
+static string? GetOptionalValue(IReadOnlyDictionary<string, string?> parameters, string key)
+    => parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value) ? value : null;
+
+sealed class FakeGraphHandler : HttpMessageHandler
+{
+    public int CallCount { get; private set; }
+    public string? LastPath { get; private set; }
+    public string? LastAuthorization { get; private set; }
+    public string? LastBody { get; private set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        CallCount++;
+        LastPath = request.RequestUri?.ToString();
+        LastAuthorization = request.Headers.Authorization?.ToString();
+        LastBody = request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        var response = new HttpResponseMessage(HttpStatusCode.Created)
+        {
+            Content = new StringContent($"{{\"id\":\"smoke-{Guid.NewGuid():N}\",\"createdDateTime\":\"{DateTimeOffset.UtcNow:O}\"}}", Encoding.UTF8, "application/json")
+        };
+        return response;
+    }
+}
+
+sealed class StubModelProvider : IModelProvider
+{
+    public StubModelProvider(ModelProviderOptions options)
+    {
+        Options = options;
+        if (string.IsNullOrWhiteSpace(Options.TranslationPrefix))
+        {
+            Options.TranslationPrefix = "[Stub]";
+        }
+        if (Options.CostPerCharUsd <= 0)
+        {
+            Options.CostPerCharUsd = 0.00002m;
+        }
+        if (Options.LatencyTargetMs <= 0)
+        {
+            Options.LatencyTargetMs = 120;
+        }
+    }
+
+    public ModelProviderOptions Options { get; }
+
+    public Task<DetectionResult> DetectAsync(string text, CancellationToken cancellationToken)
+    {
+        var candidates = new List<DetectionCandidate>
+        {
+            new("en", 0.9),
+            new("ja", 0.1)
+        };
+        return Task.FromResult(new DetectionResult("en", 0.9, candidates));
+    }
+
+    public Task<ModelTranslationResult> TranslateAsync(string text, string sourceLanguage, string targetLanguage, string promptPrefix, CancellationToken cancellationToken)
+    {
+        var rewritten = $"{Options.TranslationPrefix}{targetLanguage}:{text}";
+        return Task.FromResult(new ModelTranslationResult(rewritten, Options.Id, 0.98, Options.LatencyTargetMs));
+    }
+
+    public Task<string> RewriteAsync(string translatedText, string tone, CancellationToken cancellationToken)
+    {
+        var normalizedTone = string.IsNullOrWhiteSpace(tone) ? ToneTemplateService.DefaultTone : tone;
+        return Task.FromResult($"[{normalizedTone}] {translatedText}");
+    }
+
+    public Task<string> SummarizeAsync(string text, CancellationToken cancellationToken)
+    {
+        var summary = text.Length <= 120 ? text : text[..117] + "...";
+        return Task.FromResult(summary);
+    }
+}

--- a/scripts/SmokeTests/Stage5SmokeTests/Stage5SmokeTests.csproj
+++ b/scripts/SmokeTests/Stage5SmokeTests/Stage5SmokeTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/TlaPlugin/TlaPlugin.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add Stage5SmokeTests console project that validates KeyVault secrets and simulates OBO + Teams reply flows
- document Stage 5 integration runbook covering secret mapping, Graph permissions, and observability checks
- reference the new smoke tests and runbook from the README and include the tool in the solution file

## Testing
- dotnet build bobtla.sln *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddad1fbdd8832f99cfca8a4f5535cf