### PR TITLE
Enforce bearer auth across Teams translation APIs

### DIFF
--- a/src/TlaPlugin/Models/ContextRetrievalModels.cs
+++ b/src/TlaPlugin/Models/ContextRetrievalModels.cs
@@ -18,6 +18,8 @@ public class ContextRetrievalRequest
         = null;
     public IList<string> ContextHints { get; set; }
         = new List<string>();
+    public string? UserAssertion { get; set; }
+        = null;
 }
 
 /// <summary>

--- a/src/TlaPlugin/Models/PipelineExecutionResult.cs
+++ b/src/TlaPlugin/Models/PipelineExecutionResult.cs
@@ -106,6 +106,7 @@ public class PipelineExecutionResult
             Tone = request.Tone,
             UseGlossary = request.UseGlossary,
             UiLocale = request.UiLocale,
+            UserAssertion = request.UserAssertion,
             AdditionalTargetLanguages = new List<string>(request.AdditionalTargetLanguages),
             GlossaryDecisions = request.GlossaryDecisions.ToDictionary(
                 pair => pair.Key,

--- a/src/TlaPlugin/Models/ReplyModels.cs
+++ b/src/TlaPlugin/Models/ReplyModels.cs
@@ -32,6 +32,8 @@ public class ReplyRequest
         = null;
     public ReplyLanguagePolicy? LanguagePolicy { get; set; }
         = null;
+    public string? UserAssertion { get; set; }
+        = null;
 
     public IList<string> AdditionalTargetLanguages
     {

--- a/src/TlaPlugin/Models/RewriteRequest.cs
+++ b/src/TlaPlugin/Models/RewriteRequest.cs
@@ -15,6 +15,8 @@ public class RewriteRequest
         = null;
     public string? UiLocale { get; set; }
         = null;
+    public string? UserAssertion { get; set; }
+        = null;
 }
 
 /// <summary>

--- a/src/TlaPlugin/Models/SummarizeRequest.cs
+++ b/src/TlaPlugin/Models/SummarizeRequest.cs
@@ -8,6 +8,8 @@ public class SummarizeRequest
     public string Context { get; set; } = string.Empty;
     public string TenantId { get; set; } = string.Empty;
     public string UserId { get; set; } = string.Empty;
+    public string? UserAssertion { get; set; }
+        = null;
 }
 
 /// <summary>

--- a/src/TlaPlugin/Models/TranslationRequest.cs
+++ b/src/TlaPlugin/Models/TranslationRequest.cs
@@ -31,6 +31,8 @@ public class TranslationRequest
         = null;
     public string? UiLocale { get; set; }
         = null;
+    public string? UserAssertion { get; set; }
+        = null;
     public IDictionary<string, GlossaryDecision> GlossaryDecisions { get; set; }
         = new Dictionary<string, GlossaryDecision>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/TlaPlugin/Services/BrokeredGraphAuthenticationProvider.cs
+++ b/src/TlaPlugin/Services/BrokeredGraphAuthenticationProvider.cs
@@ -45,7 +45,7 @@ public sealed class BrokeredGraphAuthenticationProvider : IAuthenticationProvide
             }
 
             token = await _tokenBroker
-                .ExchangeOnBehalfOfAsync(context.TenantId, context.UserId, cancellationToken)
+                .ExchangeOnBehalfOfAsync(context.TenantId, context.UserId, context.UserAssertion, cancellationToken)
                 .ConfigureAwait(false);
 
             context.UpdateToken(token);

--- a/src/TlaPlugin/Services/ContextRetrievalService.cs
+++ b/src/TlaPlugin/Services/ContextRetrievalService.cs
@@ -108,11 +108,16 @@ public class ContextRetrievalService
                 limit = _options.Rag.MaxMessages > 0 ? _options.Rag.MaxMessages : 10;
             }
 
+            if (string.IsNullOrWhiteSpace(request.UserAssertion))
+            {
+                return Array.Empty<ContextMessage>();
+            }
+
             AccessToken? accessToken = null;
             try
             {
                 accessToken = await _tokenBroker
-                    .ExchangeOnBehalfOfAsync(request.TenantId, request.UserId, cancellationToken)
+                    .ExchangeOnBehalfOfAsync(request.TenantId, request.UserId, request.UserAssertion, cancellationToken)
                     .ConfigureAwait(false);
             }
             catch (AuthenticationException)
@@ -128,6 +133,7 @@ public class ContextRetrievalService
                     limit,
                     accessToken,
                     request.UserId,
+                    request.UserAssertion,
                     cancellationToken)
                 .ConfigureAwait(false);
 

--- a/src/TlaPlugin/Services/GraphRequestContextAccessor.cs
+++ b/src/TlaPlugin/Services/GraphRequestContextAccessor.cs
@@ -69,16 +69,19 @@ public sealed class GraphRequestContextAccessor : IGraphRequestContextAccessor
 /// </summary>
 public sealed class GraphRequestContext
 {
-    public GraphRequestContext(string tenantId, string? userId, AccessToken? accessToken)
+    public GraphRequestContext(string tenantId, string? userId, AccessToken? accessToken, string? userAssertion = null)
     {
         TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
         UserId = userId;
         AccessToken = accessToken;
+        UserAssertion = userAssertion;
     }
 
     public string TenantId { get; }
 
     public string? UserId { get; }
+
+    public string? UserAssertion { get; }
 
     public AccessToken? AccessToken { get; private set; }
 

--- a/src/TlaPlugin/Services/GraphTeamsMessageClient.cs
+++ b/src/TlaPlugin/Services/GraphTeamsMessageClient.cs
@@ -40,6 +40,7 @@ public class GraphTeamsMessageClient : ITeamsMessageClient
             maxMessages,
             accessToken: null,
             userId: null,
+            userAssertion: null,
             cancellationToken);
 
     public async Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
@@ -49,6 +50,7 @@ public class GraphTeamsMessageClient : ITeamsMessageClient
         int maxMessages,
         AccessToken? accessToken,
         string? userId,
