### PR TITLE
Add reservation scope for translation budget

### DIFF
--- a/src/TlaPlugin/Services/BudgetGuard.cs
+++ b/src/TlaPlugin/Services/BudgetGuard.cs
@@ -17,15 +17,68 @@ public class BudgetGuard
         _options = options ?? new PluginOptions();
     }
 
-    public bool TryReserve(string tenantId, decimal cost)
+    public bool TryReserve(string tenantId, decimal cost, out BudgetReservation reservation)
     {
         var key = $"{tenantId}:{DateTime.UtcNow:yyyyMMdd}";
         var total = _dailyCosts.AddOrUpdate(key, cost, (_, existing) => existing + cost);
         if (total > _options.DailyBudgetUsd)
         {
             _dailyCosts.AddOrUpdate(key, 0, (_, existing) => existing - cost);
+            reservation = default!;
             return false;
         }
+
+        reservation = new BudgetReservation(this, key, cost);
         return true;
+    }
+
+    internal void Release(string key, decimal cost)
+    {
+        _dailyCosts.AddOrUpdate(key, 0, (_, existing) =>
+        {
+            var updated = existing - cost;
+            return updated < 0 ? 0 : updated;
+        });
+    }
+
+    public sealed class BudgetReservation : IDisposable
+    {
+        private readonly BudgetGuard _guard;
+        private readonly string _key;
+        private readonly decimal _cost;
+        private bool _disposed;
+        private bool _committed;
+
+        internal BudgetReservation(BudgetGuard guard, string key, decimal cost)
+        {
+            _guard = guard;
+            _key = key;
+            _cost = cost;
+        }
+
+        public void Commit()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(BudgetReservation));
+            }
+
+            _committed = true;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (!_committed)
+            {
+                _guard.Release(_key, _cost);
+            }
+
+            _disposed = true;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add disposable reservation support to BudgetGuard so failed attempts release daily allocations
- update TranslationRouter operations to only commit budget after successful model responses and reuse the reserved scope during retries
- extend TranslationRouter tests to cover multi-provider success/failure scenarios and ensure metrics reflect actual usage

## Testing
- dotnet test tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de792aaa34832f8c87f1d8a45a0a47