### PR TITLE
Add stage five readiness diagnostics to dashboard

### DIFF
--- a/src/TlaPlugin/Models/ProjectStatusSnapshot.cs
+++ b/src/TlaPlugin/Models/ProjectStatusSnapshot.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace TlaPlugin.Models;
 
 /// <summary>
@@ -8,7 +10,8 @@ public record ProjectStatusSnapshot(
     IReadOnlyList<StageStatus> Stages,
     IReadOnlyList<string> NextSteps,
     int OverallCompletionPercent,
-    FrontendProgress Frontend);
+    FrontendProgress Frontend,
+    StageFiveDiagnostics StageFiveDiagnostics);
 
 /// <summary>
 /// 单个开发阶段的状态信息。
@@ -27,3 +30,17 @@ public record FrontendProgress(
     bool DataPlaneReady,
     bool UiImplemented,
     bool IntegrationReady);
+
+/// <summary>
+/// 阶段五（上线准备）的诊断明细，帮助定位阻塞原因。
+/// </summary>
+public record StageFiveDiagnostics(
+    bool StageReady,
+    bool HmacConfigured,
+    string HmacStatus,
+    bool GraphScopesValid,
+    string GraphScopesStatus,
+    bool SmokeTestRecent,
+    string SmokeStatus,
+    DateTimeOffset? LastSmokeSuccess,
+    string? FailureReason);

--- a/src/TlaPlugin/wwwroot/webapp/app.js
+++ b/src/TlaPlugin/wwwroot/webapp/app.js
@@ -15,11 +15,22 @@ const FALLBACK_STATUS = {
     { id: "phase4", name: "阶段 4：前端体验", completed: true },
     { id: "phase5", name: "阶段 5：上线准备", completed: false }
   ],
+  stageFiveDiagnostics: {
+    stageReady: false,
+    hmacConfigured: false,
+    hmacStatus: "仍启用了 HMAC 回退，需要切换到 AAD/OBO",
+    graphScopesValid: false,
+    graphScopesStatus: "Graph 作用域缺失或格式不正确",
+    smokeTestRecent: false,
+    smokeStatus: "尚未记录冒烟成功",
+    lastSmokeSuccess: null,
+    failureReason: "冒烟链路尚未通过"
+  },
   frontend: {
     completionPercent: 80,
     dataPlaneReady: true,
     uiImplemented: true,
-    integrationReady: true
+    integrationReady: false
   }
 };
 
@@ -445,6 +456,44 @@ export function renderSummary(cards, metricsInput = latestMetrics) {
       li.textContent = `${item.label}: ${item.ready ? "已就绪" : "待完成"}`;
       readinessList.appendChild(li);
     });
+  }
+
+  const diagnosticsData = cardData.stageFiveDiagnostics ?? {};
+  const diagnosticsList = document.querySelector("[data-stage-five-diagnostics]");
+  if (diagnosticsList) {
+    diagnosticsList.innerHTML = "";
+    const diagItems = Array.isArray(diagnosticsData.items) ? diagnosticsData.items : [];
+    if (diagItems.length === 0) {
+      const empty = document.createElement("li");
+      empty.className = "diagnostic diagnostic--empty";
+      empty.textContent = "暂无诊断信息";
+      diagnosticsList.appendChild(empty);
+    } else {
+      diagItems.forEach((item) => {
+        const li = document.createElement("li");
+        li.className = `diagnostic ${item.ready ? "diagnostic--ready" : "diagnostic--pending"}`;
+        const label = document.createElement("span");
+        label.className = "diagnostic__label";
+        label.textContent = item.label ?? "";
+        const message = document.createElement("span");
+        message.className = "diagnostic__message";
+        message.textContent = item.message ?? "";
+        li.append(label, message);
+        diagnosticsList.appendChild(li);
+      });
+    }
+  }
+
+  const diagnosticsFailure = document.querySelector("[data-stage-five-failure]");
+  if (diagnosticsFailure) {
+    const failureText = typeof diagnosticsData.failureReason === "string" ? diagnosticsData.failureReason : "";
+    if (failureText) {
+      diagnosticsFailure.textContent = `阻塞原因：${failureText}`;
+      diagnosticsFailure.hidden = false;
+    } else {
+      diagnosticsFailure.textContent = "";
+      diagnosticsFailure.hidden = true;
+    }
   }
 
   const nextSteps = document.querySelector("[data-next-steps]");

--- a/src/TlaPlugin/wwwroot/webapp/index.html
+++ b/src/TlaPlugin/wwwroot/webapp/index.html
@@ -30,6 +30,11 @@
             <h2>当前阶段</h2>
             <h3 data-active-stage-title>阶段加载中</h3>
             <p data-active-stage-body>正在同步阶段目标...</p>