+        string? userAssertion,
         CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(tenantId) || string.IsNullOrWhiteSpace(channelId))
@@ -60,7 +62,7 @@ public class GraphTeamsMessageClient : ITeamsMessageClient
 
         var messages = new List<ContextMessage>();
 
-        using var scope = _contextAccessor.Push(new GraphRequestContext(tenantId, userId, accessToken));
+        using var scope = _contextAccessor.Push(new GraphRequestContext(tenantId, userId, accessToken, userAssertion));
 
         var threadLookupAttempted = false;
         if (!string.IsNullOrEmpty(threadId))

--- a/src/TlaPlugin/Services/ITeamsMessageClient.cs
+++ b/src/TlaPlugin/Services/ITeamsMessageClient.cs
@@ -43,6 +43,7 @@ public interface ITeamsMessageClient
         int maxMessages,
         AccessToken? accessToken,
         string? userId,
+        string? userAssertion,
         CancellationToken cancellationToken)
         => GetRecentMessagesAsync(tenantId, channelId, threadId, maxMessages, cancellationToken);
 }

--- a/src/TlaPlugin/Services/RewriteService.cs
+++ b/src/TlaPlugin/Services/RewriteService.cs
@@ -32,6 +32,11 @@ public class RewriteService
             throw new AuthenticationException("tenantId と userId は必須です。");
         }
 
+        if (string.IsNullOrWhiteSpace(request.UserAssertion))
+        {
+            throw new AuthenticationException("缺少用户令牌。");
+        }
+
         var textToRewrite = !string.IsNullOrWhiteSpace(request.EditedText)
             ? request.EditedText!
             : request.Text;
@@ -49,7 +54,8 @@ public class RewriteService
             TenantId = request.TenantId,
             UserId = request.UserId,
             ChannelId = request.ChannelId,
-            UiLocale = request.UiLocale
+            UiLocale = request.UiLocale,
+            UserAssertion = request.UserAssertion
         };
 
         return await _router.RewriteAsync(normalizedRequest, cancellationToken);

--- a/src/TlaPlugin/Services/TranslationPipeline.cs
+++ b/src/TlaPlugin/Services/TranslationPipeline.cs
@@ -197,6 +197,7 @@ public class TranslationPipeline : ITranslationPipeline
             ContextHints = new List<string>(contextHints),
             ContextSummary = request.ContextSummary,
             UiLocale = request.UiLocale,
+            UserAssertion = request.UserAssertion,
             GlossaryDecisions = request.GlossaryDecisions.ToDictionary(
                 pair => pair.Key,
                 pair => pair.Value.Clone(),
@@ -222,7 +223,8 @@ public class TranslationPipeline : ITranslationPipeline
                 ChannelId = request.ChannelId,
                 ThreadId = request.ThreadId,
                 MaxMessages = _options.Rag.MaxMessages,
-                ContextHints = new List<string>(request.ContextHints)
+                ContextHints = new List<string>(request.ContextHints),
+                UserAssertion = request.UserAssertion
             }, cancellationToken);
         }
         catch (OperationCanceledException)
@@ -253,7 +255,8 @@ public class TranslationPipeline : ITranslationPipeline
             {
                 Context = combined,
                 TenantId = request.TenantId,
-                UserId = request.UserId
+                UserId = request.UserId,
+                UserAssertion = request.UserAssertion
             }, cancellationToken);
 
             summary = summarize.Summary;

--- a/src/TlaPlugin/Teams/MessageExtensionHandler.cs
+++ b/src/TlaPlugin/Teams/MessageExtensionHandler.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Security.Authentication;
 using Microsoft.Extensions.Options;
 using TlaPlugin.Models;
 using TlaPlugin.Services;
