### PR TITLE
Auto-enable Stage 5 remote smoke mode

### DIFF
--- a/docs/stage5-integration-runbook.md
+++ b/docs/stage5-integration-runbook.md
@@ -104,7 +104,7 @@
      --use-live-model
    ```
 
-   **远程 API 模式** – 若要直接验证已部署 Stage 服务的端到端行为，可追加 `--use-remote-api` 并通过 `--baseUrl` 指定目标地址（默认 `https://localhost:5001`）。脚本会把命令行中的租户、语种、断言等参数原样发送到远端 `/api/translate` 与 `/api/reply`，随后再访问 `/api/metrics` 与 `/api/audit` 校验服务端是否记录成功。示例命令：
+   **远程 API 模式** – 当 Stage 配置禁用 HMAC 回退 (`Plugin.Security.UseHmacFallback=false`) 或命令行提供 `--baseUrl` 时，脚本会自动直接访问已部署服务的 `/api/translate`、`/api/reply` 与 `/api/metrics`。可继续使用 `--use-remote-api` 在本地配置下手动触发，或通过 `--use-local-stub` 在 Stage 配置下强制回退到离线 Stub。示例命令：
 
    ```bash
    export USER_ASSERTION=$(az account get-access-token --resource api://tla-plugin --query accessToken -o tsv)
@@ -114,12 +114,11 @@
      --thread 19:stage-thread@thread.tacv2 \
      --language ja \
      --text "Stage 5 远程 API 冒烟" \
-     --use-remote-api \
      --baseUrl https://stage5.contoso.net \
      --assertion "$USER_ASSERTION"
    ```
 
-   远程模式运行成功时会输出远端返回的翻译摘要、回帖结果、`/api/metrics` 与 `/api/audit` JSON 片段；如遇 401/403/429 等状态，脚本会打印 `21/22/23` 等退出码帮助定位鉴权或配额问题。与离线模式不同，此时不再显示本地 Graph 诊断信息，而是复用远程响应作为调试依据。
+   远程模式运行成功时会输出远端返回的翻译摘要、回帖结果、`/api/metrics` 与 `/api/audit` JSON 片段；如遇 401/403/429 等状态，脚本会打印 `21/22/23` 等退出码帮助定位鉴权或配额问题。与离线模式不同，此时不再显示本地 Graph 诊断信息，而是复用远程响应作为调试依据。若需要短暂关闭自动远程（例如在 Stage 配置下测试 Stub），可在命令末尾追加 `--use-local-stub`，脚本会提示已忽略自动触发条件。
 
    成功运行后，控制台会打印一次 Graph 请求与指标快照，可用于变更记录留痕：
 

--- a/scripts/SmokeTests/Stage5SmokeTests/Program.cs
+++ b/scripts/SmokeTests/Stage5SmokeTests/Program.cs
@@ -120,8 +120,9 @@ static void PrintUsage()
     Console.WriteLine("  --assertion <jwt>       用户断言 (JWT)。HMAC 回退模式下可省略，脚本会生成模拟值。");
     Console.WriteLine("  --use-live-graph        启用真实 Graph 调用，默认使用内置模拟响应。");
     Console.WriteLine("  --use-live-model        启用真实模型 Provider，默认使用内置 Stub 模型。");
-    Console.WriteLine("  --use-remote-api        直接访问 Stage 部署的 /api/translate 与 /api/reply。");
-    Console.WriteLine("  --baseUrl <url>         远程模式下指定 Stage 服务根地址，默认 https://localhost:5001。");
+    Console.WriteLine("  --use-remote-api        强制访问 Stage 部署的 API；当 UseHmacFallback=false 或指定 --baseUrl 时会自动启用。");
+    Console.WriteLine("  --use-local-stub        即使满足自动触发条件，也继续使用本地 Stub 管道。");
+    Console.WriteLine("  --baseUrl <url>         远程模式下指定 Stage 服务根地址，默认 https://localhost:5001。提供该参数将自动启用远程模式。");
     Console.WriteLine();
     Console.WriteLine("metrics 命令参数:");
     Console.WriteLine("  --baseUrl <url>         Stage 服务的根地址，默认为 https://localhost:5001。");
@@ -408,21 +409,13 @@ static void PrintGraphScopeReminder(PluginOptions options)
     Console.WriteLine();
 }
 
