### PR TITLE
Compute dynamic stage five readiness

### DIFF
--- a/src/TlaPlugin/Services/ProjectStatusService.cs
+++ b/src/TlaPlugin/Services/ProjectStatusService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
 using TlaPlugin.Models;
 
 namespace TlaPlugin.Services;
@@ -10,13 +12,14 @@ namespace TlaPlugin.Services;
 /// </summary>
 public class ProjectStatusService
 {
-    private static readonly IReadOnlyList<StageStatus> Stages = new List<StageStatus>
+    private const string StageFiveId = "phase5";
+    private static readonly IReadOnlyList<(string Id, string Name, string Description, bool Completed)> StageBlueprint = new List<(string, string, string, bool)>
     {
-        new("phase1", "阶段 1：平台基线", "完成需求解读、服务编排与消息扩展骨架。", true),
-        new("phase2", "阶段 2：安全与合规", "交付合规网关、预算守卫与密钥/OBO 管理。", true),
-        new("phase3", "阶段 3：性能与可观测", "完成缓存、速率控制与多模型互联。", true),
-        new("phase4", "阶段 4：前端体验", "实现 Teams Tab 仪表盘与本地化界面。", true),
-        new("phase5", "阶段 5：上线准备", "拉通真实模型、联调并准备发布清单。", false)
+        ("phase1", "阶段 1：平台基线", "完成需求解读、服务编排与消息扩展骨架。", true),
+        ("phase2", "阶段 2：安全与合规", "交付合规网关、预算守卫与密钥/OBO 管理。", true),
+        ("phase3", "阶段 3：性能与可观测", "完成缓存、速率控制与多模型互联。", true),
+        ("phase4", "阶段 4：前端体验", "实现 Teams Tab 仪表盘与本地化界面。", true),
+        (StageFiveId, "阶段 5：上线准备", "拉通真实模型、联调并准备发布清单。", false)
     };
 
     private static readonly IReadOnlyList<string> NextSteps = new List<string>
@@ -26,26 +29,130 @@ public class ProjectStatusService
         "切换至真实模型并执行发布 SmokeTest"
     };
 
+    private static readonly TimeSpan SmokeSuccessWindow = TimeSpan.FromHours(24);
+
+    private readonly PluginOptions _options;
+    private readonly UsageMetricsService _usageMetrics;
+    private readonly DevelopmentRoadmapService _roadmapService;
+
+    public ProjectStatusService(
+        IOptions<PluginOptions> options,
+        UsageMetricsService usageMetrics,
+        DevelopmentRoadmapService roadmapService)
+    {
+        _options = options?.Value ?? new PluginOptions();
+        _usageMetrics = usageMetrics ?? throw new ArgumentNullException(nameof(usageMetrics));
+        _roadmapService = roadmapService ?? throw new ArgumentNullException(nameof(roadmapService));
+    }
+
     /// <summary>
     /// 返回当前的进度快照。
     /// </summary>
     public ProjectStatusSnapshot GetSnapshot()
     {
-        var current = Stages.FirstOrDefault(s => !s.Completed) ?? Stages.Last();
-        var overallPercent = CalculateOverallPercent();
-        var frontend = new FrontendProgress(
-            CompletionPercent: 80,
-            DataPlaneReady: true,
-            UiImplemented: true,
-            IntegrationReady: true);
+        var roadmap = _roadmapService.GetRoadmap();
+        var stageFiveCompleted = IsStageFiveCompleted(_options);
+        var stages = BuildStages(roadmap, stageFiveCompleted);
+        var current = stages.FirstOrDefault(s => !s.Completed) ?? stages.Last();
+        var overallPercent = CalculateOverallPercent(stages);
+        var frontend = BuildFrontendProgress(stages, stageFiveCompleted);
 
-        return new ProjectStatusSnapshot(current.Id, Stages, NextSteps, overallPercent, frontend);
+        return new ProjectStatusSnapshot(current.Id, stages, NextSteps, overallPercent, frontend);
     }
 
