### PR TITLE
Allow configuring stage readiness persistence path

### DIFF
--- a/docs/stage5-integration-runbook.md
+++ b/docs/stage5-integration-runbook.md
@@ -178,3 +178,15 @@
    5. 将脚本与命令记录在变更工单或自动化流水线中，便于回归与成本复核。
 
 通过上述步骤，可在 Stage 环境保证 Key Vault、Graph OBO 与观测指标三项能力全部打通，为后续正式上线提供可重复的联调手册。
+
+## 4. Stage 就绪文件持久化
+
+1. **指定共享卷路径** – 为确保阶段就绪状态在重启后仍然保留，可在配置中设置 `Plugin.StageReadinessFilePath` 指向挂载到容器或 App Service 的持久化卷，例如：
+
+   ```bash
+   export TLA_Plugin__StageReadinessFilePath="/mnt/stage/shared/stage-readiness.txt"
+   ```
+
+2. **验证写入权限** – `FileStageReadinessStore` 会在自定义路径下自动创建缺失的目录并写入 ISO-8601 时间戳。请确认部署身份对目标卷具有读写权限，且路径在多个实例间共享，以便 Stage Ready 状态在横向扩展时保持一致。
+
+3. **保留默认回退** – 如果未配置该项，插件会继续使用 `App_Data/stage-readiness.txt` 默认路径，可用于单实例或开发环境。Stage 环境推荐显式指向持久化卷，以避免 Pod/实例重启后阶段状态丢失。【F:src/TlaPlugin/Program.cs†L136-L147】【F:src/TlaPlugin/Services/FileStageReadinessStore.cs†L10-L69】

--- a/src/TlaPlugin/Configuration/PluginOptions.cs
+++ b/src/TlaPlugin/Configuration/PluginOptions.cs
@@ -17,6 +17,7 @@ public class PluginOptions
     public TimeSpan DraftReplayPollingInterval { get; set; } = TimeSpan.FromSeconds(3);
     public int DraftReplayMaxAttempts { get; set; } = 3;
     public string OfflineDraftConnectionString { get; set; } = "Data Source=tla-offline.db";
+    public string? StageReadinessFilePath { get; set; }
     public IList<string> SupportedLanguages { get; set; } = new List<string>
     {
         "ja-JP",

--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -133,7 +133,18 @@ builder.Services.AddSingleton<TranslationCache>();
 builder.Services.AddSingleton<TranslationThrottle>();
 builder.Services.AddSingleton<KeyVaultSecretResolver>();
 builder.Services.AddSingleton<ModelProviderFactory>();
-builder.Services.AddSingleton<IStageReadinessStore, FileStageReadinessStore>();
+builder.Services.AddSingleton<IStageReadinessStore>(provider =>
+{
+    var options = provider.GetService<IOptions<PluginOptions>>();
+    var configuredPath = options?.Value?.StageReadinessFilePath;
+
+    if (!string.IsNullOrWhiteSpace(configuredPath))
+    {
+        return new FileStageReadinessStore(configuredPath!);
+    }
+
+    return new FileStageReadinessStore();
+});
 builder.Services.AddSingleton<UsageMetricsService>();
 builder.Services.AddSingleton<LocalizationCatalogService>();
 builder.Services.AddSingleton<ContextRetrievalService>();

--- a/tests/TlaPlugin.Tests/FileStageReadinessStoreTests.cs
+++ b/tests/TlaPlugin.Tests/FileStageReadinessStoreTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Globalization;
+using System.IO;
+using TlaPlugin.Services;
+using Xunit;
+
+namespace TlaPlugin.Tests;
+
+public class FileStageReadinessStoreTests
+{
+    [Fact]
+    public void WriteAndRead_UsesConfiguredPath()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "tla-plugin-tests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDirectory);
+        var filePath = Path.Combine(tempDirectory, "stage-ready.txt");
+        try
+        {
+            var store = new FileStageReadinessStore(filePath);
+            var timestamp = DateTimeOffset.UtcNow;
+
+            store.WriteLastSuccess(timestamp);
+            var storedValue = File.ReadAllText(filePath);
+            var parsed = DateTimeOffset.Parse(storedValue, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
+            Assert.Equal(timestamp.ToString("O", CultureInfo.InvariantCulture), storedValue.Trim());
+            Assert.Equal(timestamp.ToUnixTimeSeconds(), parsed.ToUnixTimeSeconds());
+            Assert.Equal(timestamp.ToUnixTimeSeconds(), store.ReadLastSuccess()?.ToUnixTimeSeconds());
+        }
+        finally
+        {
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a configurable `StageReadinessFilePath` option for the stage readiness store
- resolve the stage readiness store via DI so a custom path is honored with a fallback to the default location
- document how to bind the readiness file to a persistent volume and add a regression test for the custom path

## Testing
- dotnet test *(fails: `dotnet` not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e122539bb8832fb7273bbfbf265544