### PR TITLE
Ensure usage metrics writes stage readiness

### DIFF
--- a/src/TlaPlugin/Program.cs
+++ b/src/TlaPlugin/Program.cs
@@ -145,7 +145,11 @@ builder.Services.AddSingleton<IStageReadinessStore>(provider =>
 
     return new FileStageReadinessStore();
 });
-builder.Services.AddSingleton<UsageMetricsService>();
+builder.Services.AddSingleton(provider =>
+{
+    var stageReadinessStore = provider.GetRequiredService<IStageReadinessStore>();
+    return new UsageMetricsService(stageReadinessStore);
+});
 builder.Services.AddSingleton<LocalizationCatalogService>();
 builder.Services.AddSingleton<ContextRetrievalService>();
 builder.Services.AddSingleton<TranslationRouter>();


### PR DESCRIPTION
## Summary
- resolve UsageMetricsService registration via factory to inject the stage readiness store
- update project status service tests to exercise usage metrics with persistence and cover recent success diagnostics

## Testing
- ⚠️ `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e135e88cb4832faa5737b8210b37d8