@@ -34,6 +35,11 @@ public class MessageExtensionHandler
 
     public async Task<JsonObject> HandleTranslateAsync(TranslationRequest request)
     {
+        if (string.IsNullOrWhiteSpace(request.UserAssertion))
+        {
+            throw new AuthenticationException("缺少用户令牌。");
+        }
+
         ApplyGlossarySelections(request);
         ApplyRagPreferences(request);
 
@@ -115,6 +121,11 @@ public class MessageExtensionHandler
 
     public async Task<JsonObject> HandleRewriteAsync(RewriteRequest request)
     {
+        if (string.IsNullOrWhiteSpace(request.UserAssertion))
+        {
+            throw new AuthenticationException("缺少用户令牌。");
+        }
+
         var locale = request.UiLocale ?? _options.DefaultUiLocale;
         var catalog = _localization.GetCatalog(locale);
         try
@@ -146,6 +157,11 @@ public class MessageExtensionHandler
 
     public async Task<JsonObject> HandleReplyAsync(ReplyRequest request)
     {
+        if (string.IsNullOrWhiteSpace(request.UserAssertion))
+        {
+            throw new AuthenticationException("缺少用户令牌。");
+        }
+
         var locale = request.UiLocale ?? _options.DefaultUiLocale;
         var catalog = _localization.GetCatalog(locale);
         try
@@ -183,7 +199,8 @@ public class MessageExtensionHandler
                 Tone = TranslationRequest.DefaultTone,
                 UiLocale = request.UiLocale,
                 UseGlossary = false,
-                UseRag = _options.Rag.Enabled
+                UseRag = _options.Rag.Enabled,
+                UserAssertion = request.UserAssertion
             };
 
             ApplyRagPreferences(translationRequest);

--- a/src/TlaPlugin/wwwroot/teamsClient/api.js
+++ b/src/TlaPlugin/wwwroot/teamsClient/api.js
@@ -49,28 +49,43 @@ export async function detectLanguage(payload, fetchImpl = fetch) {
   return await parseJsonResponse(response, "语言检测失败");
 }
 
-export async function translateText(payload, fetchImpl = fetch) {
+export async function translateText(payload, fetchImpl = fetch, { authorization } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  const headerValue = buildAuthorizationHeader(authorization);
+  if (headerValue) {
+    headers.Authorization = headerValue;
+  }
   const response = await fetchImpl("/api/translate", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(payload)
   });
   return await parseJsonResponse(response, "翻译接口失败");
 }
 
-export async function rewriteTranslation(payload, fetchImpl = fetch) {
+export async function rewriteTranslation(payload, fetchImpl = fetch, { authorization } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  const headerValue = buildAuthorizationHeader(authorization);
+  if (headerValue) {
+    headers.Authorization = headerValue;
+  }
   const response = await fetchImpl("/api/rewrite", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(payload)
   });
   return await parseJsonResponse(response, "译文润色失败");
 }
 
-export async function sendReply(payload, fetchImpl = fetch) {
+export async function sendReply(payload, fetchImpl = fetch, { authorization } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  const headerValue = buildAuthorizationHeader(authorization);
+  if (headerValue) {
+    headers.Authorization = headerValue;
+  }
   const response = await fetchImpl("/api/reply", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(payload)
   });
   return await parseJsonResponse(response, "发送回帖失败");

--- a/src/TlaPlugin/wwwroot/teamsClient/messageExtensionDialog.js
+++ b/src/TlaPlugin/wwwroot/teamsClient/messageExtensionDialog.js
@@ -283,7 +283,8 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
     try {
       updateError(ui, "");
       const payload = buildTranslatePayload(state, context);
-      const response = await translateText(payload, fetcher);
+      const authorization = await resolveAuthorization();
+      const response = await translateText(payload, fetcher, { authorization });
       if (response?.type === "glossaryConflict") {
         sdk.dialog?.submit?.({
           type: "glossaryConflict",
@@ -440,7 +441,8 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
     if (edited?.trim()) {
       try {
         const rewritePayload = buildRewritePayload(state, context, edited);
-        const rewriteResult = await rewriteTranslation(rewritePayload, fetcher);
+        const authorization = await resolveAuthorization();
+        const rewriteResult = await rewriteTranslation(rewritePayload, fetcher, { authorization });
         finalText = rewriteResult.text ?? edited;
         state.translation = finalText;
         if (rewriteResult.metadata?.tone) {
@@ -459,8 +461,9 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
     }
     if (finalText?.trim()) {
       try {
+        const authorization = await resolveAuthorization();
         const replyPayload = buildReplyPayload(state, context, finalText);
-        const replyResult = await sendReply(replyPayload, fetcher);
+        const replyResult = await sendReply(replyPayload, fetcher, { authorization });
         sdk.dialog?.submit?.({
           translation: finalText,
           targetLanguage: state.targetLanguage,

--- a/src/teamsClient/api.js
+++ b/src/teamsClient/api.js
@@ -49,28 +49,43 @@ export async function detectLanguage(payload, fetchImpl = fetch) {
   return await parseJsonResponse(response, "语言检测失败");
 }
 
-export async function translateText(payload, fetchImpl = fetch) {
+export async function translateText(payload, fetchImpl = fetch, { authorization } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  const headerValue = buildAuthorizationHeader(authorization);
+  if (headerValue) {
+    headers.Authorization = headerValue;
+  }
   const response = await fetchImpl("/api/translate", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(payload)
   });
   return await parseJsonResponse(response, "翻译接口失败");
 }
 
-export async function rewriteTranslation(payload, fetchImpl = fetch) {
+export async function rewriteTranslation(payload, fetchImpl = fetch, { authorization } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  const headerValue = buildAuthorizationHeader(authorization);
+  if (headerValue) {
+    headers.Authorization = headerValue;
+  }
   const response = await fetchImpl("/api/rewrite", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(payload)
   });
   return await parseJsonResponse(response, "译文润色失败");
 }
 
-export async function sendReply(payload, fetchImpl = fetch) {
+export async function sendReply(payload, fetchImpl = fetch, { authorization } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  const headerValue = buildAuthorizationHeader(authorization);
+  if (headerValue) {
+    headers.Authorization = headerValue;
+  }
   const response = await fetchImpl("/api/reply", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(payload)
   });
   return await parseJsonResponse(response, "发送回帖失败");

--- a/src/teamsClient/messageExtensionDialog.js
+++ b/src/teamsClient/messageExtensionDialog.js
@@ -375,7 +375,8 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
     try {
       updateError(ui, "");
       const payload = buildTranslatePayload(state, context);
-      const response = await translateText(payload, fetcher);
+      const authorization = await resolveAuthorization();
+      const response = await translateText(payload, fetcher, { authorization });
       if (response?.type === "glossaryConflict") {
         sdk.dialog?.submit?.({
           type: "glossaryConflict",
@@ -532,7 +533,8 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
     if (edited?.trim()) {
       try {
         const rewritePayload = buildRewritePayload(state, context, edited);
-        const rewriteResult = await rewriteTranslation(rewritePayload, fetcher);
+        const authorization = await resolveAuthorization();
+        const rewriteResult = await rewriteTranslation(rewritePayload, fetcher, { authorization });
         finalText = rewriteResult.text ?? edited;
         state.translation = finalText;
         if (rewriteResult.metadata?.tone) {
@@ -551,8 +553,9 @@ export async function initMessageExtensionDialog({ ui = resolveDialogUi(), teams
     }
     if (finalText?.trim()) {
       try {
+        const authorization = await resolveAuthorization();
         const replyPayload = buildReplyPayload(state, context, finalText);
-        const replyResult = await sendReply(replyPayload, fetcher);
+        const replyResult = await sendReply(replyPayload, fetcher, { authorization });
         sdk.dialog?.submit?.({
           translation: finalText,
           targetLanguage: state.targetLanguage,

--- a/tests/TlaPlugin.Tests/ApiEndpointsTests.cs
+++ b/tests/TlaPlugin.Tests/ApiEndpointsTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Threading.Tasks;
@@ -183,11 +184,14 @@ public class ApiEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
             });
         }).CreateClient();
 
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "assertion");
+
         var response = await client.PostAsJsonAsync("/api/rewrite", new RewriteRequest
         {
             Text = new string('a', 10),
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             Tone = ToneTemplateService.Business
         });
 
@@ -198,12 +202,15 @@ public class ApiEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
     public async Task RewriteEndpointReturnsRewrittenTextForEditedInput()
     {
         var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "assertion");
+
         var response = await client.PostAsJsonAsync("/api/rewrite", new RewriteRequest
         {
             Text = "Original",
             EditedText = "用户自定义",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             Tone = ToneTemplateService.Business
         });
 
@@ -217,6 +224,8 @@ public class ApiEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
     public async Task ReplyEndpointReturnsSuccessPayload()
     {
         var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "assertion");
+
         var response = await client.PostAsJsonAsync("/api/reply", new ReplyRequest
         {
             ThreadId = "thread",
@@ -224,6 +233,7 @@ public class ApiEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
             EditedText = "手动编辑",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "ja", Tone = ToneTemplateService.Business }
         });

--- a/tests/TlaPlugin.Tests/ContextRetrievalIntegrationTests.cs
+++ b/tests/TlaPlugin.Tests/ContextRetrievalIntegrationTests.cs
@@ -233,7 +233,8 @@ public class ContextRetrievalIntegrationTests
             TenantId = "contoso",
             UserId = "user",
             ChannelId = "general",
-            MaxMessages = 3
+            MaxMessages = 3,
+            UserAssertion = "assertion"
         }, CancellationToken.None);
 
         Assert.True(result.HasContext);
@@ -257,7 +258,8 @@ public class ContextRetrievalIntegrationTests
             TenantId = "contoso",
             UserId = "user",
             ChannelId = "general",
-            MaxMessages = 3
+            MaxMessages = 3,
+            UserAssertion = "assertion"
         }, CancellationToken.None);
 
         Assert.False(result.HasContext);
@@ -280,7 +282,8 @@ public class ContextRetrievalIntegrationTests
             TenantId = "contoso",
             UserId = "user",
             ChannelId = "general",
-            MaxMessages = 3
+            MaxMessages = 3,
+            UserAssertion = "assertion"
         }, CancellationToken.None);
 
         Assert.False(result.HasContext);
@@ -448,7 +451,7 @@ public class ContextRetrievalIntegrationTests
             int maxMessages,
             CancellationToken cancellationToken)
         {
-            return GetRecentMessagesAsync(tenantId, channelId, threadId, maxMessages, null, null, cancellationToken);
+            return GetRecentMessagesAsync(tenantId, channelId, threadId, maxMessages, null, null, null, cancellationToken);
         }
 
         public Task<IReadOnlyList<ContextMessage>> GetRecentMessagesAsync(
@@ -458,6 +461,7 @@ public class ContextRetrievalIntegrationTests
             int maxMessages,
             AccessToken? accessToken,
             string? userId,
+            string? userAssertion,
             CancellationToken cancellationToken)
         {
             LastAccessToken = accessToken;
@@ -501,7 +505,7 @@ public class ContextRetrievalIntegrationTests
 
         public int CallCount { get; private set; }
 
-        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
+        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, string? userAssertion, CancellationToken cancellationToken)
         {
             CallCount++;
             var token = _tokens[Math.Min(_index, _tokens.Count - 1)];

--- a/tests/TlaPlugin.Tests/ReplyServiceTests.cs
+++ b/tests/TlaPlugin.Tests/ReplyServiceTests.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -46,6 +47,7 @@ public class ReplyServiceTests
             ReplyText = "hello",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "random"
         }, CancellationToken.None));
     }
@@ -72,6 +74,7 @@ public class ReplyServiceTests
             EditedText = "手动调整",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { Tone = ToneTemplateService.Business, TargetLang = "ja" }
         }, CancellationToken.None);
@@ -107,6 +110,7 @@ public class ReplyServiceTests
             ReplyText = "Bonjour",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "fr", Tone = ToneTemplateService.Casual },
             AdditionalTargetLanguages = new List<string> { "en", "en", "de" }
@@ -175,6 +179,7 @@ public class ReplyServiceTests
             ReplyText = "ignored",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "ja", Tone = ToneTemplateService.Business }
         }, "最终文本", ToneTemplateService.Business, CancellationToken.None);
@@ -202,6 +207,7 @@ public class ReplyServiceTests
             ReplyText = "ignored",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "ja" }
         }, string.Empty, null, CancellationToken.None));
