### PR TITLE
feat: integrate Azure Key Vault secret retrieval

### DIFF
--- a/docs/stage5-integration-runbook.md
+++ b/docs/stage5-integration-runbook.md
@@ -20,7 +20,9 @@
    az keyvault secret set --vault-name <vault> --name enterprise-graph-secret --value <enterprise-secret>
    ```
 
-3. **将 Key Vault 引用映射进配置** – 在 Stage 配置（例如 `appsettings.Stage.json`）或部署环境变量中，设置以下键值对，让 `KeyVaultSecretResolver` 能够解析到实际密钥。对真实 Key Vault，可使用 [Azure App Service Key Vault 引用](https://learn.microsoft.com/azure/app-service/app-service-key-vault-references) 或下方示例直接注入机密值：
+3. **配置访问策略或托管身份** – 为运行 Stage 服务的托管身份或应用注册授予目标 Key Vault 的 `get`/`list` Secret 权限。可通过 Azure Portal、`az keyvault set-policy` 或 Terraform 完成，确保 `Stage5SmokeTests` 的 `secrets` 命令能够直接读取远程机密。未授予权限时脚本会输出「无法访问远程 Key Vault」的提示，请根据错误信息补齐访问策略。
+
+4. **将 Key Vault 引用映射进配置** – 在 Stage 配置（例如 `appsettings.Stage.json`）或部署环境变量中，设置以下键值对，让 `KeyVaultSecretResolver` 能够解析到实际密钥。若不同租户使用独立 Vault，可在 `Plugin.Security.TenantOverrides["<tenant>"].KeyVaultUri` 指向各自的 Key Vault。对真实 Key Vault，可使用 [Azure App Service Key Vault 引用](https://learn.microsoft.com/azure/app-service/app-service-key-vault-references) 或下方示例直接注入机密值：
 
    ```bash
    # 使用环境变量覆盖 SeedSecrets
@@ -29,7 +31,7 @@
    export TLA_Plugin__Security__SeedSecrets__enterprise-graph-secret="<enterprise-secret>"
    ```
 
-4. **运行密钥解析冒烟** – 利用新增的 `Stage5SmokeTests` 工具检查所有密钥是否可被 `KeyVaultSecretResolver` 获取，确认映射指向 Key Vault 中的真实条目：
+5. **运行密钥解析冒烟** – 利用新增的 `Stage5SmokeTests` 工具检查所有密钥是否可被 `KeyVaultSecretResolver` 获取，确认映射指向 Key Vault 中的真实条目：
 
    ```bash
    dotnet run --project scripts/SmokeTests/Stage5SmokeTests -- secrets --appsettings src/TlaPlugin/appsettings.json --override appsettings.Stage.json