-    private static int CalculateOverallPercent()
+    private static FrontendProgress BuildFrontendProgress(IReadOnlyList<StageStatus> stages, bool stageFiveCompleted)
     {
-        var completed = Stages.Count(stage => stage.Completed);
-        var percent = (double)completed / Stages.Count * 100;
+        var percent = CalculateOverallPercent(stages);
+        return new FrontendProgress(
+            CompletionPercent: percent,
+            DataPlaneReady: true,
+            UiImplemented: true,
+            IntegrationReady: stageFiveCompleted);
+    }
+
+    private static int CalculateOverallPercent(IReadOnlyList<StageStatus> stages)
+    {
+        if (stages.Count == 0)
+        {
+            return 0;
+        }
+
+        var completed = stages.Count(stage => stage.Completed);
+        var percent = (double)completed / stages.Count * 100;
         return (int)Math.Round(percent, MidpointRounding.AwayFromZero);
+    }
+
+    private static IReadOnlyList<StageStatus> BuildStages(DevelopmentRoadmap roadmap, bool stageFiveCompleted)
+    {
+        if (roadmap?.Stages is null || roadmap.Stages.Count == 0)
+        {
+            return StageBlueprint
+                .Select(stage => new StageStatus(
+                    stage.Id,
+                    stage.Name,
+                    stage.Description,
+                    stage.Id == StageFiveId ? stageFiveCompleted : stage.Completed))
+                .ToList();
+        }
+
+        var overrides = roadmap.Stages
+            .ToDictionary(stage => stage.Id, stage => stage, StringComparer.OrdinalIgnoreCase);
+
+        return StageBlueprint
+            .Select(template =>
+            {
+                var hasOverride = overrides.TryGetValue(template.Id, out var stageOverride);
+                var completed = template.Id == StageFiveId
+                    ? stageFiveCompleted
+                    : (hasOverride ? stageOverride!.Completed : template.Completed);
+                var name = hasOverride ? stageOverride!.Name : template.Name;
+                var description = hasOverride ? stageOverride!.Objective : template.Description;
+                return new StageStatus(template.Id, name, description, completed);
+            })
+            .ToList();
+    }
+
+    private bool IsStageFiveCompleted(PluginOptions options)
+    {
+        var security = options.Security ?? new SecurityOptions();
+        if (security.UseHmacFallback)
+        {
+            return false;
+        }
+
+        if (!HasValidGraphScopes(security.GraphScopes))
+        {
+            return false;
+        }
+
+        return HasRecentSmokeSuccess();
+    }
+
+    private static bool HasValidGraphScopes(IList<string> scopes)
+    {
+        if (scopes is null || scopes.Count == 0)
+        {
+            return false;
+        }
+
+        const string Prefix = "https://graph.microsoft.com/";
+        return scopes.All(scope =>
+            !string.IsNullOrWhiteSpace(scope)
+            && scope.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase)
+            && scope.Length > Prefix.Length);
+    }
+
+    private bool HasRecentSmokeSuccess()
+    {
+        var report = _usageMetrics.GetReport();
+        if (report.Tenants.Count == 0)
+        {
+            return false;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        return report.Tenants.Any(snapshot =>
+            snapshot.Translations > 0
+            && now - snapshot.LastUpdated <= SmokeSuccessWindow);
     }
 }

--- a/src/webapp/app.js
+++ b/src/webapp/app.js
@@ -1,4 +1,5 @@
 import { buildStatusCards, formatLocaleOptions } from "./viewModel.js";
+export { handleGlossaryUpload, renderGlossaryUploadFeedback, renderGlossaryEntries } from "./settingsTab.js";
 
 const FALLBACK_STATUS = {
   currentStageId: "phase5",
@@ -19,7 +20,7 @@ const FALLBACK_STATUS = {
     completionPercent: 80,
     dataPlaneReady: true,
     uiImplemented: true,
-    integrationReady: true
+    integrationReady: false
   }
 };
 

--- a/tests/TlaPlugin.Tests/ProjectStatusServiceTests.cs
+++ b/tests/TlaPlugin.Tests/ProjectStatusServiceTests.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
 using TlaPlugin.Services;
 using Xunit;
 
