### PR TITLE
Update roadmap and status for phase 5 preparation

### DIFF
--- a/src/TlaPlugin/Services/DevelopmentRoadmapService.cs
+++ b/src/TlaPlugin/Services/DevelopmentRoadmapService.cs
@@ -63,17 +63,17 @@ public class DevelopmentRoadmapService
             "phase4",
             "阶段 4：前端体验",
             "构建 Teams 设置页与前端仪表盘，统一本地化。",
-            false,
+            true,
             new[]
             {
-                "LocalizationCatalogService 推送日文默认 UI",
-                "/api/status 与 /api/roadmap 汇总阶段数据",
-                "新增 src/webapp 仪表盘页面与视图模型"
+                "Teams 设置 Tab 与仪表盘 UI 凝练交互",
+                "前端消费 /api/status、/api/roadmap 实时刷新",
+                "LocalizationCatalogService 发布多语言资源"
             },
             new[]
             {
-                "本地化单测",
-                "前端视图模型测试"
+                "前端视图模型测试",
+                "仪表盘冒烟回归"
             }),
         new(
             "phase5",
@@ -83,13 +83,15 @@ public class DevelopmentRoadmapService
             new[]
             {
                 "接入生产模型与监控",
-                "前后端联调脚本",
-                "发布清单与回滚预案"
+                "密钥映射与凭据分发 Runbook",
+                "Graph/OBO 冒烟脚本与报表",
+                "真实模型切换 SmokeTest 清单"
             },
             new[]
             {
-                "联调回归测试",
-                "性能基准测试"
+                "上线 Runbook 演练",
+                "Graph/OBO 冒烟测试",
+                "发布 SmokeTest"
             })
     };
 

--- a/src/TlaPlugin/Services/ProjectStatusService.cs
+++ b/src/TlaPlugin/Services/ProjectStatusService.cs
@@ -15,15 +15,15 @@ public class ProjectStatusService
         new("phase1", "阶段 1：平台基线", "完成需求解读、服务编排与消息扩展骨架。", true),
         new("phase2", "阶段 2：安全与合规", "交付合规网关、预算守卫与密钥/OBO 管理。", true),
         new("phase3", "阶段 3：性能与可观测", "完成缓存、速率控制与多模型互联。", true),
-        new("phase4", "阶段 4：前端体验", "实现 Teams Tab 仪表盘与本地化界面。", false),
+        new("phase4", "阶段 4：前端体验", "实现 Teams Tab 仪表盘与本地化界面。", true),
         new("phase5", "阶段 5：上线准备", "拉通真实模型、联调并准备发布清单。", false)
     };
 
     private static readonly IReadOnlyList<string> NextSteps = new List<string>
     {
-        "完善设置页组件并补全前端校验",
-        "串联状态/路标 API 与实时刷新机制",
-        "安排跨团队联调与上线验收"
+        "完成密钥映射 Runbook 并固化凭据分发",
+        "安排 Graph/OBO 冒烟测试验证令牌链路",
+        "切换至真实模型并执行发布 SmokeTest"
     };
 
     /// <summary>
@@ -34,10 +34,10 @@ public class ProjectStatusService
         var current = Stages.FirstOrDefault(s => !s.Completed) ?? Stages.Last();
         var overallPercent = CalculateOverallPercent();
         var frontend = new FrontendProgress(
-            CompletionPercent: 55,
+            CompletionPercent: 80,
             DataPlaneReady: true,
             UiImplemented: true,
-            IntegrationReady: false);
+            IntegrationReady: true);
 
         return new ProjectStatusSnapshot(current.Id, Stages, NextSteps, overallPercent, frontend);
     }

