### PR TITLE
Add compose multi-target language selection

### DIFF
--- a/src/TlaPlugin/wwwroot/teamsClient/state.js
+++ b/src/TlaPlugin/wwwroot/teamsClient/state.js
@@ -48,12 +48,19 @@ export function buildDialogState({ models, languages, context } = {}) {
   };
   const defaultModel = metadata.models[0];
   const targetLanguage = resolveDefaultTargetLanguage(metadata.languages, context?.app?.locale ?? "");
+  const availableTargets = metadata.languages.filter((lang) => isSelectableLanguage(lang)).map((lang) => lang.id);
   return {
     text: "",
     translation: "",
     modelId: defaultModel?.id ?? "",
     sourceLanguage: metadata.languages[0]?.id ?? "auto",
     targetLanguage,
+    additionalTargetLanguages: resolveAdditionalTargetLanguages(
+      undefined,
+      targetLanguage,
+      availableTargets
+    ),
+    availableTargetLanguages: availableTargets,
     threadId: resolveThreadId(context),
     useTerminology: true,
     useRag: false,
@@ -103,10 +110,16 @@ export function buildTranslatePayload(state, context) {
   if (!state.targetLanguage) {
     throw new Error("缺少目标语言");
   }
+  const additionalTargetLanguages = resolveAdditionalTargetLanguages(
+    state.additionalTargetLanguages,
+    state.targetLanguage,
+    state.availableTargetLanguages
+  );
   const payload = {
     text: state.text,
     sourceLanguage: state.sourceLanguage === "auto" ? undefined : state.sourceLanguage,
     targetLanguage: state.targetLanguage,
+    additionalTargetLanguages,
     tenantId: context?.tenant?.id,
     userId: context?.user?.id,
     channelId: context?.channel?.id,
@@ -160,10 +173,16 @@ export function buildReplyPayload(state, context, text) {
   if (!text?.trim()) {
     throw new Error("缺少回帖文本");
   }
+  const additionalTargetLanguages = resolveAdditionalTargetLanguages(
+    state.additionalTargetLanguages,
+    state.targetLanguage,
+    state.availableTargetLanguages
+  );
   const payload = {
     translation: text,
     sourceLanguage: state.sourceLanguage === "auto" ? state.detectedLanguage : state.sourceLanguage,
     targetLanguage: state.targetLanguage,
+    additionalTargetLanguages,
     tenantId: context?.tenant?.id,
     userId: context?.user?.id,
     channelId: context?.channel?.id,
@@ -178,6 +197,32 @@ export function buildReplyPayload(state, context, text) {
     payload.threadId = threadId;
   }
   return applyRagPreferences(payload, state);
+}
+
+export function resolveAdditionalTargetLanguages(list, targetLanguage, available = []) {
+  const source = Array.isArray(list) ? list : [];
+  const normalizedTarget = typeof targetLanguage === "string" ? targetLanguage.trim() : "";
+  const allowed = Array.isArray(available) && available.length > 0 ? new Set(available) : null;
+  const seen = new Set();
+  const result = [];
+  for (const entry of source) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (!trimmed || trimmed === normalizedTarget) {
+      continue;
+    }
+    if (allowed && !allowed.has(trimmed)) {
+      continue;
+    }
+    if (seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
 }
 
 export function updateStateWithResponse(state, response) {

--- a/src/teamsClient/state.js
+++ b/src/teamsClient/state.js
@@ -55,7 +55,12 @@ export function buildDialogState({ models, languages, context } = {}) {
     modelId: defaultModel?.id ?? "",
     sourceLanguage: metadata.languages[0]?.id ?? "auto",
     targetLanguage,
-    additionalTargetLanguages: resolveAdditionalTargetLanguages(undefined, targetLanguage, availableTargets),
+    additionalTargetLanguages: resolveAdditionalTargetLanguages(
+      undefined,
+      targetLanguage,
+      availableTargets
+    ),
+    availableTargetLanguages: availableTargets,
     threadId: resolveThreadId(context),
     useTerminology: true,
     useRag: false,
@@ -107,7 +112,8 @@ export function buildTranslatePayload(state, context) {
   }
   const additionalTargetLanguages = resolveAdditionalTargetLanguages(
     state.additionalTargetLanguages,
-    state.targetLanguage
+    state.targetLanguage,
+    state.availableTargetLanguages
   );
   const payload = {
     text: state.text,
@@ -169,7 +175,8 @@ export function buildReplyPayload(state, context, text) {
   }
   const additionalTargetLanguages = resolveAdditionalTargetLanguages(
     state.additionalTargetLanguages,
-    state.targetLanguage
+    state.targetLanguage,
+    state.availableTargetLanguages
   );
   const payload = {
     translation: text,

--- a/src/webapp/compose.html
+++ b/src/webapp/compose.html
@@ -16,6 +16,15 @@
         目标语言
         <select data-compose-target aria-label="目标语言"></select>
       </label>
+      <label>
+        附加目标语言
+        <select
+          data-compose-additional-targets
+          aria-label="附加目标语言"
+          multiple
+        ></select>
+      </label>
+      <p class="compose__hint">可选择多个语言以同时生成额外译文。</p>
       <label class="toggle">
         <input type="checkbox" data-terminology-toggle checked /> 使用术语表
       </label>


### PR DESCRIPTION
## Summary
- add a multi-select for additional target languages in the compose webview with helper copy
- update the compose plugin/state (and mirrored wwwroot bundle) to sync additional target languages into translation/reply payloads
- extend compose plugin tests to cover sending deduplicated additional languages through the reply flow

## Testing
- npm test *(fails: src/webapp/app.js missing handleGlossaryUpload export for glossaryUpload tests)*
- node --test tests/composePlugin.test.js


------
https://chatgpt.com/codex/tasks/task_e_68de05efe5ac832f9feef665c60ef2be