@@ -247,6 +253,7 @@ public class ReplyServiceTests
             ReplyText = "ignored",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "ja", Tone = ToneTemplateService.Casual },
             AdditionalTargetLanguages = new List<string> { "fr" }
@@ -299,6 +306,7 @@ public class ReplyServiceTests
             ReplyText = "text",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "ja" }
         }, "最终", null, CancellationToken.None));
@@ -331,6 +339,7 @@ public class ReplyServiceTests
             ReplyText = "text",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "ja" }
         }, "最终", null, CancellationToken.None));
@@ -371,7 +380,7 @@ public class ReplyServiceTests
             _token = token;
         }
 
-        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
+        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, string? userAssertion, CancellationToken cancellationToken)
         {
             return Task.FromResult(new AccessToken(_token, DateTimeOffset.UtcNow.AddMinutes(10), "audience"));
         }
@@ -411,12 +420,15 @@ public class ReplyServiceMinimalApiTests : IClassFixture<WebApplicationFactory<P
             Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
         }, out var state);
 
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "assertion");
+
         var response = await client.PostAsJsonAsync("/api/reply", new ReplyRequest
         {
             ThreadId = "thread",
             ReplyText = "你好",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "zh-CN", Tone = ToneTemplateService.Casual }
         });
@@ -447,12 +459,15 @@ public class ReplyServiceMinimalApiTests : IClassFixture<WebApplicationFactory<P
             Content = new StringContent("{\"error\":{\"message\":\"denied\"}}", Encoding.UTF8, "application/json")
         }, out var state);
 
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "assertion");
+
         var response = await client.PostAsJsonAsync("/api/reply", new ReplyRequest
         {
             ThreadId = "thread",
             ReplyText = "内容",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "zh-CN" }
         });
