### PR TITLE
Enhance reply service with multilingual outputs

### DIFF
--- a/src/TlaPlugin/Models/ReplyModels.cs
+++ b/src/TlaPlugin/Models/ReplyModels.cs
@@ -16,6 +16,8 @@ public class ReplyLanguagePolicy
 /// </summary>
 public class ReplyRequest
 {
+    private IList<string> _additionalTargetLanguages = new List<string>();
+
     public string ThreadId { get; set; } = string.Empty;
     public string ReplyText { get; set; } = string.Empty;
     public string Text { get; set; } = string.Empty;
@@ -30,7 +32,12 @@ public class ReplyRequest
         = null;
     public ReplyLanguagePolicy? LanguagePolicy { get; set; }
         = null;
-    public IList<string> AdditionalTargetLanguages { get; set; } = new List<string>();
+
+    public IList<string> AdditionalTargetLanguages
+    {
+        get => _additionalTargetLanguages;
+        set => _additionalTargetLanguages = value ?? new List<string>();
+    }
 }
 
 /// <summary>

--- a/tests/TlaPlugin.Tests/ReplyServiceTests.cs
+++ b/tests/TlaPlugin.Tests/ReplyServiceTests.cs
@@ -116,6 +116,9 @@ public class ReplyServiceTests
         Assert.True(additional.ContainsKey("en"));
         Assert.True(additional.ContainsKey("de"));
         Assert.NotNull(teamsClient.LastRequest!.AdaptiveCard);
+        Assert.Equal(result.FinalText, teamsClient.LastRequest!.FinalText);
+        Assert.Contains("[en]", result.FinalText, StringComparison.Ordinal);
+        Assert.Contains("[de]", result.FinalText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -252,6 +255,7 @@ public class ReplyServiceTests
         Assert.Contains("fr", extras.GetProperty("fr").GetString());
         var html = root.GetProperty("body").GetProperty("content").GetString();
         Assert.Contains("グラフ投稿", html, StringComparison.Ordinal);
+        Assert.Contains("[fr]", html, StringComparison.Ordinal);
         var attachments = root.GetProperty("attachments");
         var card = attachments[0].GetProperty("content");
         Assert.Equal("application/vnd.microsoft.card.adaptive", attachments[0].GetProperty("contentType").GetString());


### PR DESCRIPTION
## Summary
- ensure ReplyRequest always exposes an AdditionalTargetLanguages list when deserialized
- build Teams replies that append translated variants and surface them through adaptive cards
- expand ReplyService unit tests to cover the multilingual payload formatting

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddcf4d8324832f8cd1ffe81a80c58d