--- a/src/TlaPlugin/wwwroot/webapp/app.js
+++ b/src/TlaPlugin/wwwroot/webapp/app.js
@@ -1,30 +1,30 @@
 import { buildStatusCards, formatLocaleOptions } from "./viewModel.js";
 
 const FALLBACK_STATUS = {
-  currentStageId: "phase4",
-  overallCompletionPercent: 60,
+  currentStageId: "phase5",
+  overallCompletionPercent: 80,
   nextSteps: [
-    "完善设置页组件并补全前端校验",
-    "串联状态/路标 API 与实时刷新机制",
-    "安排跨团队联调与上线验收"
+    "完成密钥映射 Runbook 并固化凭据分发",
+    "安排 Graph/OBO 冒烟测试验证令牌链路",
+    "切换至真实模型并执行发布 SmokeTest"
   ],
   stages: [
     { id: "phase1", name: "阶段 1：平台基线", completed: true },
     { id: "phase2", name: "阶段 2：安全与合规", completed: true },
     { id: "phase3", name: "阶段 3：性能与可观测", completed: true },
-    { id: "phase4", name: "阶段 4：前端体验", completed: false },
+    { id: "phase4", name: "阶段 4：前端体验", completed: true },
     { id: "phase5", name: "阶段 5：上线准备", completed: false }
   ],
   frontend: {
-    completionPercent: 55,
+    completionPercent: 80,
     dataPlaneReady: true,
     uiImplemented: true,
-    integrationReady: false
+    integrationReady: true
   }
 };
 
 const FALLBACK_ROADMAP = {
-  activeStageId: "phase4",
+  activeStageId: "phase5",
   stages: [
     {
       id: "phase1",
@@ -63,11 +63,11 @@ const FALLBACK_ROADMAP = {
       id: "phase4",
       name: "阶段 4：前端体验",
       objective: "构建 Teams 设置页与前端仪表盘，统一本地化。",
-      completed: false,
+      completed: true,
       deliverables: [
-        "LocalizationCatalogService 推送日文默认 UI",
-        "/api/status 与 /api/roadmap 汇总阶段数据",
-        "新增 src/webapp 仪表盘页面与视图模型"
+        "Teams 设置 Tab 与仪表盘 UI 凝练交互",
+        "前端消费 /api/status、/api/roadmap 实时刷新",
+        "LocalizationCatalogService 发布多语言资源"
       ]
     },
     {
@@ -77,8 +77,9 @@ const FALLBACK_ROADMAP = {
       completed: false,
       deliverables: [
         "接入生产模型与监控",
-        "前后端联调脚本",
-        "发布清单与回滚预案"
+        "密钥映射与凭据分发 Runbook",
+        "Graph/OBO 冒烟脚本与报表",
+        "真实模型切换 SmokeTest 清单"
       ]
     }
   ],

--- a/src/webapp/app.js
+++ b/src/webapp/app.js
@@ -1,30 +1,30 @@
 import { buildStatusCards, formatLocaleOptions } from "./viewModel.js";
 
 const FALLBACK_STATUS = {
-  currentStageId: "phase4",
-  overallCompletionPercent: 60,
+  currentStageId: "phase5",
+  overallCompletionPercent: 80,
   nextSteps: [
-    "完善设置页组件并补全前端校验",
-    "串联状态/路标 API 与实时刷新机制",
-    "安排跨团队联调与上线验收"
+    "完成密钥映射 Runbook 并固化凭据分发",
+    "安排 Graph/OBO 冒烟测试验证令牌链路",
+    "切换至真实模型并执行发布 SmokeTest"
   ],
   stages: [
     { id: "phase1", name: "阶段 1：平台基线", completed: true },
     { id: "phase2", name: "阶段 2：安全与合规", completed: true },
     { id: "phase3", name: "阶段 3：性能与可观测", completed: true },
-    { id: "phase4", name: "阶段 4：前端体验", completed: false },
+    { id: "phase4", name: "阶段 4：前端体验", completed: true },
     { id: "phase5", name: "阶段 5：上线准备", completed: false }
   ],
   frontend: {
-    completionPercent: 55,
+    completionPercent: 80,
     dataPlaneReady: true,
     uiImplemented: true,
-    integrationReady: false
+    integrationReady: true
   }
 };
 
 const FALLBACK_ROADMAP = {
-  activeStageId: "phase4",
+  activeStageId: "phase5",
   stages: [
     {
       id: "phase1",
@@ -63,11 +63,11 @@ const FALLBACK_ROADMAP = {
       id: "phase4",
       name: "阶段 4：前端体验",
       objective: "构建 Teams 设置页与前端仪表盘，统一本地化。",
-      completed: false,
+      completed: true,
       deliverables: [
-        "LocalizationCatalogService 推送日文默认 UI",
-        "/api/status 与 /api/roadmap 汇总阶段数据",
-        "新增 src/webapp 仪表盘页面与视图模型"
+        "Teams 设置 Tab 与仪表盘 UI 凝练交互",
+        "前端消费 /api/status、/api/roadmap 实时刷新",
+        "LocalizationCatalogService 发布多语言资源"
       ]
     },
     {
@@ -77,8 +77,9 @@ const FALLBACK_ROADMAP = {
       completed: false,
       deliverables: [
         "接入生产模型与监控",
-        "前后端联调脚本",
-        "发布清单与回滚预案"
+        "密钥映射与凭据分发 Runbook",
+        "Graph/OBO 冒烟脚本与报表",
+        "真实模型切换 SmokeTest 清单"
       ]
     }
   ],

--- a/tests/TlaPlugin.Tests/DevelopmentRoadmapServiceTests.cs
+++ b/tests/TlaPlugin.Tests/DevelopmentRoadmapServiceTests.cs
@@ -12,10 +12,10 @@ public class DevelopmentRoadmapServiceTests
 
         var roadmap = service.GetRoadmap();
 
-        Assert.Equal("phase4", roadmap.ActiveStageId);
+        Assert.Equal("phase5", roadmap.ActiveStageId);
         Assert.Equal(5, roadmap.Stages.Count);
-        Assert.Contains(roadmap.Stages, stage => stage.Id == "phase4" && !stage.Completed);
-        Assert.Contains(roadmap.Stages, stage => stage.Deliverables.Contains("新增 src/webapp 仪表盘页面与视图模型"));
+        Assert.Contains(roadmap.Stages, stage => stage.Id == "phase4" && stage.Completed);
+        Assert.Contains(roadmap.Stages, stage => stage.Deliverables.Contains("密钥映射与凭据分发 Runbook"));
         Assert.Contains(roadmap.Tests, test => test.Id == "dashboard" && test.Automated);
     }
 }

--- a/tests/TlaPlugin.Tests/ProjectStatusServiceTests.cs
+++ b/tests/TlaPlugin.Tests/ProjectStatusServiceTests.cs
@@ -12,14 +12,14 @@ public class ProjectStatusServiceTests
 
         var snapshot = service.GetSnapshot();
 
-        Assert.Equal("phase4", snapshot.CurrentStageId);
-        Assert.Contains(snapshot.Stages, stage => stage.Id == "phase4" && !stage.Completed);
+        Assert.Equal("phase5", snapshot.CurrentStageId);
+        Assert.Contains(snapshot.Stages, stage => stage.Id == "phase4" && stage.Completed);
         Assert.Equal(3, snapshot.NextSteps.Count);
-        Assert.Contains(snapshot.NextSteps, step => step.Contains("前端"));
-        Assert.Equal(60, snapshot.OverallCompletionPercent);
+        Assert.Contains(snapshot.NextSteps, step => step.Contains("密钥"));
+        Assert.Equal(80, snapshot.OverallCompletionPercent);
         Assert.True(snapshot.Frontend.DataPlaneReady);
         Assert.True(snapshot.Frontend.UiImplemented);
-        Assert.False(snapshot.Frontend.IntegrationReady);
-        Assert.Equal(55, snapshot.Frontend.CompletionPercent);
+        Assert.True(snapshot.Frontend.IntegrationReady);
+        Assert.Equal(80, snapshot.Frontend.CompletionPercent);
     }
 }

--- a/tests/dashboardMetrics.render.test.js
+++ b/tests/dashboardMetrics.render.test.js
@@ -44,10 +44,10 @@ test("renderSummary populates metrics blocks", (t) => {
   });
 
   const cards = {
-    overallPercent: 75,
-    frontend: { completionPercent: 60, dataPlaneReady: true, uiImplemented: false, integrationReady: false },
-    nextSteps: ["完善 API"],
-    activeStage: { name: "阶段 4", objective: "交付前端体验" }
+    overallPercent: 80,
+    frontend: { completionPercent: 80, dataPlaneReady: true, uiImplemented: true, integrationReady: true },
+    nextSteps: ["密钥映射 Runbook"],
+    activeStage: { name: "阶段 5", objective: "上线准备" }
   };
 
   const metrics = normalizeMetrics({

--- a/tests/dashboardViewModel.test.js
+++ b/tests/dashboardViewModel.test.js
@@ -5,36 +5,39 @@ import { groupStagesForTimeline, buildStatusCards, formatLocaleOptions } from ".
 test("groupStagesForTimeline marks active stage and progress", () => {
   const stages = [
     { id: "phase1", name: "阶段 1：平台基线", completed: true },
-    { id: "phase4", name: "阶段 4：前端体验", completed: false }
+    { id: "phase4", name: "阶段 4：前端体验", completed: true },
+    { id: "phase5", name: "阶段 5：上线准备", completed: false }
   ];
 
-  const grouped = groupStagesForTimeline(stages, "phase4");
-  assert.equal(grouped.length, 2);
+  const grouped = groupStagesForTimeline(stages, "phase5");
+  assert.equal(grouped.length, 3);
   assert.equal(grouped[0].progress, 100);
-  assert.equal(grouped[1].isActive, true);
-  assert.equal(grouped[1].progress, 50);
+  assert.equal(grouped[1].progress, 100);
+  assert.equal(grouped[2].isActive, true);
+  assert.equal(grouped[2].progress, 50);
 });
 
 test("buildStatusCards merges roadmap and status information", () => {
   const status = {
-    currentStageId: "phase4",
-    overallCompletionPercent: 60,
-    frontend: { completionPercent: 55, dataPlaneReady: true, uiImplemented: true, integrationReady: false },
-    nextSteps: ["完善设置页"],
+    currentStageId: "phase5",
+    overallCompletionPercent: 80,
+    frontend: { completionPercent: 80, dataPlaneReady: true, uiImplemented: true, integrationReady: true },
+    nextSteps: ["密钥映射"],
     stages: [{ id: "phase1", name: "阶段 1", completed: true }]
   };
   const roadmap = {
-    activeStageId: "phase4",
+    activeStageId: "phase5",
     stages: [
       { id: "phase1", name: "阶段 1", completed: true, objective: "完成基础" },
-      { id: "phase4", name: "阶段 4", completed: false, objective: "交付前端" }
+      { id: "phase4", name: "阶段 4", completed: true, objective: "交付前端" },
+      { id: "phase5", name: "阶段 5", completed: false, objective: "上线准备" }
     ],
     tests: [{ id: "dashboard", name: "dashboardViewModel.test.js", description: "verify" }]
   };
 
   const cards = buildStatusCards(status, roadmap);
-  assert.equal(cards.timeline.length, 2);
-  assert.equal(cards.activeStage.name, "阶段 4");
+  assert.equal(cards.timeline.length, 3);
+  assert.equal(cards.activeStage.name, "阶段 5");
   assert.equal(cards.frontend.uiImplemented, true);
   assert.equal(cards.tests[0].id, "dashboard");
 });


### PR DESCRIPTION
## Summary
- mark phase 4 as complete in the project snapshot and roadmap services while elevating frontend readiness and next steps for phase 5
- refresh roadmap deliverables and fallback webapp data to emphasize runbook, Graph/OBO smoke coverage, and real model cutover work for phase 5
- align .NET and web dashboard tests with the updated stage activation, completion percentages, and next-step expectations

## Testing
- node --test tests/dashboardViewModel.test.js tests/dashboardMetrics.render.test.js
- ❌ dotnet test *(.NET SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de05f012e8832fa3a20ea0ceaaf647