@@ -472,12 +487,15 @@ public class ReplyServiceMinimalApiTests : IClassFixture<WebApplicationFactory<P
             Content = new StringContent("{\"error\":{\"message\":\"budget exceeded\"}}", Encoding.UTF8, "application/json")
         }, out _);
 
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "assertion");
+
         var response = await client.PostAsJsonAsync("/api/reply", new ReplyRequest
         {
             ThreadId = "thread",
             ReplyText = "内容",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { TargetLang = "zh-CN" }
         });
@@ -525,7 +543,7 @@ public class ReplyServiceMinimalApiTests : IClassFixture<WebApplicationFactory<P
             _token = token;
         }
 
-        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
+        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, string? userAssertion, CancellationToken cancellationToken)
         {
             return Task.FromResult(new AccessToken(_token, DateTimeOffset.UtcNow.AddMinutes(5), "audience"));
         }

--- a/tests/TlaPlugin.Tests/TokenBrokerTests.cs
+++ b/tests/TlaPlugin.Tests/TokenBrokerTests.cs
@@ -21,8 +21,8 @@ public class TokenBrokerTests
         var resolver = new KeyVaultSecretResolver(options);
         var broker = new TokenBroker(resolver, options);
 
-        var first = await broker.ExchangeOnBehalfOfAsync("contoso", "user", CancellationToken.None);
-        var second = await broker.ExchangeOnBehalfOfAsync("contoso", "user", CancellationToken.None);
+        var first = await broker.ExchangeOnBehalfOfAsync("contoso", "user", "assertion", CancellationToken.None);
+        var second = await broker.ExchangeOnBehalfOfAsync("contoso", "user", "assertion", CancellationToken.None);
 
         Assert.Equal(first.Value, second.Value);
     }
@@ -34,8 +34,8 @@ public class TokenBrokerTests
         var resolver = new KeyVaultSecretResolver(options);
         var broker = new TokenBroker(resolver, options);
 
-        var userToken = await broker.ExchangeOnBehalfOfAsync("contoso", "user1", CancellationToken.None);
-        var adminToken = await broker.ExchangeOnBehalfOfAsync("contoso", "user2", CancellationToken.None);
+        var userToken = await broker.ExchangeOnBehalfOfAsync("contoso", "user1", "assertion", CancellationToken.None);
+        var adminToken = await broker.ExchangeOnBehalfOfAsync("contoso", "user2", "assertion", CancellationToken.None);
 
         // 验证不同用户得到不同的token
         Assert.NotEqual(userToken.Value, adminToken.Value);
@@ -68,8 +68,8 @@ public class TokenBrokerTests
         var resolver = new KeyVaultSecretResolver(options);
         var broker = new TokenBroker(resolver, options);
 
-        var defaultToken = await broker.ExchangeOnBehalfOfAsync("contoso.onmicrosoft.com", "user", CancellationToken.None);
-        var enterpriseToken = await broker.ExchangeOnBehalfOfAsync("enterprise.onmicrosoft.com", "user", CancellationToken.None);
+        var defaultToken = await broker.ExchangeOnBehalfOfAsync("contoso.onmicrosoft.com", "user", "assertion", CancellationToken.None);
+        var enterpriseToken = await broker.ExchangeOnBehalfOfAsync("enterprise.onmicrosoft.com", "user", "assertion", CancellationToken.None);
 
         Assert.NotEqual(defaultToken.Value, enterpriseToken.Value);
         Assert.Equal("api://enterprise-graph", enterpriseToken.Audience);
@@ -100,7 +100,7 @@ public class TokenBrokerTests
         fakeClient.Results.Enqueue(new OnBehalfOfTokenResult("obo-token", expiry));
         var broker = new TokenBroker(resolver, options, fakeClient);
 
-        var token = await broker.ExchangeOnBehalfOfAsync("contoso", "user-assertion", CancellationToken.None);
+        var token = await broker.ExchangeOnBehalfOfAsync("contoso", "user", "user-assertion", CancellationToken.None);
 
         Assert.Equal("obo-token", token.Value);
         Assert.Equal(expiry, token.ExpiresOn);
@@ -147,7 +147,7 @@ public class TokenBrokerTests
         fakeClient.Results.Enqueue(new OnBehalfOfTokenResult("enterprise-token", DateTimeOffset.UtcNow.AddMinutes(10)));
         var broker = new TokenBroker(resolver, options, fakeClient);
 
-        var token = await broker.ExchangeOnBehalfOfAsync("enterprise.onmicrosoft.com", "enterprise-assertion", CancellationToken.None);
+        var token = await broker.ExchangeOnBehalfOfAsync("enterprise.onmicrosoft.com", "user", "enterprise-assertion", CancellationToken.None);
 
         Assert.Equal("api://enterprise-graph", token.Audience);
         var call = Assert.Single(fakeClient.Calls);
@@ -182,7 +182,32 @@ public class TokenBrokerTests
         var broker = new TokenBroker(resolver, options, fakeClient);
 
         await Assert.ThrowsAsync<AuthenticationException>(() =>
-            broker.ExchangeOnBehalfOfAsync("contoso", "user-assertion", CancellationToken.None));
+            broker.ExchangeOnBehalfOfAsync("contoso", "user", "user-assertion", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ThrowsWhenUserAssertionMissingInMsalMode()
+    {
+        var options = Options.Create(new PluginOptions
+        {
+            Security = new SecurityOptions
+            {
+                ClientId = "obo-client",
+                ClientSecretName = "obo-secret",
+                UseHmacFallback = false,
+                GraphScopes = new List<string> { "https://graph.microsoft.com/.default" },
+                SeedSecrets = new Dictionary<string, string>
+                {
+                    ["obo-secret"] = "obo-secret-value"
+                }
+            }
+        });
+
+        var resolver = new KeyVaultSecretResolver(options);
+        var broker = new TokenBroker(resolver, options, new StubOnBehalfOfTokenClient());
+
+        await Assert.ThrowsAsync<AuthenticationException>(() =>
+            broker.ExchangeOnBehalfOfAsync("contoso", "user", null, CancellationToken.None));
     }
 
     private sealed class StubOnBehalfOfTokenClient : IOnBehalfOfTokenClient

--- a/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationPipelineTests.cs
@@ -70,6 +70,7 @@ public class TranslationPipelineTests
             Text = "hi",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en"
         };
