### PR TITLE
Run webapp build before MSBuild entry points

### DIFF
--- a/src/TlaPlugin/TlaPlugin.csproj
+++ b/src/TlaPlugin/TlaPlugin.csproj
@@ -32,14 +32,13 @@
     <Error Condition="'$(NodeExitCode)' != '0'" Text="Node.js is required to build the web assets. Please install Node.js and ensure it is available on the PATH." />
   </Target>
 
-  <Target Name="BuildWebApp" DependsOnTargets="EnsureNode" Inputs="@(WebAppSourceFiles);$(BuildWebAppScript)" Outputs="$(WebAppOutputDir)/build.stamp">
+  <Target Name="BuildWebApp"
+          BeforeTargets="Build;Publish"
+          DependsOnTargets="EnsureNode"
+          Inputs="@(WebAppSourceFiles);$(BuildWebAppScript)"
+          Outputs="$(WebAppOutputDir)/build.stamp">
     <Message Text="Building web assets..." Importance="high" />
     <Exec Command="&quot;$(NodeCommand)&quot; &quot;$(BuildWebAppScript)&quot;" />
     <WriteLinesToFile File="$(WebAppOutputDir)/build.stamp" Lines="Built $(MSBuildProjectName) web assets." Overwrite="true" />
   </Target>
-
-  <PropertyGroup>
-    <BuildDependsOn>BuildWebApp;$(BuildDependsOn)</BuildDependsOn>
-    <PublishDependsOn>BuildWebApp;$(PublishDependsOn)</PublishDependsOn>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- ensure the Node.js web build runs ahead of Build and Publish
- keep incremental execution by wiring Inputs/Outputs around the web assets

## Testing
- dotnet publish src/TlaPlugin/TlaPlugin.csproj -c Release *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddcf4d0948832f9d4db898497c897e