### PR TITLE
Update reply payload to include replyText/text fields

### DIFF
--- a/src/TlaPlugin/wwwroot/teamsClient/state.js
+++ b/src/TlaPlugin/wwwroot/teamsClient/state.js
@@ -179,7 +179,8 @@ export function buildReplyPayload(state, context, text) {
     state.availableTargetLanguages
   );
   const payload = {
-    translation: text,
+    replyText: text,
+    text,
     sourceLanguage: state.sourceLanguage === "auto" ? state.detectedLanguage : state.sourceLanguage,
     targetLanguage: state.targetLanguage,
     additionalTargetLanguages,

--- a/src/teams/messageExtension.js
+++ b/src/teams/messageExtension.js
@@ -22,11 +22,13 @@ export class MessageExtensionHandler {
   }
 
   async reply(payload) {
+    const translation =
+      payload?.replyText ?? payload?.text ?? payload?.translation;
     return this.pipeline.replyWithTranslation({
-      translation: payload.translation,
-      sourceLanguage: payload.sourceLanguage,
-      targetLanguage: payload.targetLanguage,
-      metadata: payload.metadata
+      translation,
+      sourceLanguage: payload?.sourceLanguage,
+      targetLanguage: payload?.targetLanguage,
+      metadata: payload?.metadata
     });
   }
 

--- a/src/teamsClient/state.js
+++ b/src/teamsClient/state.js
@@ -179,7 +179,8 @@ export function buildReplyPayload(state, context, text) {
     state.availableTargetLanguages
   );
   const payload = {
-    translation: text,
+    replyText: text,
+    text,
     sourceLanguage: state.sourceLanguage === "auto" ? state.detectedLanguage : state.sourceLanguage,
     targetLanguage: state.targetLanguage,
     additionalTargetLanguages,

--- a/tests/composePlugin.test.js
+++ b/tests/composePlugin.test.js
@@ -94,7 +94,8 @@ test("compose plugin translates and posts reply payload", async () => {
   assert.equal(preview.value || preview.textContent, "hola");
   await applyButton.trigger("click");
   assert.equal(fetchCalls[1].url, "/api/reply");
-  assert.equal(fetchCalls[1].body.translation, "hola");
+  assert.equal(fetchCalls[1].body.replyText, "hola");
+  assert.equal(fetchCalls[1].body.text, "hola");
   assert.equal(fetchCalls[1].body.sourceLanguage, "en");
   assert.equal(fetchCalls[1].body.sourceLanguage, state.detectedLanguage);
   assert.equal(fetchCalls[1].body.metadata.modelId, "model-a");

--- a/tests/messageExtensionDialog.jest.js
+++ b/tests/messageExtensionDialog.jest.js
@@ -169,7 +169,8 @@ describe("message extension dialog (jest)", () => {
     const rewriteCall = fetchCalls.find((call) => call.url === "/api/rewrite");
     const replyCall = fetchCalls.find((call) => call.url === "/api/reply");
     expect(rewriteCall.body.text).toBe("hola");
-    expect(replyCall.body.translation).toBe("【润色】hola");
+    expect(replyCall.body.replyText).toBe("【润色】hola");
+    expect(replyCall.body.text).toBe("【润色】hola");
     expect(replyCall.body.additionalTargetLanguages).toEqual([]);
     expect(teams.dialog.submit).toHaveBeenCalled();
     expect(teams.dialog.lastSubmit.translation).toBe("【润色】hola");

--- a/tests/messageExtensionDialog.test.js
+++ b/tests/messageExtensionDialog.test.js
@@ -124,7 +124,8 @@ test("dialog runs detect → translate → rewrite and submits rewritten text", 
   assert.equal(fetchCalls[2].url, "/api/rewrite");
   assert.equal(fetchCalls[2].headers.Authorization, "Bearer user");
   assert.equal(fetchCalls[3].url, "/api/reply");
-  assert.equal(fetchCalls[3].body.translation, "【正式】hola");
+  assert.equal(fetchCalls[3].body.replyText, "【正式】hola");
+  assert.equal(fetchCalls[3].body.text, "【正式】hola");
   assert.deepEqual(fetchCalls[3].body.additionalTargetLanguages, ["fr"]);
   assert.equal(fetchCalls[3].headers.Authorization, "Bearer user");
   assert.equal(teams.dialog.lastSubmit.translation, "【正式】hola");

--- a/tests/messageExtensionDialogState.test.js
+++ b/tests/messageExtensionDialogState.test.js
@@ -90,6 +90,9 @@ test("buildReplyPayload reuses rag preferences", () => {
   };
   const context = { tenant: { id: "tenant" }, user: { id: "user" }, channel: { id: "channel" } };
   const payload = buildReplyPayload(state, context, "こんにちは");
+  assert.equal(payload.replyText, "こんにちは");
+  assert.equal(payload.text, "こんにちは");
+  assert.equal("translation" in payload, false);
   assert.equal(payload.useRag, true);
   assert.deepEqual(payload.contextHints, ["pricing"]);
   assert.deepEqual(payload.additionalTargetLanguages, ["en", "fr"]);

--- a/tests/playwright/compose.spec.js
+++ b/tests/playwright/compose.spec.js
@@ -83,12 +83,13 @@ async function setupComposePage(page, { translateCalls, replyCalls, metadataHand
   await page.route("**/api/reply", async (route) => {
     const payload = JSON.parse(route.request().postData() ?? "{}");
     replyCalls?.push(payload);
+    const replyText = payload.replyText ?? payload.text ?? payload.translation ?? "";
     await route.fulfill({
       status: 200,
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         status: "ok",
-        card: { type: "AdaptiveCard", body: [{ type: "TextBlock", text: payload.translation ?? "" }] }
+        card: { type: "AdaptiveCard", body: [{ type: "TextBlock", text: replyText }] }
       })
     });
   });
@@ -149,7 +150,8 @@ test("compose page delegates to teams compose plugin", async ({ page }) => {
 
   expect(replyCalls).toHaveLength(1);
   expect(replyCalls[0].metadata.tone).toBe("formal");
-  expect(replyCalls[0].translation).toBe("hola");
+  expect(replyCalls[0].replyText).toBe("hola");
+  expect(replyCalls[0].text).toBe("hola");
 
   const sentMessages = await page.evaluate(() => window.sentMessages);
   expect(sentMessages).toHaveLength(1);

--- a/tests/playwright/dialog.spec.js
+++ b/tests/playwright/dialog.spec.js
@@ -88,10 +88,15 @@ async function setupDialogPage(page, { metadata = defaultMetadata, metadataHandl
 
   await page.route("**/api/reply", async (route) => {
     const payload = JSON.parse(route.request().postData() ?? "{}");
+    const replyText = payload.replyText ?? payload.text ?? payload.translation ?? "";
     await route.fulfill({
       status: 200,
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ status: "ok", echo: payload, card: { type: "AdaptiveCard", body: [] } })
+      body: JSON.stringify({
+        status: "ok",
+        echo: payload,
+        card: { type: "AdaptiveCard", body: [{ type: "TextBlock", text: replyText }] }
+      })
     });
   });
 


### PR DESCRIPTION
## Summary
- replace the reply payload `translation` property with `replyText` and `text` in both Teams client bundles
- allow the message extension handler to consume the new payload shape while preserving other metadata
- refresh compose and dialog unit/integration tests to assert the new reply payload structure

## Testing
- npm test *(fails: src/webapp/app.js no longer exports handleGlossaryUpload, existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68de9e769a80832fa1cb0ebef5508e39