--- a/scripts/SmokeTests/Stage5SmokeTests/Program.cs
+++ b/scripts/SmokeTests/Stage5SmokeTests/Program.cs
@@ -151,27 +151,9 @@ static (PluginOptions Options, IConfigurationRoot Configuration) LoadOptions(str
 static async Task<int> RunSecretCheckAsync(PluginOptions options, CancellationToken cancellationToken)
 {
     var resolver = new KeyVaultSecretResolver(Options.Create(options));
-    var secretNames = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+    var probes = BuildSecretProbes(options);
 
-    if (!string.IsNullOrWhiteSpace(options.Security.ClientSecretName))
-    {
-        secretNames.Add(options.Security.ClientSecretName);
-    }
-
-    foreach (var provider in options.Providers.Where(p => !string.IsNullOrWhiteSpace(p.ApiKeySecretName)))
-    {
-        secretNames.Add(provider.ApiKeySecretName);
-    }
-
-    foreach (var tenantOverride in options.Security.TenantOverrides.Values)
-    {
-        if (!string.IsNullOrWhiteSpace(tenantOverride.ClientSecretName))
-        {
-            secretNames.Add(tenantOverride.ClientSecretName);
-        }
-    }
-
-    if (secretNames.Count == 0)
+    if (probes.Count == 0)
     {
         Console.WriteLine("未在配置中找到任何需要解析的密钥名称。");
         return 0;
@@ -180,23 +162,29 @@ static async Task<int> RunSecretCheckAsync(PluginOptions options, CancellationTo
     var success = new List<string>();
     var failures = new List<string>();
 
-    foreach (var name in secretNames)
+    foreach (var probe in probes)
     {
         try
         {
-            var value = await resolver.GetSecretAsync(name, cancellationToken).ConfigureAwait(false);
+            var value = await resolver.GetSecretAsync(probe.SecretName, probe.TenantId, cancellationToken).ConfigureAwait(false);
             if (string.IsNullOrEmpty(value))
             {
-                failures.Add($"{name} => 解析结果为空");
+                failures.Add($"{FormatProbe(probe)} => 解析结果为空");
             }
             else
             {
-                success.Add($"{name} => 长度 {value.Length}");
+                success.Add($"{FormatProbe(probe)} => 长度 {value.Length}");
             }
+        }
+        catch (SecretRetrievalException ex)
+        {
+            var vault = string.IsNullOrWhiteSpace(ex.VaultUri) ? options.Security.KeyVaultUri : ex.VaultUri;
+            var hint = "请确认托管身份或应用主体已在对应 Key Vault 中授予 get 权限，并且密钥名称拼写正确。";
+            failures.Add($"{FormatProbe(probe)} => 无法访问远程 Key Vault ({vault}): {ex.InnerException?.Message ?? ex.Message}. {hint}");
         }
         catch (Exception ex)
         {
-            failures.Add($"{name} => {ex.Message}");
+            failures.Add($"{FormatProbe(probe)} => {ex.Message}");
         }
     }
 
@@ -215,6 +203,49 @@ static async Task<int> RunSecretCheckAsync(PluginOptions options, CancellationTo
     Console.WriteLine($"成功: {success.Count}, 失败: {failures.Count}");
     return failures.Count == 0 ? 0 : 2;
 }
+
+static List<SecretProbe> BuildSecretProbes(PluginOptions options)
+{
+    var probes = new List<SecretProbe>();
+    var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    void AddProbe(string? tenantId, string? secretName)
+    {
+        if (string.IsNullOrWhiteSpace(secretName))
+        {
+            return;
+        }
+
+        var key = $"{tenantId ?? "__default__"}::{secretName}";
+        if (seen.Add(key))
+        {
+            probes.Add(new SecretProbe(tenantId, secretName));
+        }
+    }
+
+    AddProbe(null, options.Security.ClientSecretName);
+
+    foreach (var provider in options.Providers.Where(p => !string.IsNullOrWhiteSpace(p.ApiKeySecretName)))
+    {
+        AddProbe(null, provider.ApiKeySecretName);
+    }
+
+    foreach (var kvp in options.Security.TenantOverrides)
+    {
+        var tenantSecret = !string.IsNullOrWhiteSpace(kvp.Value.ClientSecretName)
+            ? kvp.Value.ClientSecretName
+            : options.Security.ClientSecretName;
+        AddProbe(kvp.Key, tenantSecret);
+    }
+
+    probes.Sort((left, right) => string.CompareOrdinal(FormatProbe(left), FormatProbe(right)));
+    return probes;
+}
+
+static string FormatProbe(SecretProbe probe)
+    => string.IsNullOrWhiteSpace(probe.TenantId) ? probe.SecretName : $"{probe.TenantId}/{probe.SecretName}";
+
+private readonly record struct SecretProbe(string? TenantId, string SecretName);
 
 static async Task<int> RunReplySmokeAsync(PluginOptions options, IReadOnlyDictionary<string, string?> parameters, CancellationToken cancellationToken)
 {

--- a/src/TlaPlugin/Configuration/PluginOptions.cs
+++ b/src/TlaPlugin/Configuration/PluginOptions.cs
@@ -274,6 +274,7 @@ public class SecurityOptions
 
 public class TenantSecurityOverride
 {
+    public string? KeyVaultUri { get; set; }
     public string? ClientId { get; set; }
     public string? ClientSecretName { get; set; }
     public string? UserAssertionAudience { get; set; }

--- a/src/TlaPlugin/Services/TokenBroker.cs
+++ b/src/TlaPlugin/Services/TokenBroker.cs
@@ -44,7 +44,7 @@ public class TokenBroker : ITokenBroker
             ? tenantOverride!.ClientSecretName!
             : security.ClientSecretName;
 
-        var clientSecret = await _resolver.GetSecretAsync(clientSecretName, cancellationToken);
+        var clientSecret = await _resolver.GetSecretAsync(clientSecretName, tenantId, cancellationToken);
         if (string.IsNullOrEmpty(clientSecret))
         {
             throw new AuthenticationException("无法获取客户端机密。");

--- a/src/TlaPlugin/TlaPlugin.csproj
+++ b/src/TlaPlugin/TlaPlugin.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.11.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.20" />
     <PackageReference Include="Microsoft.Graph" Version="5.53.0" />
   </ItemGroup>

--- a/src/TlaPlugin/appsettings.json
+++ b/src/TlaPlugin/appsettings.json
@@ -256,10 +256,12 @@
       },
       "TenantOverrides": {
         "contoso.onmicrosoft.com": {
+          "KeyVaultUri": "https://contoso.vault.azure.net/",
           "ClientSecretName": "tla-client-secret",
           "UserAssertionAudience": "api://tla-plugin"
         },
         "enterprise.onmicrosoft.com": {
+          "KeyVaultUri": "https://enterprise.vault.azure.net/",
           "ClientSecretName": "enterprise-graph-secret",
           "UserAssertionAudience": "api://enterprise-graph"
         }


### PR DESCRIPTION
## Summary
- resolve secrets from Azure Key Vault using DefaultAzureCredential with per-tenant vault overrides and detailed fallback errors
- extend Stage5 smoke tests to probe per-tenant secrets and surface friendly guidance when vault access fails
- document required Key Vault access policies and sample configuration updates for tenant-specific vault URIs

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de1962566c832f8380ce77afc30ef0