@@ -138,6 +139,7 @@ public class TranslationPipelineTests
             Text = "Here is the purchase summary",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             TargetLanguage = "ja",
             SourceLanguage = "en",
@@ -200,6 +202,7 @@ public class TranslationPipelineTests
             Text = "Here is the purchase summary",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             TargetLanguage = "ja",
             SourceLanguage = "en",
@@ -270,6 +273,7 @@ public class TranslationPipelineTests
             Text = "Share the latest update",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             TargetLanguage = "ja",
             SourceLanguage = "en",
@@ -316,6 +320,7 @@ public class TranslationPipelineTests
             Text = "12345",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en"
         }, CancellationToken.None);
@@ -361,6 +366,7 @@ public class TranslationPipelineTests
             Text = "12345",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja"
         }, detection, CancellationToken.None);
 
@@ -394,6 +400,7 @@ public class TranslationPipelineTests
             Text = "first",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en"
         }, CancellationToken.None);
@@ -405,6 +412,7 @@ public class TranslationPipelineTests
             Text = "second",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en"
         }, CancellationToken.None));
@@ -437,6 +445,7 @@ public class TranslationPipelineTests
             Text = "locale test",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en",
             UiLocale = "ja-JP"
@@ -447,6 +456,7 @@ public class TranslationPipelineTests
             Text = "locale test",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en",
             UiLocale = "zh-CN"
@@ -487,6 +497,7 @@ public class TranslationPipelineTests
             Text = "Team update",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             ChannelId = "general"
         }, CancellationToken.None);
@@ -499,6 +510,7 @@ public class TranslationPipelineTests
             EditedText = translation.RawTranslatedText + "（追加の説明）",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             Tone = ToneTemplateService.Business
         }, CancellationToken.None);
@@ -512,6 +524,7 @@ public class TranslationPipelineTests
             EditedText = rewrite.RewrittenText,
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             ChannelId = "general",
             LanguagePolicy = new ReplyLanguagePolicy { Tone = ToneTemplateService.Business, TargetLang = "ja" }
         }, CancellationToken.None);
@@ -545,6 +558,7 @@ public class TranslationPipelineTests
             EditedText = "Custom content",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             Tone = ToneTemplateService.Business
         }, CancellationToken.None);
 
@@ -582,6 +596,7 @@ public class TranslationPipelineTests
             Text = "GPU",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en",
             ChannelId = "finance",
@@ -626,6 +641,7 @@ public class TranslationPipelineTests
             Text = "GPU", 
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en",
             ChannelId = "finance",
@@ -671,6 +687,7 @@ public class TranslationPipelineTests
             Text = "Hello there",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja"
         }, CancellationToken.None);
 
@@ -705,6 +722,7 @@ public class TranslationPipelineTests
             Text = "Besok pagi kami akan berangkat ke pasar untuk membeli sayur segar dan buah segar.",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja"
         }, CancellationToken.None);
 
@@ -736,6 +754,7 @@ public class TranslationPipelineTests
             Text = "La nation et la population attendent une solution rapide.",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja"
         }, CancellationToken.None);
 
@@ -795,6 +814,7 @@ public class TranslationPipelineTests
             Text = "東京都庁",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "en"
         }, CancellationToken.None);
 
@@ -827,6 +847,7 @@ public class TranslationPipelineTests
             Text = "東京都大阪府。",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "en"
         }, CancellationToken.None);
 
@@ -859,6 +880,7 @@ public class TranslationPipelineTests
             Text = "Hello again",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja"
         };
 
@@ -906,6 +928,7 @@ public class TranslationPipelineTests
             Text = "漢字語彙句読点、標準。",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "en"
         }, CancellationToken.None);
 
@@ -976,6 +999,7 @@ public class TranslationPipelineTests
             Text = "Provider requires manual confirmation despite supplied source language.",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en"
         }, CancellationToken.None);
@@ -1034,7 +1058,7 @@ public class TranslationPipelineTests
 
     private sealed class StaticTokenBroker : ITokenBroker
     {
-        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
+        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, string? userAssertion, CancellationToken cancellationToken)
             => Task.FromResult(new AccessToken("token", DateTimeOffset.UtcNow.AddMinutes(5), "api://audience"));
     }
 

--- a/tests/TlaPlugin.Tests/TranslationRouterTests.cs
+++ b/tests/TlaPlugin.Tests/TranslationRouterTests.cs
@@ -42,6 +42,8 @@ public class TranslationRouterTests
             Text = "hello world",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en",
             AdditionalTargetLanguages = new List<string> { "fr" }
@@ -91,6 +93,7 @@ public class TranslationRouterTests
             ContextSummary = "recent decision on merger",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en",
             UseRag = true
@@ -126,6 +129,7 @@ public class TranslationRouterTests
             Text = "blocked content",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             Tone = ToneTemplateService.Business
         }, CancellationToken.None));
     }
@@ -154,6 +158,7 @@ public class TranslationRouterTests
             Text = new string('a', 200),
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en"
         };
@@ -192,6 +197,7 @@ public class TranslationRouterTests
             Text = "hello",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en"
         }, CancellationToken.None));
@@ -234,6 +240,7 @@ public class TranslationRouterTests
             Text = "hello world",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en"
         }, CancellationToken.None);
@@ -308,6 +315,7 @@ public class TranslationRouterTests
             Text = "hello world",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en",
             AdditionalTargetLanguages = new List<string> { "fr", "de" }
@@ -361,6 +369,7 @@ public class TranslationRouterTests
             Text = "hello",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en",
             AdditionalTargetLanguages = new List<string> { "fr" }
