### PR TITLE
Ensure environment-specific configuration files reload automatically

### DIFF
--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -22,9 +22,9 @@ using TlaPlugin.Teams;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Configuration
-    .AddJsonFile("appsettings.json", optional: true)
-    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true)
-    .AddJsonFile("appsettings.Local.json", optional: true)
+    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+    .AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true)
     .AddEnvironmentVariables();
 
 builder.Services.Configure<PluginOptions>(builder.Configuration.GetSection("Plugin"));


### PR DESCRIPTION
## Summary
- enable reload-on-change for base, environment-specific, and local appsettings files so Stage/Production overrides load correctly

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0aed916d4832faa1f2fd5c9d9e095