### PR TITLE
Add Stage5 smoke test remote runners

### DIFF
--- a/docs/stage5-integration-runbook.md
+++ b/docs/stage5-integration-runbook.md
@@ -120,6 +120,55 @@
 
    远程模式运行成功时会输出远端返回的翻译摘要、回帖结果、`/api/metrics` 与 `/api/audit` JSON 片段；如遇 401/403/429 等状态，脚本会打印 `21/22/23` 等退出码帮助定位鉴权或配额问题。与离线模式不同，此时不再显示本地 Graph 诊断信息，而是复用远程响应作为调试依据。若需要短暂关闭自动远程（例如在 Stage 配置下测试 Stub），可在命令末尾追加 `--use-local-stub`，脚本会提示已忽略自动触发条件。
 
+   ```text
+   [ModeDecider] 检测到 --use-remote-api 参数
+   [Remote] /api/translate 调用成功:
+     ModelId:   gpt4-stage
+     Language:  ja-JP
+     Latency:   123 ms
+     CostUsd:   0.1500
+     Response:  こちらは Stage5 の远程调用示例。
+
+   [Remote] /api/reply 调用成功:
+     MessageId: 19:stage-thread@thread.tacv2;messageid
+     Status:    Created
+     Language:  ja-JP
+     Tone:      business
+
+   使用指标摘要:
+   {
+     "overall": {
+       "translations": 42,
+       "totalCostUsd": 6.3,
+       "averageLatencyMs": 310,
+       "failures": []
+     },
+     "tenants": [
+       {
+         "tenantId": "contoso.onmicrosoft.com",
+         "translations": 5,
+         "totalCostUsd": 0.75,
+         "averageLatencyMs": 280,
+         "lastUpdated": "2024-03-12T02:11:34.123Z",
+         "models": [
+           { "modelId": "gpt4-stage", "translations": 5, "totalCostUsd": 0.75 }
+         ],
+         "failures": []
+       }
+     ]
+   }
+
+   审计记录样例:
+   [
+     {
+       "tenantId": "contoso.onmicrosoft.com",
+       "status": "Success",
+       "language": "ja-JP",
+       "toneApplied": "business"
+     }
+   ]
+   ```
+
    成功运行后，控制台会打印一次 Graph 请求与指标快照，可用于变更记录留痕：
 
    ```text

--- a/scripts/SmokeTests/Stage5SmokeTests/RemoteReplySmokeRunner.cs
+++ b/scripts/SmokeTests/Stage5SmokeTests/RemoteReplySmokeRunner.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using TlaPlugin.Models;
+
+public static class RemoteReplySmokeRunner
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    public static async Task<int> RunAsync(
+        string baseUrl,
+        TranslationRequest translationRequest,
+        string? tone,
+        IEnumerable<string> additionalLanguages,
+        CancellationToken cancellationToken,
+        HttpMessageHandler? handler = null)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new ArgumentException("baseUrl 不能为空。", nameof(baseUrl));
+        }
+
+        if (translationRequest is null)
+        {
+            throw new ArgumentNullException(nameof(translationRequest));
+        }
+
+        if (string.IsNullOrWhiteSpace(translationRequest.UserAssertion))
+        {
+            throw new ArgumentException("远程模式需要用户断言以填充 Authorization 头。", nameof(translationRequest));
+        }
+
+        using var httpClient = handler is null
+            ? new HttpClient()
+            : new HttpClient(handler, disposeHandler: false);
+
+        httpClient.BaseAddress = new Uri(baseUrl, UriKind.Absolute);
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", translationRequest.UserAssertion);
+
+        var translateResponse = await httpClient.PostAsJsonAsync("/api/translate", translationRequest, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(translateResponse, "POST /api/translate", cancellationToken).ConfigureAwait(false);
+
+        var translation = await translateResponse.Content.ReadFromJsonAsync<TranslationResult>(SerializerOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("远程 /api/translate 返回了空响应。");
+
+        Console.WriteLine("[Remote] /api/translate 调用成功:");
+        Console.WriteLine($"  ModelId:   {translation.ModelId}");
+        Console.WriteLine($"  Language:  {translation.TargetLanguage}");
+        Console.WriteLine($"  Latency:   {translation.LatencyMs} ms");
+        Console.WriteLine($"  CostUsd:   {translation.CostUsd:F4}");
+        Console.WriteLine($"  Response:  {translation.TranslatedText}");
+
+        var replyRequest = BuildReplyRequest(translationRequest, translation, tone, additionalLanguages);
+        var replyResponse = await httpClient.PostAsJsonAsync("/api/reply", replyRequest, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(replyResponse, "POST /api/reply", cancellationToken).ConfigureAwait(false);
+
+        var reply = await replyResponse.Content.ReadFromJsonAsync<ReplyResult>(SerializerOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("远程 /api/reply 返回了空响应。");
+
+        Console.WriteLine();
+        Console.WriteLine("[Remote] /api/reply 调用成功:");
+        Console.WriteLine($"  MessageId: {reply.MessageId}");
+        Console.WriteLine($"  Status:    {reply.Status}");
+        Console.WriteLine($"  Language:  {reply.Language}");
+        Console.WriteLine($"  Tone:      {reply.ToneApplied ?? tone ?? TranslationRequest.DefaultTone}");
+
+        var metrics = await httpClient.GetFromJsonAsync<UsageMetricsReport>("/api/metrics", SerializerOptions, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("远程 /api/metrics 返回了空响应。");
+
+        var auditRaw = await httpClient.GetStringAsync("/api/audit", cancellationToken).ConfigureAwait(false);
+        using var auditDocument = JsonDocument.Parse(auditRaw);
+
+        Console.WriteLine();
+        Console.WriteLine("使用指标摘要:");
+        Console.WriteLine(JsonSerializer.Serialize(metrics, SerializerOptions));
+
+        Console.WriteLine();
+        Console.WriteLine("审计记录样例:");
+        Console.WriteLine(JsonSerializer.Serialize(auditDocument.RootElement, SerializerOptions));
+
+        return 0;
+    }
+
+    private static ReplyRequest BuildReplyRequest(
+        TranslationRequest translationRequest,
+        TranslationResult translation,
+        string? tone,
+        IEnumerable<string> additionalLanguages)
+    {
+        var finalTone = tone ?? translationRequest.Tone ?? TranslationRequest.DefaultTone;
+        var languages = additionalLanguages?.Where(l => !string.IsNullOrWhiteSpace(l)).Distinct(StringComparer.OrdinalIgnoreCase).ToList()
+            ?? new List<string>();
+
+        var replyRequest = new ReplyRequest
+        {
+            ThreadId = translationRequest.ThreadId ?? string.Empty,
+            ReplyText = translation.TranslatedText,
+            Text = translationRequest.Text,
+            EditedText = translation.TranslatedText,
+            TenantId = translationRequest.TenantId,
+            UserId = translationRequest.UserId,
+            ChannelId = translationRequest.ChannelId,
+            Language = translationRequest.TargetLanguage,
+            UiLocale = translationRequest.UiLocale,
+            LanguagePolicy = new ReplyLanguagePolicy
+            {
+                TargetLang = translationRequest.TargetLanguage,
+                Tone = finalTone
+            },
+            AdditionalTargetLanguages = languages
+        };
+
+        return replyRequest;
+    }
+
+    private static async Task EnsureSuccessAsync(HttpResponseMessage response, string operation, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        throw new HttpRequestException($"{operation} 失败，状态码 {(int)response.StatusCode}: {content}");
+    }
+}

--- a/scripts/SmokeTests/Stage5SmokeTests/SmokeTestModeDecider.cs
+++ b/scripts/SmokeTests/Stage5SmokeTests/SmokeTestModeDecider.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using TlaPlugin.Configuration;
+
+public static class SmokeTestModeDecider
+{
+
+    public static SmokeTestModeDecision Decide(PluginOptions options, IReadOnlyDictionary<string, string?> parameters)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        var baseUrlProvided = parameters.TryGetValue("baseUrl", out var baseUrl) && !string.IsNullOrWhiteSpace(baseUrl);
+        var remoteRequested = parameters.ContainsKey("use-remote-api") || parameters.ContainsKey("use-remote");
+        var localStubRequested = parameters.ContainsKey("use-local-stub") || parameters.ContainsKey("force-local");
+
+        var autoConditionMet = !options.Security.UseHmacFallback || baseUrlProvided;
+        var useRemoteApi = (remoteRequested || autoConditionMet) && !localStubRequested;
+        var isAutomatic = autoConditionMet && !remoteRequested && !localStubRequested;
+
+        string? reason = null;
+        if (localStubRequested && (remoteRequested || autoConditionMet))
+        {
+            reason = "已指定 --use-local-stub，保持本地 Stub";
+        }
+        else if (remoteRequested)
+        {
+            reason = "检测到 --use-remote-api 参数";
+        }
+        else if (!options.Security.UseHmacFallback)
+        {
+            reason = "配置中已禁用 UseHmacFallback";
+        }
+        else if (baseUrlProvided)
+        {
+            reason = "检测到 --baseUrl 参数";
+        }
+
+        return new SmokeTestModeDecision
+        {
+            UseRemoteApi = useRemoteApi,
+            AutoConditionMet = autoConditionMet,
+            BaseUrlProvided = baseUrlProvided,
+            LocalStubRequested = localStubRequested,
+            RemoteFlagProvided = remoteRequested,
+            IsAutomatic = isAutomatic,
+            Reason = reason
+        };
+    }
+}
+
+public sealed record SmokeTestModeDecision
+{
+    public bool UseRemoteApi { get; init; }
+
+    public bool AutoConditionMet { get; init; }
+
+    public bool BaseUrlProvided { get; init; }
+
+    public bool LocalStubRequested { get; init; }
+
+    public bool RemoteFlagProvided { get; init; }
+
+    public bool IsAutomatic { get; init; }
+
+    public string? Reason { get; init; }
+}


### PR DESCRIPTION
## Summary
- add a smoke-test mode decider so the Stage5 CLI can automatically choose the remote API when configuration requires it
- implement a remote reply smoke runner that calls /api/translate, /api/reply, /api/metrics and /api/audit and emits their payloads
- expand the Stage5 runbook with a sample remote invocation that shows the emitted metrics and audit snippets

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e144558030832f8bf34405282a5d36