@@ -371,6 +380,7 @@ public class TranslationRouterTests
             Text = "hello",
             TenantId = "fabrikam",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en"
         }, CancellationToken.None);
@@ -408,6 +418,7 @@ public class TranslationRouterTests
             Text = "hello",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en"
         }, CancellationToken.None));
@@ -442,6 +453,7 @@ public class TranslationRouterTests
             Text = "hello",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja",
             SourceLanguage = "en",
             UiLocale = "zh-CN"
@@ -489,6 +501,7 @@ public class TranslationRouterTests
             Text = "こんにちは",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             Tone = ToneTemplateService.Business
         }, CancellationToken.None);
 
@@ -567,6 +580,7 @@ public class TranslationRouterTests
             Text = "12345",
             TenantId = "contoso",
             UserId = "user",
+            UserAssertion = "assertion",
             TargetLanguage = "ja"
         }, CancellationToken.None));
 
@@ -580,7 +594,7 @@ public class TranslationRouterTests
         public bool ShouldThrow { get; set; }
         public int Calls { get; private set; }
 
-        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, CancellationToken cancellationToken)
+        public Task<AccessToken> ExchangeOnBehalfOfAsync(string tenantId, string userId, string? userAssertion, CancellationToken cancellationToken)
         {
             Calls++;
             if (ShouldThrow)

--- a/tests/composePlugin.test.js
+++ b/tests/composePlugin.test.js
@@ -26,7 +26,7 @@ test("compose plugin translates and posts reply payload", async () => {
   const fetchCalls = [];
   const fakeFetch = async (url, options = {}) => {
     if (options.body) {
-      fetchCalls.push({ url, options: JSON.parse(options.body) });
+      fetchCalls.push({ url, headers: options.headers ?? {}, body: JSON.parse(options.body) });
     }
     return {
       ok: true,
@@ -88,16 +88,18 @@ test("compose plugin translates and posts reply payload", async () => {
   await toneToggle.trigger("change");
   await suggestButton.trigger("click");
   assert.equal(fetchCalls[0].url, "/api/translate");
-  assert.equal(fetchCalls[0].options.text, "hello");
+  assert.equal(fetchCalls[0].body.text, "hello");
+  assert.equal(fetchCalls[0].headers.Authorization, "Bearer u");
   assert.equal(state.detectedLanguage, "en");
   assert.equal(preview.value || preview.textContent, "hola");
   await applyButton.trigger("click");
   assert.equal(fetchCalls[1].url, "/api/reply");
-  assert.equal(fetchCalls[1].options.translation, "hola");
-  assert.equal(fetchCalls[1].options.sourceLanguage, "en");
-  assert.equal(fetchCalls[1].options.sourceLanguage, state.detectedLanguage);
-  assert.equal(fetchCalls[1].options.metadata.modelId, "model-a");
-  assert.equal(fetchCalls[1].options.metadata.tone, "formal");
+  assert.equal(fetchCalls[1].body.translation, "hola");
+  assert.equal(fetchCalls[1].body.sourceLanguage, "en");
+  assert.equal(fetchCalls[1].body.sourceLanguage, state.detectedLanguage);
+  assert.equal(fetchCalls[1].body.metadata.modelId, "model-a");
+  assert.equal(fetchCalls[1].body.metadata.tone, "formal");
+  assert.equal(fetchCalls[1].headers.Authorization, "Bearer u");
   assert.equal(state.tone, "formal");
   assert.deepEqual(teams.conversations.lastMessage.attachments[0].content, {
     type: "AdaptiveCard",
@@ -111,7 +113,7 @@ test("compose plugin sends additional target languages", async () => {
   const fetchCalls = [];
   const fakeFetch = async (url, options = {}) => {
     if (options.body) {
-      fetchCalls.push({ url, options: JSON.parse(options.body) });
+      fetchCalls.push({ url, headers: options.headers ?? {}, body: JSON.parse(options.body) });
     }
     return {
       ok: true,
@@ -188,8 +190,8 @@ test("compose plugin sends additional target languages", async () => {
   const replyCall = fetchCalls.find((call) => call.url === "/api/reply");
   assert.ok(translateCall, "expected translate call");
   assert.ok(replyCall, "expected reply call");
-  assert.deepEqual(translateCall.options.additionalTargetLanguages, ["fr", "ja"]);
-  assert.deepEqual(replyCall.options.additionalTargetLanguages, ["fr", "ja"]);
+  assert.deepEqual(translateCall.body.additionalTargetLanguages, ["fr", "ja"]);
+  assert.deepEqual(replyCall.body.additionalTargetLanguages, ["fr", "ja"]);
   assert.equal(
     teams.conversations.lastMessage.attachments[0].content.body[1].text,
     "bonjour"
@@ -205,7 +207,7 @@ test("compose plugin falls back to first non-auto target", async () => {
   const fetchCalls = [];
   const fakeFetch = async (url, options = {}) => {
     if (options.body) {
-      fetchCalls.push({ url, options: JSON.parse(options.body) });
+      fetchCalls.push({ url, headers: options.headers ?? {}, body: JSON.parse(options.body) });
     }
     return {
       ok: true,
@@ -256,14 +258,14 @@ test("compose plugin falls back to first non-auto target", async () => {
   assert.equal(state.targetLanguage, "fr");
   assert.equal(targetSelect.value, "fr");
   assert.equal(fetchCalls.length, 1);
-  assert.equal(fetchCalls[0].options.targetLanguage, "fr");
+  assert.equal(fetchCalls[0].body.targetLanguage, "fr");
 });
 
 test("compose plugin corrects target when locale missing from metadata", async () => {
   const fetchCalls = [];
   const fakeFetch = async (url, options = {}) => {
     if (options.body) {
-      fetchCalls.push({ url, options: JSON.parse(options.body) });
+      fetchCalls.push({ url, headers: options.headers ?? {}, body: JSON.parse(options.body) });
     }
     return {
       ok: true,
@@ -314,14 +316,14 @@ test("compose plugin corrects target when locale missing from metadata", async (
   assert.equal(state.targetLanguage, "ja");
   assert.equal(targetSelect.value, "ja");
   assert.equal(fetchCalls.length, 1);
-  assert.equal(fetchCalls[0].options.targetLanguage, "ja");
+  assert.equal(fetchCalls[0].body.targetLanguage, "ja");
 });
 
 test("compose plugin reports reply failure", async () => {
   const fetchCalls = [];
   const fakeFetch = async (url, options = {}) => {
     if (options.body) {
-      fetchCalls.push({ url, options: JSON.parse(options.body) });
+      fetchCalls.push({ url, headers: options.headers ?? {}, body: JSON.parse(options.body) });
     }
     if (url === "/api/reply") {
       return {
@@ -397,7 +399,7 @@ test("compose plugin uses concrete target when user locale is unavailable", asyn
   const fetchCalls = [];
   const fakeFetch = async (url, options = {}) => {
     if (options.body) {
-      fetchCalls.push({ url, options: JSON.parse(options.body) });
+      fetchCalls.push({ url, headers: options.headers ?? {}, body: JSON.parse(options.body) });
     }
     return {
       ok: true,
@@ -447,5 +449,5 @@ test("compose plugin uses concrete target when user locale is unavailable", asyn
   assert.equal(state.targetLanguage, "es");
   assert.equal(targetSelect.value, "es");
   assert.ok(translateCall, "expected translate call");
-  assert.equal(translateCall.options.targetLanguage, "es");
+  assert.equal(translateCall.body.targetLanguage, "es");
 });

--- a/tests/messageExtensionDialog.test.js
+++ b/tests/messageExtensionDialog.test.js
@@ -42,7 +42,7 @@ test("dialog runs detect → translate → rewrite and submits rewritten text", 
   const fetchCalls = [];
   const fakeFetch = async (url, options = {}) => {
     if (options.body) {
-      fetchCalls.push({ url, body: JSON.parse(options.body) });
+      fetchCalls.push({ url, headers: options.headers ?? {}, body: JSON.parse(options.body) });
     }
     return {
       ok: true,
@@ -119,11 +119,14 @@ test("dialog runs detect → translate → rewrite and submits rewritten text", 
   assert.equal(fetchCalls[1].url, "/api/translate");
   assert.equal(fetchCalls[1].body.text, "hello");
   assert.deepEqual(fetchCalls[1].body.additionalTargetLanguages, ["fr"]);
+  assert.equal(fetchCalls[1].headers.Authorization, "Bearer user");
   await ui.submitButton.trigger("click");
   assert.equal(fetchCalls[2].url, "/api/rewrite");
+  assert.equal(fetchCalls[2].headers.Authorization, "Bearer user");
   assert.equal(fetchCalls[3].url, "/api/reply");
   assert.equal(fetchCalls[3].body.translation, "【正式】hola");
   assert.deepEqual(fetchCalls[3].body.additionalTargetLanguages, ["fr"]);
+  assert.equal(fetchCalls[3].headers.Authorization, "Bearer user");
   assert.equal(teams.dialog.lastSubmit.translation, "【正式】hola");
   assert.equal(teams.dialog.lastSubmit.tone, "formal");
   assert.deepEqual(teams.dialog.lastSubmit.additionalTargetLanguages, ["fr"]);
@@ -149,7 +152,7 @@ test("dialog forwards glossary conflict card to Teams host", async () => {
   };
   const fakeFetch = async (url, options = {}) => {
     if (options.body) {
-      fetchCalls.push({ url, body: JSON.parse(options.body) });
+      fetchCalls.push({ url, headers: options.headers ?? {}, body: JSON.parse(options.body) });
     }
     return {
       ok: true,
@@ -232,7 +235,7 @@ test("dialog defaults to first non-auto target and preserves detection label", a
   const fetchCalls = [];
   const fakeFetch = async (url, options = {}) => {
     if (options.body) {
-      fetchCalls.push({ url, body: JSON.parse(options.body) });
+      fetchCalls.push({ url, headers: options.headers ?? {}, body: JSON.parse(options.body) });
     }
     return {
       ok: true,
@@ -316,7 +319,7 @@ test("initMessageExtensionDialog corrects target when locale missing from metada
   const fetchCalls = [];
   const fakeFetch = async (url, options = {}) => {
     if (options.body) {
-      fetchCalls.push({ url, body: JSON.parse(options.body) });
+      fetchCalls.push({ url, headers: options.headers ?? {}, body: JSON.parse(options.body) });
     }
     return {
       ok: true,
@@ -398,7 +401,7 @@ test("initMessageExtensionDialog corrects target when locale missing from metada
 test("dialog surfaces offline draft completion state", async () => {
   const fetchCalls = [];
   const fakeFetch = async (url, options = {}) => {
-    fetchCalls.push({ url, method: options.method ?? "GET" });
+    fetchCalls.push({ url, method: options.method ?? "GET", headers: options.headers ?? {} });
     return {
       ok: true,
       async json() {
@@ -480,7 +483,7 @@ test("dialog uses concrete target when user locale is unavailable", async () => 
   const fetchCalls = [];
   const fakeFetch = async (url, options = {}) => {
     if (options.body) {
-      fetchCalls.push({ url, body: JSON.parse(options.body) });
+      fetchCalls.push({ url, headers: options.headers ?? {}, body: JSON.parse(options.body) });
     }
     return {
       ok: true,


### PR DESCRIPTION
## Summary
- propagate authorization tokens through the Teams clients when calling translate, rewrite and reply endpoints and reuse cached auth in both the dialog and compose experiences
- require and forward bearer tokens across the minimal API endpoints, models and services so on-behalf-of exchanges prefer real user assertions and fail unauthorized when absent
- update unit and integration tests to cover the new authorization flow and real OBO path, asserting Authorization headers and token broker behavior

## Testing
- npm test *(fails: glossaryUpload.test.js expects an export that is not available in the current Node test harness)*
- dotnet test *(fails: dotnet CLI is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de575e0a1c832f96c4714c2bdf6e5e