### PR TITLE
Align Graph scopes with Azure AD OBO requirements

### DIFF
--- a/src/TlaPlugin/appsettings.Stage.json
+++ b/src/TlaPlugin/appsettings.Stage.json
@@ -4,11 +4,10 @@
       "KeyVaultUri": "https://<stage-key-vault-name>.vault.azure.net/",
       "UseHmacFallback": false,
       "GraphScopes": [
-        "Chat.ReadWrite",
-        "ChatMessage.Send",
-        "ChannelMessage.Send",
-        "Group.ReadWrite.All"
+        "https://graph.microsoft.com/.default",
+        "https://graph.microsoft.com/Chat.ReadWrite"
       ],
+      "_graphScopesNote": "GraphScopes 必须与 Azure AD 授权范围一致（示例：.default 或特定权限的资源限定形式），否则 OBO 将返回 invalid_scope。",
       "_secretsReference": "需要在 Key Vault 中预配 docs/stage5-integration-runbook.md 所列的 tla-client-secret、openai-api-key、enterprise-graph-secret 等机密。",
       "TenantOverrides": {
         "contoso.onmicrosoft.com": {


### PR DESCRIPTION
## Summary
- update the stage appsettings template to use Azure AD-compliant Graph scope URIs and document the requirement
- deduplicate Graph scopes when issuing MSAL OBO tokens and cover the behavior with unit tests
- extend the Stage5 smoke test tooling and runbook guidance to surface scope-format reminders for field engineers

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de575fc944832fadb3e2da1b970a17