### PR TITLE
Add remote API mode for Stage5 reply smoke tests

### DIFF
--- a/docs/stage5-integration-runbook.md
+++ b/docs/stage5-integration-runbook.md
@@ -104,6 +104,23 @@
      --use-live-model
    ```
 
+   **远程 API 模式** – 若要直接验证已部署 Stage 服务的端到端行为，可追加 `--use-remote-api` 并通过 `--baseUrl` 指定目标地址（默认 `https://localhost:5001`）。脚本会把命令行中的租户、语种、断言等参数原样发送到远端 `/api/translate` 与 `/api/reply`，随后再访问 `/api/metrics` 与 `/api/audit` 校验服务端是否记录成功。示例命令：
+
+   ```bash
+   export USER_ASSERTION=$(az account get-access-token --resource api://tla-plugin --query accessToken -o tsv)
+   dotnet run --project scripts/SmokeTests/Stage5SmokeTests -- reply \
+     --tenant contoso.onmicrosoft.com \
+     --user stage-user \
+     --thread 19:stage-thread@thread.tacv2 \
+     --language ja \
+     --text "Stage 5 远程 API 冒烟" \
+     --use-remote-api \
+     --baseUrl https://stage5.contoso.net \
+     --assertion "$USER_ASSERTION"
+   ```
+
+   远程模式运行成功时会输出远端返回的翻译摘要、回帖结果、`/api/metrics` 与 `/api/audit` JSON 片段；如遇 401/403/429 等状态，脚本会打印 `21/22/23` 等退出码帮助定位鉴权或配额问题。与离线模式不同，此时不再显示本地 Graph 诊断信息，而是复用远程响应作为调试依据。
+
    成功运行后，控制台会打印一次 Graph 请求与指标快照，可用于变更记录留痕：
 
    ```text

--- a/scripts/SmokeTests/Stage5SmokeTests/Program.cs
+++ b/scripts/SmokeTests/Stage5SmokeTests/Program.cs
@@ -5,9 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
@@ -116,6 +120,8 @@ static void PrintUsage()
     Console.WriteLine("  --assertion <jwt>       用户断言 (JWT)。HMAC 回退模式下可省略，脚本会生成模拟值。");
     Console.WriteLine("  --use-live-graph        启用真实 Graph 调用，默认使用内置模拟响应。");
     Console.WriteLine("  --use-live-model        启用真实模型 Provider，默认使用内置 Stub 模型。");
+    Console.WriteLine("  --use-remote-api        直接访问 Stage 部署的 /api/translate 与 /api/reply。");
+    Console.WriteLine("  --baseUrl <url>         远程模式下指定 Stage 服务根地址，默认 https://localhost:5001。");
     Console.WriteLine();
     Console.WriteLine("metrics 命令参数:");
     Console.WriteLine("  --baseUrl <url>         Stage 服务的根地址，默认为 https://localhost:5001。");
@@ -402,10 +408,21 @@ static void PrintGraphScopeReminder(PluginOptions options)
     Console.WriteLine();
 }
 
+static readonly JsonSerializerOptions RemoteSerializerOptions = new(JsonSerializerDefaults.Web)
+{
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+};
+
+static readonly JsonSerializerOptions PrettyJsonOptions = new()
+{
+    WriteIndented = true
+};
+
 static async Task<int> RunReplySmokeAsync(PluginOptions options, IReadOnlyDictionary<string, string?> parameters, CancellationToken cancellationToken)
 {
     var useLiveGraph = parameters.ContainsKey("use-live-graph");
     var useLiveModel = parameters.ContainsKey("use-live-model");
+    var useRemoteApi = parameters.ContainsKey("use-remote-api");
     var tenantId = GetValue(parameters, "tenant", "contoso.onmicrosoft.com");
     var userId = GetValue(parameters, "user", "user1");
     var threadId = GetValue(parameters, "thread", "message-id");
@@ -435,6 +452,40 @@ static async Task<int> RunReplySmokeAsync(PluginOptions options, IReadOnlyDictio
     if (!options.Security.UseHmacFallback)
     {
         PrintGraphScopeReminder(options);
+    }
+
+    var additionalTargets = options.DefaultTargetLanguages
+        .Where(l => !string.Equals(l, language, StringComparison.OrdinalIgnoreCase))
+        .Take(3)
+        .ToList();
+    if (additionalTargets.Count == 0)
+    {
+        additionalTargets.Add("en-US");
+    }
+
+    var translationRequest = new TranslationRequest
+    {
+        Text = text,
+        TargetLanguage = language,
+        TenantId = tenantId,
+        UserId = userId,
+        ChannelId = channelId,
+        ThreadId = threadId,
+        Tone = tone,
+        UiLocale = options.DefaultUiLocale,
+        AdditionalTargetLanguages = additionalTargets,
+        UserAssertion = userAssertion
+    };
+
+    if (useRemoteApi)
+    {
+        var baseUrl = GetValue(parameters, "baseUrl", "https://localhost:5001");
+        return await RunRemoteReplySmokeAsync(
+            baseUrl,
+            translationRequest,
+            tone,
+            additionalTargets,
+            cancellationToken).ConfigureAwait(false);
     }
 
     var metrics = new UsageMetricsService();
@@ -504,29 +555,6 @@ static async Task<int> RunReplySmokeAsync(PluginOptions options, IReadOnlyDictio
         providerOverrides);
     var throttle = new TranslationThrottle(Options.Create(options));
     var rewrite = new RewriteService(router, throttle);
-
-    var additionalTargets = options.DefaultTargetLanguages
-        .Where(l => !string.Equals(l, language, StringComparison.OrdinalIgnoreCase))
-        .Take(3)
-        .ToList();
-    if (additionalTargets.Count == 0)
-    {
-        additionalTargets.Add("en-US");
-    }
-
-    var translationRequest = new TranslationRequest
-    {
-        Text = text,
-        TargetLanguage = language,
-        TenantId = tenantId,
-        UserId = userId,
-        ChannelId = channelId,
-        ThreadId = threadId,
-        Tone = tone,
-        UiLocale = options.DefaultUiLocale,
-        AdditionalTargetLanguages = additionalTargets,
-        UserAssertion = userAssertion
-    };
 
     TranslationResult translation;
     try
@@ -699,6 +727,255 @@ static async Task<int> RunReplySmokeAsync(PluginOptions options, IReadOnlyDictio
 
     return 0;
 }
+
+static async Task<int> RunRemoteReplySmokeAsync(
+    string baseUrl,
+    TranslationRequest translationRequest,
+    string tone,
+    IReadOnlyList<string> additionalTargets,
+    CancellationToken cancellationToken)
+{
+    if (string.IsNullOrWhiteSpace(translationRequest.UserAssertion))
+    {
+        Console.Error.WriteLine("远程模式需要提供用户断言 (--assertion <jwt>)。");
+        return 13;
+    }
+
+    if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri))
+    {
+        Console.Error.WriteLine($"无效的 baseUrl: {baseUrl}");
+        return 14;
+    }
+
+    using var httpClient = new HttpClient
+    {
+        BaseAddress = baseUri
+    };
+    httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", translationRequest.UserAssertion);
+
+    Console.WriteLine($"远程 API 模式已启用，目标服务: {baseUri}");
+
+    HttpResponseMessage translateResponse;
+    try
+    {
+        translateResponse = await httpClient.PostAsJsonAsync("/api/translate", translationRequest, RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine("调用远程 /api/translate 失败: " + ex.Message);
+        return 3;
+    }
+
+    if (!translateResponse.IsSuccessStatusCode)
+    {
+        return await ReportRemoteFailureAsync(translateResponse, "/api/translate", 3, cancellationToken).ConfigureAwait(false);
+    }
+
+    TranslationResult? translation;
+    try
+    {
+        translation = await translateResponse.Content.ReadFromJsonAsync<TranslationResult>(RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine("解析远程翻译响应失败: " + ex.Message);
+        return 3;
+    }
+
+    if (translation is null)
+    {
+        Console.Error.WriteLine("远程翻译响应为空。");
+        return 3;
+    }
+
+    Console.WriteLine("远程翻译完成:");
+    Console.WriteLine($"  ModelId:       {translation.ModelId}");
+    Console.WriteLine($"  TargetLanguage: {translation.TargetLanguage}");
+    Console.WriteLine($"  LatencyMs:     {translation.LatencyMs}");
+    Console.WriteLine($"  CostUsd:       {translation.CostUsd}");
+    Console.WriteLine($"  Text:          {translation.TranslatedText}");
+
+    if (additionalTargets.Count > 0)
+    {
+        if (translation.AdditionalTranslations.Count == 0)
+        {
+            Console.Error.WriteLine("远程翻译响应缺少附加语种输出。");
+            return 8;
+        }
+
+        foreach (var language in additionalTargets)
+        {
+            if (!translation.AdditionalTranslations.ContainsKey(language))
+            {
+                Console.Error.WriteLine($"远程翻译未包含 {language} 的附加译文。");
+                return 9;
+            }
+        }
+    }
+
+    var replyRequest = new ReplyRequest
+    {
+        ThreadId = translationRequest.ThreadId,
+        ReplyText = translation.TranslatedText,
+        Text = translation.TranslatedText,
+        TenantId = translationRequest.TenantId,
+        UserId = translationRequest.UserId,
+        ChannelId = translationRequest.ChannelId,
+        UiLocale = translation.UiLocale,
+        LanguagePolicy = new ReplyLanguagePolicy
+        {
+            TargetLang = translation.TargetLanguage,
+            Tone = tone
+        },
+        AdditionalTargetLanguages = new List<string>(additionalTargets),
+        UserAssertion = translationRequest.UserAssertion
+    };
+
+    HttpResponseMessage replyResponse;
+    try
+    {
+        replyResponse = await httpClient.PostAsJsonAsync("/api/reply", replyRequest, RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine("调用远程 /api/reply 失败: " + ex.Message);
+        return 4;
+    }
+
+    if (!replyResponse.IsSuccessStatusCode)
+    {
+        return await ReportRemoteFailureAsync(replyResponse, "/api/reply", 4, cancellationToken).ConfigureAwait(false);
+    }
+
+    ReplyResult? replyResult;
+    try
+    {
+        replyResult = await replyResponse.Content.ReadFromJsonAsync<ReplyResult>(RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine("解析远程回帖响应失败: " + ex.Message);
+        return 4;
+    }
+
+    if (replyResult is null)
+    {
+        Console.Error.WriteLine("远程回帖响应为空。");
+        return 4;
+    }
+
+    Console.WriteLine("远程回帖完成:");
+    Console.WriteLine($"  MessageId: {replyResult.MessageId}");
+    Console.WriteLine($"  Status:    {replyResult.Status}");
+    Console.WriteLine($"  Language:  {replyResult.Language}");
+
+    UsageMetricsReport? metricsReport;
+    try
+    {
+        using var metricsResponse = await httpClient.GetAsync("/api/metrics", cancellationToken).ConfigureAwait(false);
+        if (!metricsResponse.IsSuccessStatusCode)
+        {
+            return await ReportRemoteFailureAsync(metricsResponse, "/api/metrics", 5, cancellationToken).ConfigureAwait(false);
+        }
+
+        metricsReport = await metricsResponse.Content.ReadFromJsonAsync<UsageMetricsReport>(RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine("调用远程 /api/metrics 失败: " + ex.Message);
+        return 5;
+    }
+
+    if (metricsReport is null)
+    {
+        Console.Error.WriteLine("远程指标响应为空。");
+        return 5;
+    }
+
+    var tenantMetrics = metricsReport.Tenants.FirstOrDefault(t => string.Equals(t.TenantId, translationRequest.TenantId, StringComparison.OrdinalIgnoreCase));
+    if (tenantMetrics is null || tenantMetrics.Translations == 0)
+    {
+        Console.Error.WriteLine("远程指标中未找到当前租户的成功记录。");
+        return 5;
+    }
+
+    Console.WriteLine("使用指标摘要:");
+    Console.WriteLine(JsonSerializer.Serialize(metricsReport, PrettyJsonOptions));
+    Console.WriteLine();
+
+    JsonArray? auditArray;
+    try
+    {
+        using var auditResponse = await httpClient.GetAsync("/api/audit", cancellationToken).ConfigureAwait(false);
+        if (!auditResponse.IsSuccessStatusCode)
+        {
+            return await ReportRemoteFailureAsync(auditResponse, "/api/audit", 6, cancellationToken).ConfigureAwait(false);
+        }
+
+        var payload = await auditResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        auditArray = JsonNode.Parse(payload) as JsonArray;
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine("调用远程 /api/audit 失败: " + ex.Message);
+        return 6;
+    }
+
+    if (auditArray is null || auditArray.Count == 0)
+    {
+        Console.Error.WriteLine("远程审计日志为空。");
+        return 6;
+    }
+
+    var hasTenantLog = auditArray
+        .Select(node => node as JsonObject)
+        .Any(entry => string.Equals(entry?["tenantId"]?.GetValue<string>(), translationRequest.TenantId, StringComparison.OrdinalIgnoreCase));
+
+    if (!hasTenantLog)
+    {
+        Console.Error.WriteLine("远程审计日志未记录当前租户。");
+        return 6;
+    }
+
+    Console.WriteLine("审计记录样例:");
+    foreach (var entry in auditArray)
+    {
+        if (entry is JsonObject obj)
+        {
+            Console.WriteLine(obj.ToJsonString(PrettyJsonOptions));
+        }
+        else
+        {
+            Console.WriteLine(entry?.ToJsonString(PrettyJsonOptions) ?? "null");
+        }
+    }
+
+    return 0;
+}
+
+static async Task<int> ReportRemoteFailureAsync(HttpResponseMessage response, string endpoint, int defaultExitCode, CancellationToken cancellationToken)
+{
+    var exitCode = MapRemoteStatusToExitCode(response.StatusCode, defaultExitCode);
+    var payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+    Console.Error.WriteLine($"远程 {endpoint} 返回 {(int)response.StatusCode} {response.StatusCode}，退出码 {exitCode}。");
+    if (!string.IsNullOrWhiteSpace(payload))
+    {
+        Console.Error.WriteLine(payload);
+    }
+
+    return exitCode;
+}
+
+static int MapRemoteStatusToExitCode(HttpStatusCode statusCode, int fallback)
+    => statusCode switch
+    {
+        HttpStatusCode.Unauthorized => 21,
+        HttpStatusCode.Forbidden => 22,
+        HttpStatusCode.TooManyRequests => 23,
+        HttpStatusCode.PaymentRequired => 24,
+        HttpStatusCode.ServiceUnavailable => 25,
+        _ => fallback
+    };
 
 static async Task<int> RunMetricsProbeAsync(IReadOnlyDictionary<string, string?> parameters, CancellationToken cancellationToken)
 {

--- a/scripts/SmokeTests/Stage5SmokeTests/README.md
+++ b/scripts/SmokeTests/Stage5SmokeTests/README.md
@@ -1,0 +1,82 @@
+# Stage5SmokeTests 自测指南
+
+本文档说明如何验证 `reply` 命令在默认离线模式与新增的 `--use-remote-api` 模式下均能正常运行，以便在修改脚本后快速自测。
+
+## 前置准备
+
+1. 安装 .NET 8 SDK，并在仓库根目录执行 `dotnet restore`。
+2. 若需要演示远程模式，请在新的终端窗口启动本地 API：
+   ```bash
+   dotnet run --project src/TlaPlugin/TlaPlugin.csproj --urls https://localhost:5001
+   ```
+   服务器会监听 `https://localhost:5001`，使用默认自签名证书。首次访问时可接受证书提示。
+
+## 离线模式验证
+
+该模式复用脚本内置的 Stub Provider 与模拟 Graph，确保历史流程不受影响：
+
+```bash
+dotnet run --project scripts/SmokeTests/Stage5SmokeTests -- reply \
+  --tenant contoso.onmicrosoft.com \
+  --user smoke-user \
+  --thread smoke-thread \
+  --language ja \
+  --text "Stage 5 离线验证"
+```
+
+预期输出包括：
+
+- 控制台提示“已生成模拟 JWT”；
+- `TeamsReplyClient 调用成功` 以及 Graph 调用诊断；
+- 指标摘要与审计样例。若命令返回非零退出码，则离线流程被破坏，应先回归。
+
+## 远程模式验证
+
+1. 确保上文提到的本地 API 已启动，并可通过 `curl -k https://localhost:5001/healthz` 获得 200。
+2. 使用以下一次性脚本生成与工具内部逻辑一致的模拟用户断言（若已有真实用户断言，可跳过本步并替换后续命令中的变量）：
+   ```bash
+   export ASSERTION=$(python - <<'PY'
+import base64, json, time
+header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').rstrip(b'=')
+payload = {
+    "aud": "api://tla-plugin",
+    "tid": "contoso.onmicrosoft.com",
+    "sub": "smoke-user",
+    "upn": "smoke-user",
+    "iss": "Stage5SmokeTests",
+    "iat": int(time.time()),
+    "exp": int(time.time() + 1800),
+    "ver": "1.0"
+}
+payload_json = json.dumps(payload, separators=(',', ':')).encode()
+payload_segment = base64.urlsafe_b64encode(payload_json).rstrip(b'=')
+signature = base64.urlsafe_b64encode(b'stage5-smoke').rstrip(b'=')
+print(f"{header.decode()}.{payload_segment.decode()}.{signature.decode()}")
+PY
+)
+   ```
+3. 执行远程模式命令：
+   ```bash
+   dotnet run --project scripts/SmokeTests/Stage5SmokeTests -- reply \
+     --tenant contoso.onmicrosoft.com \
+     --user smoke-user \
+     --thread smoke-thread \
+     --language ja \
+     --text "Stage 5 远程验证" \
+     --use-remote-api \
+     --assertion "$ASSERTION"
+   ```
+
+预期输出：
+
+- `远程 API 模式已启用` 提示以及翻译、回帖响应摘要；
+- `/api/metrics` 与 `/api/audit` 的 JSON 片段，且包含当前租户的记录；
+- 若远程接口返回 401/403/429，会打印对应的退出码（21/22/23），便于快速定位权限或配额问题。
+
+## 常见问题排查
+
+- **证书错误**：本地 HTTPS 服务器使用自签名证书，可在命令中追加 `DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=0` 环境变量或改用 `http://localhost:5000` 自定义端口。
+- **返回 401/403**：检查 `--assertion` 是否为有效 JWT，以及部署环境是否识别该用户；脚本会同时输出退出码映射帮助定位。
+- **返回 429**：说明服务端触发速率限制，可稍后重试或调整负载；远程模式会直接展示服务端返回的正文。
+
+按照上述步骤可快速确认新增开关没有破坏原有流程，并在需要时模拟部署环境的远程调用链路。


### PR DESCRIPTION
## Summary
- add a `--use-remote-api` flag to the Stage5 smoke test runner so it can call deployed `/api/translate` and `/api/reply`, reuse responses for diagnostics, and surface metrics/audit plus HTTP status exit codes
- provide a self-test README for local/remote flows and update the Stage5 runbook with guidance on choosing remote versus local execution

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df3bfcc570832fb69a288b33e7f236