### PR TITLE
Add multi-language reply handling

### DIFF
--- a/src/TlaPlugin/Models/ReplyModels.cs
+++ b/src/TlaPlugin/Models/ReplyModels.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace TlaPlugin.Models;
 
 /// <summary>
@@ -28,6 +30,7 @@ public class ReplyRequest
         = null;
     public ReplyLanguagePolicy? LanguagePolicy { get; set; }
         = null;
+    public IList<string> AdditionalTargetLanguages { get; set; } = new List<string>();
 }
 
 /// <summary>

--- a/src/TlaPlugin/Services/TeamsReplyClient.cs
+++ b/src/TlaPlugin/Services/TeamsReplyClient.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,9 +65,22 @@ public class TeamsReplyClient : ITeamsReplyClient
                 metadata = new
                 {
                     language = request.Language,
-                    tone = request.Tone
+                    tone = request.Tone,
+                    additionalTranslations = request.AdditionalTranslations.Count > 0
+                        ? request.AdditionalTranslations
+                        : null
                 }
-            }
+            },
+            attachments = request.AdaptiveCard is null
+                ? null
+                : new object[]
+                {
+                    new
+                    {
+                        contentType = "application/vnd.microsoft.card.adaptive",
+                        content = request.AdaptiveCard
+                    }
+                }
         };
 
         httpRequest.Content = new StringContent(JsonSerializer.Serialize(payload, SerializerOptions), Encoding.UTF8, "application/json");
@@ -187,7 +202,9 @@ public sealed record TeamsReplyRequest(
     string FinalText,
     string Language,
     string Tone,
-    string AccessToken);
+    string AccessToken,
+    IReadOnlyDictionary<string, string> AdditionalTranslations,
+    JsonObject? AdaptiveCard);
 
 public sealed record TeamsReplyResponse(string MessageId, DateTimeOffset SentAt, string Status);
 

--- a/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
+++ b/tests/TlaPlugin.Tests/MessageExtensionHandlerTests.cs
@@ -475,7 +475,8 @@ public class MessageExtensionHandlerTests
         var cache = new TranslationCache(options);
         var throttle = new TranslationThrottle(options);
         var rewrite = new RewriteService(router, throttle);
-        var reply = new ReplyService(rewrite, options);
+        var replyClient = replyClientOverride ?? new StubTeamsReplyClient();
+        var reply = new ReplyService(rewrite, router, replyClient, tokenBroker, metrics, options);
         var context = contextOverride ?? new ContextRetrievalService(new NullTeamsMessageClient(), new MemoryCache(new MemoryCacheOptions()), tokenBroker, options);
         var pipeline = new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, context, rewrite, reply, options);
         return new MessageExtensionHandler(pipeline, localization, options);

--- a/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
@@ -965,7 +965,7 @@ public class TranslationPipelineTests
         var glossary = new GlossaryService();
         var cache = new TranslationCache(options);
         var rewrite = new RewriteService(router, throttle);
-        var reply = new ReplyService(rewrite, new NoopTeamsReplyClient(), tokenBroker, metrics, options);
+        var reply = new ReplyService(rewrite, router, new NoopTeamsReplyClient(), tokenBroker, metrics, options);
 
         var context = new ContextRetrievalService(new NullTeamsMessageClient(), new MemoryCache(new MemoryCacheOptions()), tokenBroker, options);
 
@@ -1002,7 +1002,7 @@ public class TranslationPipelineTests
         var cache = new TranslationCache(options);
         var throttle = new TranslationThrottle(options);
         var rewrite = new RewriteService(router, throttle);
-        var reply = new ReplyService(rewrite, options);
+        var reply = new ReplyService(rewrite, router, new NoopTeamsReplyClient(), tokenBroker, metrics, options);
         var context = contextOverride ?? new ContextRetrievalService(teamsClient ?? new NullTeamsMessageClient(), memoryCache ?? new MemoryCache(new MemoryCacheOptions()), tokenBroker, options);
         return new TranslationPipeline(router, glossary, new OfflineDraftStore(options), new LanguageDetector(), cache, throttle, context, rewrite, reply, options);
     }
@@ -1036,6 +1036,12 @@ public class TranslationPipelineTests
     {
         public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
             => Task.FromResult(new AccessToken("token", DateTimeOffset.UtcNow.AddMinutes(5), "api://audience"));
+    }
+
+    private sealed class NoopTeamsReplyClient : ITeamsReplyClient
+    {
+        public Task<TeamsReplyResponse> SendReplyAsync(TeamsReplyRequest request, CancellationToken cancellationToken)
+            => Task.FromResult(new TeamsReplyResponse("noop", DateTimeOffset.UtcNow, "skipped"));
     }
 
     private sealed class FakeTeamsMessageClient : ITeamsMessageClient


### PR DESCRIPTION
## Summary
- add support for optional additional target languages on reply requests
- update the reply service to translate extra languages, emit adaptive card attachments, and pass metadata to the Teams client
- adjust the Teams reply client and supporting tests to cover multi-lingual replies and new dependencies

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ddad1e9314832fad1e637d7b7a1b40