### PR TITLE
Load environment-specific appsettings

### DIFF
--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -21,7 +21,11 @@ using TlaPlugin.Teams;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Configuration.AddJsonFile("appsettings.json", optional: true);
+builder.Configuration
+    .AddJsonFile("appsettings.json", optional: true)
+    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true)
+    .AddJsonFile("appsettings.Local.json", optional: true)
+    .AddEnvironmentVariables();
 
 builder.Services.Configure<PluginOptions>(builder.Configuration.GetSection("Plugin"));
 

--- a/tests/TlaPlugin.Tests/Configuration/AppConfigurationTests.cs
+++ b/tests/TlaPlugin.Tests/Configuration/AppConfigurationTests.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using TlaPlugin.Configuration;
+using Xunit;
+
+namespace TlaPlugin.Tests.Configuration;
+
+public class AppConfigurationTests
+{
+    [Fact]
+    public void StageEnvironmentLoadsStageAppSettings()
+    {
+        using var factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseSetting(WebHostDefaults.EnvironmentKey, "Stage");
+            });
+
+        using var scope = factory.Services.CreateScope();
+        var options = scope.ServiceProvider.GetRequiredService<IOptions<PluginOptions>>().Value;
+
+        Assert.NotNull(options.Security);
+        Assert.False(options.Security!.UseHmacFallback);
+
+        var scopes = options.Security.GraphScopes ?? Array.Empty<string>();
+        Assert.Contains("https://graph.microsoft.com/.default", scopes);
+        Assert.Contains("https://graph.microsoft.com/Chat.ReadWrite", scopes);
+    }
+}


### PR DESCRIPTION
## Summary
- load environment-specific and local appsettings files along with environment variables in the plugin host
- add a configuration test to ensure Stage settings are applied when the environment is Stage

## Testing
- Unable to run `dotnet test` (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df4c4b9f40832f93437f876ad7aad3