@@ -6,9 +9,12 @@ namespace TlaPlugin.Tests;
 public class ProjectStatusServiceTests
 {
     [Fact]
-    public void GetSnapshot_Returns_CurrentStage_And_NextSteps()
+    public void GetSnapshot_Reflects_DefaultStageFivePending_WhenPrerequisitesMissing()
     {
-        var service = new ProjectStatusService();
+        var options = Options.Create(new PluginOptions());
+        var metrics = new UsageMetricsService();
+        var roadmap = new DevelopmentRoadmapService();
+        var service = new ProjectStatusService(options, metrics, roadmap);
 
         var snapshot = service.GetSnapshot();
 
@@ -16,10 +22,37 @@ public class ProjectStatusServiceTests
         Assert.Contains(snapshot.Stages, stage => stage.Id == "phase4" && stage.Completed);
         Assert.Equal(3, snapshot.NextSteps.Count);
         Assert.Contains(snapshot.NextSteps, step => step.Contains("密钥"));
+        Assert.False(snapshot.Stages.Single(stage => stage.Id == "phase5").Completed);
         Assert.Equal(80, snapshot.OverallCompletionPercent);
         Assert.True(snapshot.Frontend.DataPlaneReady);
         Assert.True(snapshot.Frontend.UiImplemented);
-        Assert.True(snapshot.Frontend.IntegrationReady);
+        Assert.False(snapshot.Frontend.IntegrationReady);
         Assert.Equal(80, snapshot.Frontend.CompletionPercent);
+    }
+
+    [Fact]
+    public void GetSnapshot_MarksStageFiveComplete_WhenSecurityAndMetricsReady()
+    {
+        var pluginOptions = new PluginOptions
+        {
+            Security = new SecurityOptions
+            {
+                UseHmacFallback = false,
+                GraphScopes = new[] { "https://graph.microsoft.com/.default", "https://graph.microsoft.com/ChannelMessage.Send" }
+            }
+        };
+        var options = Options.Create(pluginOptions);
+        var metrics = new UsageMetricsService();
+        metrics.RecordSuccess("contoso", "model-a", 0.12m, 120, 1);
+        var roadmap = new DevelopmentRoadmapService();
+        var service = new ProjectStatusService(options, metrics, roadmap);
+
+        var snapshot = service.GetSnapshot();
+
+        var stageFive = snapshot.Stages.Single(stage => stage.Id == "phase5");
+        Assert.True(stageFive.Completed);
+        Assert.Equal(100, snapshot.OverallCompletionPercent);
+        Assert.True(snapshot.Frontend.IntegrationReady);
+        Assert.Equal(100, snapshot.Frontend.CompletionPercent);
     }
 }

--- a/tests/dashboardViewModel.test.js
+++ b/tests/dashboardViewModel.test.js
@@ -20,10 +20,13 @@ test("groupStagesForTimeline marks active stage and progress", () => {
 test("buildStatusCards merges roadmap and status information", () => {
   const status = {
     currentStageId: "phase5",
-    overallCompletionPercent: 80,
-    frontend: { completionPercent: 80, dataPlaneReady: true, uiImplemented: true, integrationReady: true },
-    nextSteps: ["密钥映射"],
-    stages: [{ id: "phase1", name: "阶段 1", completed: true }]
+    overallCompletionPercent: 100,
+    frontend: { completionPercent: 100, dataPlaneReady: true, uiImplemented: true, integrationReady: true },
+    nextSteps: ["发布清单"],
+    stages: [
+      { id: "phase1", name: "阶段 1", completed: true },
+      { id: "phase5", name: "阶段 5", completed: true }
+    ]
   };
   const roadmap = {
     activeStageId: "phase5",
@@ -40,6 +43,11 @@ test("buildStatusCards merges roadmap and status information", () => {
   assert.equal(cards.activeStage.name, "阶段 5");
   assert.equal(cards.frontend.uiImplemented, true);
   assert.equal(cards.tests[0].id, "dashboard");
+  const phase5 = cards.timeline.find((stage) => stage.id === "phase5");
+  assert.ok(phase5?.completed);
+  assert.equal(phase5.progress, 100);
+  assert.deepEqual(cards.nextSteps, ["发布清单"]);
+  assert.equal(cards.overallPercent, 100);
 });
 
 test("formatLocaleOptions sorts locales alphabetically", () => {


### PR DESCRIPTION
## Summary
- derive the stage five completion flag from plugin options, usage metrics, and roadmap metadata so overall and front-end progress adapt to runtime conditions
- cover stage-five-ready and not-ready service states in unit tests and refresh the dashboard view-model test to assert dynamic percentages and next steps
- expose glossary upload helpers for node tests and align the fallback status integration readiness with the backend defaults

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df35ca2c54832f83fe81acfa6b2070