-static readonly JsonSerializerOptions RemoteSerializerOptions = new(JsonSerializerDefaults.Web)
-{
-    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-};
-
-static readonly JsonSerializerOptions PrettyJsonOptions = new()
-{
-    WriteIndented = true
-};
-
 static async Task<int> RunReplySmokeAsync(PluginOptions options, IReadOnlyDictionary<string, string?> parameters, CancellationToken cancellationToken)
 {
     var useLiveGraph = parameters.ContainsKey("use-live-graph");
     var useLiveModel = parameters.ContainsKey("use-live-model");
-    var useRemoteApi = parameters.ContainsKey("use-remote-api");
+    var localStubRequested = parameters.ContainsKey("use-local-stub");
+    var remoteDecision = SmokeTestModeDecider.Decide(options, parameters);
+    var useRemoteApi = remoteDecision.UseRemoteApi;
     var tenantId = GetValue(parameters, "tenant", "contoso.onmicrosoft.com");
     var userId = GetValue(parameters, "user", "user1");
     var threadId = GetValue(parameters, "thread", "message-id");
@@ -434,7 +427,7 @@ static async Task<int> RunReplySmokeAsync(PluginOptions options, IReadOnlyDictio
 
     if (string.IsNullOrWhiteSpace(userAssertion))
     {
-        if (options.Security.UseHmacFallback)
+        if (options.Security.UseHmacFallback || localStubRequested)
         {
             userAssertion = BuildSimulatedUserAssertion(
                 tenantId,
@@ -452,6 +445,15 @@ static async Task<int> RunReplySmokeAsync(PluginOptions options, IReadOnlyDictio
     if (!options.Security.UseHmacFallback)
     {
         PrintGraphScopeReminder(options);
+    }
+
+    if (!useRemoteApi && remoteDecision.LocalStubRequested && remoteDecision.AutoConditionMet)
+    {
+        Console.WriteLine("提示：检测到 --use-local-stub，本次命令将忽略自动触发的远程 API 条件并继续使用本地 Stub 管道。");
+    }
+    else if (useRemoteApi && remoteDecision.IsAutomatic && !string.IsNullOrWhiteSpace(remoteDecision.Reason))
+    {
+        Console.WriteLine($"提示：{remoteDecision.Reason}，已自动启用远程 API 模式。如需继续使用本地 Stub，请追加 --use-local-stub。");
     }
 
     var additionalTargets = options.DefaultTargetLanguages
@@ -480,7 +482,7 @@ static async Task<int> RunReplySmokeAsync(PluginOptions options, IReadOnlyDictio
     if (useRemoteApi)
     {
         var baseUrl = GetValue(parameters, "baseUrl", "https://localhost:5001");
-        return await RunRemoteReplySmokeAsync(
+        return await RemoteReplySmokeRunner.RunAsync(
             baseUrl,
             translationRequest,
             tone,
@@ -727,255 +729,6 @@ static async Task<int> RunReplySmokeAsync(PluginOptions options, IReadOnlyDictio
 
     return 0;
 }
-
-static async Task<int> RunRemoteReplySmokeAsync(
-    string baseUrl,
-    TranslationRequest translationRequest,
-    string tone,
-    IReadOnlyList<string> additionalTargets,
-    CancellationToken cancellationToken)
-{
-    if (string.IsNullOrWhiteSpace(translationRequest.UserAssertion))
-    {
-        Console.Error.WriteLine("远程模式需要提供用户断言 (--assertion <jwt>)。");
-        return 13;
-    }
-
-    if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri))
-    {
-        Console.Error.WriteLine($"无效的 baseUrl: {baseUrl}");
-        return 14;
-    }
-
-    using var httpClient = new HttpClient
-    {
-        BaseAddress = baseUri
-    };
-    httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", translationRequest.UserAssertion);
-
-    Console.WriteLine($"远程 API 模式已启用，目标服务: {baseUri}");
-
-    HttpResponseMessage translateResponse;
-    try
-    {
-        translateResponse = await httpClient.PostAsJsonAsync("/api/translate", translationRequest, RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
-    }
-    catch (Exception ex)
-    {
-        Console.Error.WriteLine("调用远程 /api/translate 失败: " + ex.Message);
-        return 3;
-    }
-
-    if (!translateResponse.IsSuccessStatusCode)
-    {
-        return await ReportRemoteFailureAsync(translateResponse, "/api/translate", 3, cancellationToken).ConfigureAwait(false);
-    }
-
-    TranslationResult? translation;
-    try
-    {
-        translation = await translateResponse.Content.ReadFromJsonAsync<TranslationResult>(RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
-    }
-    catch (Exception ex)
-    {
-        Console.Error.WriteLine("解析远程翻译响应失败: " + ex.Message);
-        return 3;
-    }
-
-    if (translation is null)
-    {
-        Console.Error.WriteLine("远程翻译响应为空。");
-        return 3;
-    }
-
-    Console.WriteLine("远程翻译完成:");
-    Console.WriteLine($"  ModelId:       {translation.ModelId}");
-    Console.WriteLine($"  TargetLanguage: {translation.TargetLanguage}");
-    Console.WriteLine($"  LatencyMs:     {translation.LatencyMs}");
-    Console.WriteLine($"  CostUsd:       {translation.CostUsd}");
-    Console.WriteLine($"  Text:          {translation.TranslatedText}");
-
-    if (additionalTargets.Count > 0)
-    {
-        if (translation.AdditionalTranslations.Count == 0)
-        {
-            Console.Error.WriteLine("远程翻译响应缺少附加语种输出。");
-            return 8;
-        }
-
-        foreach (var language in additionalTargets)
-        {
-            if (!translation.AdditionalTranslations.ContainsKey(language))
-            {
-                Console.Error.WriteLine($"远程翻译未包含 {language} 的附加译文。");
-                return 9;
-            }
-        }
-    }
-
-    var replyRequest = new ReplyRequest
-    {
-        ThreadId = translationRequest.ThreadId,
-        ReplyText = translation.TranslatedText,
-        Text = translation.TranslatedText,
-        TenantId = translationRequest.TenantId,
-        UserId = translationRequest.UserId,
-        ChannelId = translationRequest.ChannelId,
-        UiLocale = translation.UiLocale,
-        LanguagePolicy = new ReplyLanguagePolicy
-        {
-            TargetLang = translation.TargetLanguage,
-            Tone = tone
-        },
-        AdditionalTargetLanguages = new List<string>(additionalTargets),
-        UserAssertion = translationRequest.UserAssertion
-    };
-
-    HttpResponseMessage replyResponse;
-    try
-    {
-        replyResponse = await httpClient.PostAsJsonAsync("/api/reply", replyRequest, RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
-    }
-    catch (Exception ex)
-    {
-        Console.Error.WriteLine("调用远程 /api/reply 失败: " + ex.Message);
-        return 4;
-    }
-
-    if (!replyResponse.IsSuccessStatusCode)
-    {
-        return await ReportRemoteFailureAsync(replyResponse, "/api/reply", 4, cancellationToken).ConfigureAwait(false);
-    }
-
-    ReplyResult? replyResult;
-    try
-    {
-        replyResult = await replyResponse.Content.ReadFromJsonAsync<ReplyResult>(RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
-    }
-    catch (Exception ex)
-    {
-        Console.Error.WriteLine("解析远程回帖响应失败: " + ex.Message);
-        return 4;
-    }
-
-    if (replyResult is null)
-    {
-        Console.Error.WriteLine("远程回帖响应为空。");
-        return 4;
-    }
-
-    Console.WriteLine("远程回帖完成:");
-    Console.WriteLine($"  MessageId: {replyResult.MessageId}");
-    Console.WriteLine($"  Status:    {replyResult.Status}");
-    Console.WriteLine($"  Language:  {replyResult.Language}");
-
-    UsageMetricsReport? metricsReport;
-    try
-    {
-        using var metricsResponse = await httpClient.GetAsync("/api/metrics", cancellationToken).ConfigureAwait(false);
-        if (!metricsResponse.IsSuccessStatusCode)
-        {
-            return await ReportRemoteFailureAsync(metricsResponse, "/api/metrics", 5, cancellationToken).ConfigureAwait(false);
-        }
-
-        metricsReport = await metricsResponse.Content.ReadFromJsonAsync<UsageMetricsReport>(RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
-    }
-    catch (Exception ex)
-    {
-        Console.Error.WriteLine("调用远程 /api/metrics 失败: " + ex.Message);
-        return 5;
-    }
-
-    if (metricsReport is null)
-    {
-        Console.Error.WriteLine("远程指标响应为空。");
-        return 5;
-    }
-
-    var tenantMetrics = metricsReport.Tenants.FirstOrDefault(t => string.Equals(t.TenantId, translationRequest.TenantId, StringComparison.OrdinalIgnoreCase));
-    if (tenantMetrics is null || tenantMetrics.Translations == 0)
-    {
-        Console.Error.WriteLine("远程指标中未找到当前租户的成功记录。");
-        return 5;
-    }
-
-    Console.WriteLine("使用指标摘要:");
-    Console.WriteLine(JsonSerializer.Serialize(metricsReport, PrettyJsonOptions));
-    Console.WriteLine();
-
-    JsonArray? auditArray;
-    try
-    {
-        using var auditResponse = await httpClient.GetAsync("/api/audit", cancellationToken).ConfigureAwait(false);
-        if (!auditResponse.IsSuccessStatusCode)
-        {
-            return await ReportRemoteFailureAsync(auditResponse, "/api/audit", 6, cancellationToken).ConfigureAwait(false);
-        }
-
-        var payload = await auditResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        auditArray = JsonNode.Parse(payload) as JsonArray;
-    }
-    catch (Exception ex)
-    {
-        Console.Error.WriteLine("调用远程 /api/audit 失败: " + ex.Message);
-        return 6;
-    }
-
-    if (auditArray is null || auditArray.Count == 0)
-    {
-        Console.Error.WriteLine("远程审计日志为空。");
-        return 6;
-    }
-
-    var hasTenantLog = auditArray
-        .Select(node => node as JsonObject)
-        .Any(entry => string.Equals(entry?["tenantId"]?.GetValue<string>(), translationRequest.TenantId, StringComparison.OrdinalIgnoreCase));
-
-    if (!hasTenantLog)
-    {
-        Console.Error.WriteLine("远程审计日志未记录当前租户。");
-        return 6;
-    }
-
-    Console.WriteLine("审计记录样例:");
-    foreach (var entry in auditArray)
-    {
-        if (entry is JsonObject obj)
-        {
-            Console.WriteLine(obj.ToJsonString(PrettyJsonOptions));
-        }
-        else
-        {
-            Console.WriteLine(entry?.ToJsonString(PrettyJsonOptions) ?? "null");
-        }
-    }
-
-    return 0;
-}
-
-static async Task<int> ReportRemoteFailureAsync(HttpResponseMessage response, string endpoint, int defaultExitCode, CancellationToken cancellationToken)
-{
-    var exitCode = MapRemoteStatusToExitCode(response.StatusCode, defaultExitCode);
-    var payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-    Console.Error.WriteLine($"远程 {endpoint} 返回 {(int)response.StatusCode} {response.StatusCode}，退出码 {exitCode}。");
-    if (!string.IsNullOrWhiteSpace(payload))
-    {
-        Console.Error.WriteLine(payload);
-    }
-
-    return exitCode;
-}
-
-static int MapRemoteStatusToExitCode(HttpStatusCode statusCode, int fallback)
-    => statusCode switch
-    {
-        HttpStatusCode.Unauthorized => 21,
-        HttpStatusCode.Forbidden => 22,
-        HttpStatusCode.TooManyRequests => 23,
-        HttpStatusCode.PaymentRequired => 24,
-        HttpStatusCode.ServiceUnavailable => 25,
-        _ => fallback
-    };
 
 static async Task<int> RunMetricsProbeAsync(IReadOnlyDictionary<string, string?> parameters, CancellationToken cancellationToken)
 {

--- a/scripts/SmokeTests/Stage5SmokeTests/Properties/AssemblyInfo.cs
+++ b/scripts/SmokeTests/Stage5SmokeTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("TlaPlugin.Tests")]

--- a/scripts/SmokeTests/Stage5SmokeTests/README.md
+++ b/scripts/SmokeTests/Stage5SmokeTests/README.md
@@ -1,6 +1,6 @@
 # Stage5SmokeTests 自测指南
 
-本文档说明如何验证 `reply` 命令在默认离线模式与新增的 `--use-remote-api` 模式下均能正常运行，以便在修改脚本后快速自测。
+本文档说明如何验证 `reply` 命令在默认离线模式与远程 API 模式下均能正常运行。脚本会在 `Plugin.Security.UseHmacFallback=false` 或显式提供 `--baseUrl` 时自动切换到远程 API，可使用新增的 `--use-local-stub` 参数强制回退至本地 Stub。
 
 ## 前置准备
 
@@ -63,15 +63,17 @@ PY
      --thread smoke-thread \
      --language ja \
      --text "Stage 5 远程验证" \
-     --use-remote-api \
+     --baseUrl https://localhost:5001 \
      --assertion "$ASSERTION"
    ```
 
 预期输出：
 
-- `远程 API 模式已启用` 提示以及翻译、回帖响应摘要；
+- `远程 API 模式已启用` 提示以及翻译、回帖响应摘要；若同时加载 Stage 配置（`--override appsettings.Stage.json`），因 `UseHmacFallback=false` 会自动进入远程模式；
 - `/api/metrics` 与 `/api/audit` 的 JSON 片段，且包含当前租户的记录；
 - 若远程接口返回 401/403/429，会打印对应的退出码（21/22/23），便于快速定位权限或配额问题。
+
+如需在 Stage 配置下继续使用本地 Stub，可在命令末尾追加 `--use-local-stub`，脚本会提示已忽略自动远程条件。
 
 ## 常见问题排查
 

--- a/scripts/SmokeTests/Stage5SmokeTests/RemoteReplySmokeRunner.cs
+++ b/scripts/SmokeTests/Stage5SmokeTests/RemoteReplySmokeRunner.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using TlaPlugin.Models;
+
+internal static class RemoteReplySmokeRunner
+{
+    static readonly JsonSerializerOptions RemoteSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    static readonly JsonSerializerOptions PrettyJsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    internal static async Task<int> RunAsync(
+        string baseUrl,
+        TranslationRequest translationRequest,
+        string tone,
+        IReadOnlyList<string> additionalTargets,
+        CancellationToken cancellationToken,
+        HttpMessageHandler? messageHandler = null)
+    {
+        if (string.IsNullOrWhiteSpace(translationRequest.UserAssertion))
+        {
+            Console.Error.WriteLine("远程模式需要提供用户断言 (--assertion <jwt>)。");
+            return 13;
+        }
+
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri))
+        {
+            Console.Error.WriteLine($"无效的 baseUrl: {baseUrl}");
+            return 14;
+        }
+
+        using var httpClient = messageHandler is null
+            ? new HttpClient { BaseAddress = baseUri }
+            : new HttpClient(messageHandler) { BaseAddress = baseUri };
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", translationRequest.UserAssertion);
+
+        Console.WriteLine($"远程 API 模式已启用，目标服务: {baseUri}");
+
+        HttpResponseMessage translateResponse;
+        try
+        {
+            translateResponse = await httpClient.PostAsJsonAsync("/api/translate", translationRequest, RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("调用远程 /api/translate 失败: " + ex.Message);
+            return 3;
+        }
+
+        if (!translateResponse.IsSuccessStatusCode)
+        {
+            return await ReportRemoteFailureAsync(translateResponse, "/api/translate", 3, cancellationToken).ConfigureAwait(false);
+        }
+
+        TranslationResult? translation;
+        try
+        {
+            translation = await translateResponse.Content.ReadFromJsonAsync<TranslationResult>(RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("解析远程翻译响应失败: " + ex.Message);
+            return 3;
+        }
+
+        if (translation is null)
+        {
+            Console.Error.WriteLine("远程翻译响应为空。");
+            return 3;
+        }
+
+        Console.WriteLine("远程翻译完成:");
+        Console.WriteLine($"  ModelId:       {translation.ModelId}");
+        Console.WriteLine($"  TargetLanguage: {translation.TargetLanguage}");
+        Console.WriteLine($"  LatencyMs:     {translation.LatencyMs}");
+        Console.WriteLine($"  CostUsd:       {translation.CostUsd}");
+        Console.WriteLine($"  Text:          {translation.TranslatedText}");
+
+        if (additionalTargets.Count > 0)
+        {
+            if (translation.AdditionalTranslations.Count == 0)
+            {
+                Console.Error.WriteLine("远程翻译响应缺少附加语种输出。");
+                return 8;
+            }
+
+            foreach (var language in additionalTargets)
+            {
+                if (!translation.AdditionalTranslations.ContainsKey(language))
+                {
+                    Console.Error.WriteLine($"远程翻译未包含 {language} 的附加译文。");
+                    return 9;
+                }
+            }
+        }
+
+        var replyRequest = new ReplyRequest
+        {
+            ThreadId = translationRequest.ThreadId,
+            ReplyText = translation.TranslatedText,
+            Text = translation.TranslatedText,
+            TenantId = translationRequest.TenantId,
+            UserId = translationRequest.UserId,
+            ChannelId = translationRequest.ChannelId,
+            UiLocale = translation.UiLocale,
+            LanguagePolicy = new ReplyLanguagePolicy
+            {
+                TargetLang = translation.TargetLanguage,
+                Tone = tone
+            },
+            AdditionalTargetLanguages = new List<string>(additionalTargets),
+            UserAssertion = translationRequest.UserAssertion
+        };
+
+        HttpResponseMessage replyResponse;
+        try
+        {
+            replyResponse = await httpClient.PostAsJsonAsync("/api/reply", replyRequest, RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("调用远程 /api/reply 失败: " + ex.Message);
+            return 4;
+        }
+
+        if (!replyResponse.IsSuccessStatusCode)
+        {
+            return await ReportRemoteFailureAsync(replyResponse, "/api/reply", 4, cancellationToken).ConfigureAwait(false);
+        }
+
+        ReplyResult? replyResult;
+        try
+        {
+            replyResult = await replyResponse.Content.ReadFromJsonAsync<ReplyResult>(RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("解析远程回帖响应失败: " + ex.Message);
+            return 4;
+        }
+
+        if (replyResult is null)
+        {
+            Console.Error.WriteLine("远程回帖响应为空。");
+            return 4;
+        }
+
+        Console.WriteLine("远程回帖完成:");
+        Console.WriteLine($"  MessageId: {replyResult.MessageId}");
+        Console.WriteLine($"  Status:    {replyResult.Status}");
+        Console.WriteLine($"  Language:  {replyResult.Language}");
+
+        UsageMetricsReport? metricsReport;
+        try
+        {
+            using var metricsResponse = await httpClient.GetAsync("/api/metrics", cancellationToken).ConfigureAwait(false);
+            if (!metricsResponse.IsSuccessStatusCode)
+            {
+                return await ReportRemoteFailureAsync(metricsResponse, "/api/metrics", 5, cancellationToken).ConfigureAwait(false);
+            }
+
+            metricsReport = await metricsResponse.Content.ReadFromJsonAsync<UsageMetricsReport>(RemoteSerializerOptions, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("调用远程 /api/metrics 失败: " + ex.Message);
+            return 5;
+        }
+
+        if (metricsReport is null)
+        {
+            Console.Error.WriteLine("远程指标响应为空。");
+            return 5;
+        }
+
+        var tenantMetrics = metricsReport.Tenants.FirstOrDefault(t => string.Equals(t.TenantId, translationRequest.TenantId, StringComparison.OrdinalIgnoreCase));
+        if (tenantMetrics is null || tenantMetrics.Translations == 0)
+        {
+            Console.Error.WriteLine("远程指标中未找到当前租户的成功记录。");
+            return 5;
+        }
+
+        Console.WriteLine("使用指标摘要:");
+        Console.WriteLine(JsonSerializer.Serialize(metricsReport, PrettyJsonOptions));
+        Console.WriteLine();
+
+        JsonArray? auditArray;
+        try
+        {
+            using var auditResponse = await httpClient.GetAsync("/api/audit", cancellationToken).ConfigureAwait(false);
+            if (!auditResponse.IsSuccessStatusCode)
+            {
+                return await ReportRemoteFailureAsync(auditResponse, "/api/audit", 6, cancellationToken).ConfigureAwait(false);
+            }
+
+            var payload = await auditResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            auditArray = JsonNode.Parse(payload) as JsonArray;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("调用远程 /api/audit 失败: " + ex.Message);
+            return 6;
+        }
+
+        if (auditArray is null || auditArray.Count == 0)
+        {
+            Console.Error.WriteLine("远程审计日志为空。");
+            return 6;
+        }
+
+        var hasTenantLog = auditArray
+            .Select(node => node as JsonObject)
+            .Any(entry => string.Equals(entry?["tenantId"]?.GetValue<string>(), translationRequest.TenantId, StringComparison.OrdinalIgnoreCase));
+
+        if (!hasTenantLog)
+        {
+            Console.Error.WriteLine("远程审计日志未记录当前租户。");
+            return 6;
+        }
+
+        Console.WriteLine("审计记录样例:");
+        foreach (var entry in auditArray)
+        {
+            if (entry is JsonObject obj)
+            {
+                Console.WriteLine(obj.ToJsonString(PrettyJsonOptions));
+            }
+            else
+            {
+                Console.WriteLine(entry?.ToJsonString(PrettyJsonOptions) ?? "null");
+            }
+        }
+
+        return 0;
+    }
+
+    static async Task<int> ReportRemoteFailureAsync(HttpResponseMessage response, string endpoint, int defaultExitCode, CancellationToken cancellationToken)
+    {
+        var exitCode = MapRemoteStatusToExitCode(response.StatusCode, defaultExitCode);
+        var payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        Console.Error.WriteLine($"远程 {endpoint} 返回 {(int)response.StatusCode} {response.StatusCode}，退出码 {exitCode}。");
+        if (!string.IsNullOrWhiteSpace(payload))
+        {
+            Console.Error.WriteLine(payload);
+        }
+
+        return exitCode;
+    }
+
+    static int MapRemoteStatusToExitCode(HttpStatusCode statusCode, int fallback)
+        => statusCode switch
+        {
+            HttpStatusCode.Unauthorized => 21,
+            HttpStatusCode.Forbidden => 22,
+            HttpStatusCode.TooManyRequests => 23,
+            HttpStatusCode.PaymentRequired => 24,
+            HttpStatusCode.ServiceUnavailable => 25,
+            _ => fallback
+        };
+}

--- a/scripts/SmokeTests/Stage5SmokeTests/SmokeTestModeDecider.cs
+++ b/scripts/SmokeTests/Stage5SmokeTests/SmokeTestModeDecider.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using TlaPlugin.Configuration;
+
+internal readonly record struct RemoteApiDecision(
+    bool UseRemoteApi,
+    bool IsAutomatic,
+    string? Reason,
+    bool LocalStubRequested,
+    bool AutoConditionMet,
+    bool BaseUrlProvided);
+
+internal static class SmokeTestModeDecider
+{
+    internal static RemoteApiDecision Decide(PluginOptions options, IReadOnlyDictionary<string, string?> parameters)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        var localStubRequested = parameters.ContainsKey("use-local-stub");
+        var remoteRequested = parameters.ContainsKey("use-remote-api");
+        var baseUrlProvided = parameters.ContainsKey("baseUrl");
+        var autoConditionMet = baseUrlProvided || !options.Security.UseHmacFallback;
+
+        if (localStubRequested)
+        {
+            return new RemoteApiDecision(
+                UseRemoteApi: false,
+                IsAutomatic: false,
+                Reason: "--use-local-stub 已覆盖远程模式",
+                LocalStubRequested: true,
+                AutoConditionMet: autoConditionMet,
+                BaseUrlProvided: baseUrlProvided);
+        }
+
+        if (remoteRequested)
+        {
+            return new RemoteApiDecision(
+                UseRemoteApi: true,
+                IsAutomatic: false,
+                Reason: "--use-remote-api 已启用远程模式",
+                LocalStubRequested: false,
+                AutoConditionMet: autoConditionMet,
+                BaseUrlProvided: baseUrlProvided);
+        }
+
+        if (autoConditionMet)
+        {
+            var reason = baseUrlProvided
+                ? "检测到 --baseUrl 参数"
+                : "配置中已禁用 UseHmacFallback";
+            return new RemoteApiDecision(
+                UseRemoteApi: true,
+                IsAutomatic: true,
+                Reason: reason,
+                LocalStubRequested: false,
+                AutoConditionMet: true,
+                BaseUrlProvided: baseUrlProvided);
+        }
+
+        return new RemoteApiDecision(
+            UseRemoteApi: false,
+            IsAutomatic: false,
+            Reason: null,
+            LocalStubRequested: false,
+            AutoConditionMet: false,
+            BaseUrlProvided: baseUrlProvided);
+    }
+}

--- a/tests/TlaPlugin.Tests/Stage5SmokeTests/RemoteReplySmokeRunnerTests.cs
+++ b/tests/TlaPlugin.Tests/Stage5SmokeTests/RemoteReplySmokeRunnerTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using TlaPlugin.Models;
+using Xunit;
+
+namespace TlaPlugin.Tests.Stage5SmokeTests;
+
+public class RemoteReplySmokeRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_PrintsMetricsSummary_WhenRemoteFlowSucceeds()
+    {
+        var handler = new FakeRemoteHandler();
+        var translationRequest = new TranslationRequest
+        {
+            Text = "hello",
+            TargetLanguage = "ja",
+            TenantId = "contoso.onmicrosoft.com",
+            UserId = "user1",
+            ThreadId = "thread-id",
+            Tone = TranslationRequest.DefaultTone,
+            UiLocale = "ja-JP",
+            AdditionalTargetLanguages = new List<string> { "en-US" },
+            UserAssertion = "fake-assertion"
+        };
+
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+        var stdout = new StringWriter(new StringBuilder());
+        var stderr = new StringWriter(new StringBuilder());
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+
+        try
+        {
+            var exitCode = await RemoteReplySmokeRunner.RunAsync(
+                "https://remote.example",
+                translationRequest,
+                "polite",
+                translationRequest.AdditionalTargetLanguages,
+                CancellationToken.None,
+                handler);
+
+            Assert.Equal(0, exitCode);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+        }
+
+        var output = stdout.ToString();
+        Assert.Contains("使用指标摘要:", output);
+        Assert.Contains("\"tenantId\": \"contoso.onmicrosoft.com\"", output);
+        Assert.Contains("审计记录样例:", output);
+        Assert.True(string.IsNullOrEmpty(stderr.ToString()), "Expected stderr to be empty on success.");
+    }
+
+    sealed class FakeRemoteHandler : HttpMessageHandler
+    {
+        static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.AbsolutePath;
+            if (request.Method == HttpMethod.Post && string.Equals(path, "/api/translate", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(CreateJsonResponse(HttpStatusCode.OK, new TranslationResult
+                {
+                    ModelId = "stub-model",
+                    TargetLanguage = "ja",
+                    TranslatedText = "テスト",
+                    UiLocale = "ja-JP",
+                    LatencyMs = 123,
+                    CostUsd = 0.01m,
+                    AdditionalTranslations = new Dictionary<string, string>
+                    {
+                        ["en-US"] = "Test"
+                    }
+                }));
+            }
+
+            if (request.Method == HttpMethod.Post && string.Equals(path, "/api/reply", StringComparison.OrdinalIgnoreCase))
+            {
+                var reply = new ReplyResult("message-1", "Created")
+                {
+                    Language = "ja"
+                };
+                return Task.FromResult(CreateJsonResponse(HttpStatusCode.OK, reply));
+            }
+
+            if (request.Method == HttpMethod.Get && string.Equals(path, "/api/metrics", StringComparison.OrdinalIgnoreCase))
+            {
+                var metrics = new UsageMetricsReport(
+                    new UsageMetricsOverview(1, 0.01m, 123, Array.Empty<UsageFailureSnapshot>()),
+                    new[]
+                    {
+                        new UsageMetricsSnapshot(
+                            "contoso.onmicrosoft.com",
+                            1,
+                            0.01m,
+                            123,
+                            DateTimeOffset.UtcNow,
+                            new[] { new ModelUsageSnapshot("stub-model", 1, 0.01m) },
+                            Array.Empty<UsageFailureSnapshot>())
+                    });
+                return Task.FromResult(CreateJsonResponse(HttpStatusCode.OK, metrics));
+            }
+
+            if (request.Method == HttpMethod.Get && string.Equals(path, "/api/audit", StringComparison.OrdinalIgnoreCase))
+            {
+                var payload = "[{\"tenantId\":\"contoso.onmicrosoft.com\",\"status\":\"Success\"}]";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(payload, Encoding.UTF8, "application/json")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        static HttpResponseMessage CreateJsonResponse<T>(HttpStatusCode statusCode, T value)
+        {
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = JsonContent.Create(value, options: SerializerOptions)
+            };
+        }
+    }
+}

--- a/tests/TlaPlugin.Tests/Stage5SmokeTests/SmokeTestModeDeciderTests.cs
+++ b/tests/TlaPlugin.Tests/Stage5SmokeTests/SmokeTestModeDeciderTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using TlaPlugin.Configuration;
+using Xunit;
+
+namespace TlaPlugin.Tests.Stage5SmokeTests;
+
+public class SmokeTestModeDeciderTests
+{
+    [Fact]
+    public void Decide_AutoRemote_WhenHmacFallbackDisabled()
+    {
+        var options = new PluginOptions
+        {
+            Security =
+            {
+                UseHmacFallback = false
+            }
+        };
+
+        var decision = SmokeTestModeDecider.Decide(options, new Dictionary<string, string?>());
+
+        Assert.True(decision.UseRemoteApi);
+        Assert.True(decision.IsAutomatic);
+        Assert.Equal("配置中已禁用 UseHmacFallback", decision.Reason);
+    }
+
+    [Fact]
+    public void Decide_AutoRemote_WhenBaseUrlProvided()
+    {
+        var options = new PluginOptions();
+        var parameters = new Dictionary<string, string?>
+        {
+            ["baseUrl"] = "https://stage5.example" 
+        };
+
+        var decision = SmokeTestModeDecider.Decide(options, parameters);
+
+        Assert.True(decision.UseRemoteApi);
+        Assert.True(decision.IsAutomatic);
+        Assert.Equal("检测到 --baseUrl 参数", decision.Reason);
+        Assert.True(decision.AutoConditionMet);
+        Assert.True(decision.BaseUrlProvided);
+    }
+
+    [Fact]
+    public void Decide_RespectsLocalStubOverride()
+    {
+        var options = new PluginOptions
+        {
+            Security =
+            {
+                UseHmacFallback = false
+            }
+        };
+
+        var parameters = new Dictionary<string, string?>
+        {
+            ["use-local-stub"] = null,
+            ["baseUrl"] = "https://stage5.example"
+        };
+
+        var decision = SmokeTestModeDecider.Decide(options, parameters);
+
+        Assert.False(decision.UseRemoteApi);
+        Assert.True(decision.LocalStubRequested);
+        Assert.True(decision.AutoConditionMet);
+        Assert.True(decision.BaseUrlProvided);
+    }
+}

--- a/tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj
+++ b/tests/TlaPlugin.Tests/TlaPlugin.Tests.csproj
@@ -20,5 +20,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/TlaPlugin/TlaPlugin.csproj" />
+    <ProjectReference Include="../../scripts/SmokeTests/Stage5SmokeTests/Stage5SmokeTests.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- default the Stage 5 reply smoke test to the remote API when HMAC fallback is disabled or a baseUrl is supplied, while allowing --use-local-stub to force the local pipeline
- extract the remote smoke runner utilities, update usage text, and refresh the README/Runbook guidance
- add unit tests that cover the new mode selection logic and ensure the remote flow prints metrics/audit summaries

## Testing
- `dotnet test` *(fails: dotnet tooling is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df4c4c0ca8832f8315565e7897dab1