+            <h4>阶段诊断</h4>
+            <ul class="diagnostics" data-stage-five-diagnostics>
+              <li class="diagnostic diagnostic--empty">正在收集诊断...</li>
+            </ul>
+            <p class="diagnostic__failure" data-stage-five-failure hidden></p>
             <h4>下一步</h4>
             <ul class="next-steps" data-next-steps></ul>
           </article>

--- a/src/TlaPlugin/wwwroot/webapp/styles.css
+++ b/src/TlaPlugin/wwwroot/webapp/styles.css
@@ -229,6 +229,53 @@ body {
   margin-right: 8px;
 }
 
+.diagnostics {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.diagnostic {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.diagnostic--ready {
+  border: 1px solid rgba(118, 224, 160, 0.35);
+  color: #76e0a0;
+}
+
+.diagnostic--pending {
+  border: 1px solid rgba(255, 152, 67, 0.35);
+  color: #ffc861;
+}
+
+.diagnostic__label {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.diagnostic__message {
+  flex: 1;
+  text-align: right;
+}
+
+.diagnostic__failure {
+  margin: 0;
+  font-size: 13px;
+  color: #ff9a9a;
+  font-weight: 600;
+}
+
 .timeline {
   display: grid;
   gap: 16px;

--- a/src/webapp/app.js
+++ b/src/webapp/app.js
@@ -16,6 +16,17 @@ const FALLBACK_STATUS = {
     { id: "phase4", name: "阶段 4：前端体验", completed: true },
     { id: "phase5", name: "阶段 5：上线准备", completed: false }
   ],
+  stageFiveDiagnostics: {
+    stageReady: false,
+    hmacConfigured: false,
+    hmacStatus: "仍启用了 HMAC 回退，需要切换到 AAD/OBO",
+    graphScopesValid: false,
+    graphScopesStatus: "Graph 作用域缺失或格式不正确",
+    smokeTestRecent: false,
+    smokeStatus: "尚未记录冒烟成功",
+    lastSmokeSuccess: null,
+    failureReason: "冒烟链路尚未通过"
+  },
   frontend: {
     completionPercent: 80,
     dataPlaneReady: true,
@@ -446,6 +457,44 @@ export function renderSummary(cards, metricsInput = latestMetrics) {
       li.textContent = `${item.label}: ${item.ready ? "已就绪" : "待完成"}`;
       readinessList.appendChild(li);
     });
+  }
+
+  const diagnosticsData = cardData.stageFiveDiagnostics ?? {};
+  const diagnosticsList = document.querySelector("[data-stage-five-diagnostics]");
+  if (diagnosticsList) {
+    diagnosticsList.innerHTML = "";
+    const diagItems = Array.isArray(diagnosticsData.items) ? diagnosticsData.items : [];
+    if (diagItems.length === 0) {
+      const empty = document.createElement("li");
+      empty.className = "diagnostic diagnostic--empty";
+      empty.textContent = "暂无诊断信息";
+      diagnosticsList.appendChild(empty);
+    } else {
+      diagItems.forEach((item) => {
+        const li = document.createElement("li");
+        li.className = `diagnostic ${item.ready ? "diagnostic--ready" : "diagnostic--pending"}`;
+        const label = document.createElement("span");
+        label.className = "diagnostic__label";
+        label.textContent = item.label ?? "";
+        const message = document.createElement("span");
+        message.className = "diagnostic__message";
+        message.textContent = item.message ?? "";
+        li.append(label, message);
+        diagnosticsList.appendChild(li);
+      });
+    }
+  }
+
+  const diagnosticsFailure = document.querySelector("[data-stage-five-failure]");
+  if (diagnosticsFailure) {
+    const failureText = typeof diagnosticsData.failureReason === "string" ? diagnosticsData.failureReason : "";
+    if (failureText) {
+      diagnosticsFailure.textContent = `阻塞原因：${failureText}`;
+      diagnosticsFailure.hidden = false;
+    } else {
+      diagnosticsFailure.textContent = "";
+      diagnosticsFailure.hidden = true;
+    }
   }
 
   const nextSteps = document.querySelector("[data-next-steps]");

--- a/src/webapp/index.html
+++ b/src/webapp/index.html
@@ -30,6 +30,11 @@
             <h2>当前阶段</h2>
             <h3 data-active-stage-title>阶段加载中</h3>
             <p data-active-stage-body>正在同步阶段目标...</p>
+            <h4>阶段诊断</h4>
+            <ul class="diagnostics" data-stage-five-diagnostics>
+              <li class="diagnostic diagnostic--empty">正在收集诊断...</li>
+            </ul>
+            <p class="diagnostic__failure" data-stage-five-failure hidden></p>
             <h4>下一步</h4>
             <ul class="next-steps" data-next-steps></ul>
           </article>

--- a/src/webapp/styles.css
+++ b/src/webapp/styles.css
@@ -229,6 +229,53 @@ body {
   margin-right: 8px;
 }
 
+.diagnostics {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.diagnostic {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.diagnostic--ready {
+  border: 1px solid rgba(118, 224, 160, 0.35);
+  color: #76e0a0;
+}
+
+.diagnostic--pending {
+  border: 1px solid rgba(255, 152, 67, 0.35);
+  color: #ffc861;
+}
+
+.diagnostic__label {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.diagnostic__message {
+  flex: 1;
+  text-align: right;
+}
+
+.diagnostic__failure {
+  margin: 0;
+  font-size: 13px;
+  color: #ff9a9a;
+  font-weight: 600;
+}
+
 .timeline {
   display: grid;
   gap: 16px;

--- a/src/webapp/viewModel.js
+++ b/src/webapp/viewModel.js
@@ -16,6 +16,76 @@ function normalizeStages(stages) {
     }));
 }
 
+function parseDateOrNull(value) {
+  if (value instanceof Date) {
+    return Number.isNaN(value.valueOf()) ? null : value;
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.valueOf()) ? null : parsed;
+  }
+
+  return null;
+}
+
+function ensureMessage(text, ready, successFallback, failureFallback) {
+  if (typeof text === "string" && text.trim() !== "") {
+    return text;
+  }
+  return ready ? successFallback : failureFallback;
+}
+
+function normalizeStageFiveDiagnostics(raw) {
+  if (!raw || typeof raw !== "object") {
+    return {
+      stageReady: false,
+      failureReason: "",
+      smokeStatus: "",
+      lastSmokeSuccess: null,
+      items: []
+    };
+  }
+
+  const stageReady = Boolean(raw.stageReady ?? raw.StageReady);
+  const failureReason = raw.failureReason ?? raw.FailureReason ?? "";
+  const smokeStatus = raw.smokeStatus ?? raw.SmokeStatus ?? "";
+  const lastSmokeSuccess = parseDateOrNull(raw.lastSmokeSuccess ?? raw.LastSmokeSuccess);
+
+  const hmacReady = Boolean(raw.hmacConfigured ?? raw.HmacConfigured);
+  const graphReady = Boolean(raw.graphScopesValid ?? raw.GraphScopesValid);
+  const smokeReady = Boolean(raw.smokeTestRecent ?? raw.SmokeTestRecent);
+
+  const items = [
+    {
+      id: "hmac",
+      label: "HMAC 配置",
+      ready: hmacReady,
+      message: ensureMessage(raw.hmacStatus ?? raw.HmacStatus, hmacReady, "HMAC 回退已关闭", "仍依赖 HMAC 回退")
+    },
+    {
+      id: "graph",
+      label: "Graph 作用域",
+      ready: graphReady,
+      message: ensureMessage(raw.graphScopesStatus ?? raw.GraphScopesStatus, graphReady, "Graph 作用域已就绪", "Graph 作用域待补齐")
+    },
+    {
+      id: "smoke",
+      label: "冒烟测试",
+      ready: smokeReady,
+      message: ensureMessage(smokeStatus, smokeReady, "冒烟测试在可接受窗口内", "冒烟测试需重新执行")
+    }
+  ];
+
+  return {
+    stageReady,
+    failureReason: typeof failureReason === "string" ? failureReason : "",
+    smokeStatus,
+    lastSmokeSuccess,
+    items
+  };
+}
+
 export function groupStagesForTimeline(stages, activeStageId) {
   const normalized = normalizeStages(stages);
   return normalized.map((stage, index) => {
@@ -68,6 +138,7 @@ export function buildStatusCards(status, roadmap) {
       : Math.round((completedCount / timeline.length) * 100);
   const frontend = safeStatus.frontend ?? {};
   const activeStage = timeline.find((stage) => stage.isActive) ?? timeline.find((stage) => !stage.completed) ?? timeline[timeline.length - 1] ?? null;
+  const stageFiveDiagnostics = normalizeStageFiveDiagnostics(safeStatus.stageFiveDiagnostics ?? safeStatus.StageFiveDiagnostics);
 
   return {
     timeline,
@@ -80,7 +151,8 @@ export function buildStatusCards(status, roadmap) {
       uiImplemented: Boolean(frontend.uiImplemented),
       integrationReady: Boolean(frontend.integrationReady)
     },
-    tests: Array.isArray(safeRoadmap.tests) ? safeRoadmap.tests : []
+    tests: Array.isArray(safeRoadmap.tests) ? safeRoadmap.tests : [],
+    stageFiveDiagnostics
   };
 }
 

--- a/tests/dashboardMetrics.render.test.js
+++ b/tests/dashboardMetrics.render.test.js
@@ -13,6 +13,8 @@ test("renderSummary populates metrics blocks", (t) => {
       <div class="progress" data-frontend-progress><span>0%</span></div>
       <p data-frontend-text></p>
       <ul data-readiness></ul>
+      <ul data-stage-five-diagnostics></ul>
+      <p data-stage-five-failure hidden></p>
       <ul data-next-steps></ul>
       <h3 data-active-stage-title></h3>
       <p data-active-stage-body></p>
@@ -47,7 +49,15 @@ test("renderSummary populates metrics blocks", (t) => {
     overallPercent: 80,
     frontend: { completionPercent: 80, dataPlaneReady: true, uiImplemented: true, integrationReady: true },
     nextSteps: ["密钥映射 Runbook"],
-    activeStage: { name: "阶段 5", objective: "上线准备" }
+    activeStage: { name: "阶段 5", objective: "上线准备" },
+    stageFiveDiagnostics: {
+      failureReason: "最近一次冒烟 40 小时前，需要重新执行",
+      items: [
+        { id: "hmac", label: "HMAC 配置", ready: true, message: "HMAC 回退已关闭" },
+        { id: "graph", label: "Graph 作用域", ready: true, message: "Graph 作用域已就绪" },
+        { id: "smoke", label: "冒烟测试", ready: false, message: "最近一次冒烟 40 小时前，需要重新执行" }
+      ]
+    }
   };
 
   const metrics = normalizeMetrics({
@@ -74,6 +84,14 @@ test("renderSummary populates metrics blocks", (t) => {
   const failureItems = document.querySelectorAll("[data-failure-reasons] li");
   assert.equal(failureItems.length, 2);
   assert.equal(failureItems[0].querySelector(".metrics__reason").textContent, "RateLimitExceeded");
+
+  const diagnosticItems = document.querySelectorAll("[data-stage-five-diagnostics] li");
+  assert.equal(diagnosticItems.length, 3);
+  assert.ok(diagnosticItems[2].textContent.includes("冒烟测试"));
+
+  const diagnosticFailure = document.querySelector("[data-stage-five-failure]");
+  assert.equal(diagnosticFailure.hidden, false);
+  assert.ok(diagnosticFailure.textContent.includes("阻塞原因"));
 
   const updatedLabel = document.querySelector("[data-metrics-updated]").textContent;
   assert.match(updatedLabel, /^最近更新：/);

--- a/tests/dashboardViewModel.test.js
+++ b/tests/dashboardViewModel.test.js
@@ -23,6 +23,17 @@ test("buildStatusCards merges roadmap and status information", () => {
     overallCompletionPercent: 100,
     frontend: { completionPercent: 100, dataPlaneReady: true, uiImplemented: true, integrationReady: true },
     nextSteps: ["发布清单"],
+    stageFiveDiagnostics: {
+      stageReady: true,
+      hmacConfigured: true,
+      hmacStatus: "HMAC 回退已关闭",
+      graphScopesValid: true,
+      graphScopesStatus: "Graph 作用域已就绪",
+      smokeTestRecent: true,
+      smokeStatus: "冒烟 2 小时前通过",
+      failureReason: "",
+      lastSmokeSuccess: "2024-03-20T02:00:00Z"
+    },
     stages: [
       { id: "phase1", name: "阶段 1", completed: true },
       { id: "phase5", name: "阶段 5", completed: true }
@@ -48,6 +59,9 @@ test("buildStatusCards merges roadmap and status information", () => {
   assert.equal(phase5.progress, 100);
   assert.deepEqual(cards.nextSteps, ["发布清单"]);
   assert.equal(cards.overallPercent, 100);
+  assert.equal(cards.stageFiveDiagnostics.items.length, 3);
+  assert.equal(cards.stageFiveDiagnostics.failureReason, "");
+  assert.equal(cards.stageFiveDiagnostics.items[0].ready, true);
 });
 
 test("formatLocaleOptions sorts locales alphabetically", () => {


### PR DESCRIPTION
## Summary
- add stage five diagnostics to the status snapshot so HMAC, Graph scope, and smoke test checks surface their state and failure reasons
- expose the diagnostics on the Teams dashboard, including markup and styles for the new readiness list
- update client tests to cover the new diagnostics flow and ensure rendering stays stable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e122517b0c832fb6c982efee9aa93c