### PR TITLE
Document Stage readiness file path configuration

### DIFF
--- a/src/TlaPlugin/appsettings.Stage.json
+++ b/src/TlaPlugin/appsettings.Stage.json
@@ -1,5 +1,7 @@
 {
   "Plugin": {
+    "StageReadinessFilePath": "<shared-path>/stage-readiness.txt",
+    "_stageReadinessFilePathNote": "Stage 环境应指向挂载的共享卷（示例：Azure Files、NetApp 或 AKS PVC）内的持久化文件，以便多实例间共享就绪状态。",
     "Security": {
       "KeyVaultUri": "https://<stage-key-vault-name>.vault.azure.net/",
       "UseHmacFallback": false,


### PR DESCRIPTION
## Summary
- add a StageReadinessFilePath placeholder and guidance in the Stage appsettings
- expand the Stage 5 runbook section with steps to replace the placeholder and validate read/write access

## Testing
- `dotnet run --project scripts/SmokeTests/Stage5SmokeTests -- metrics --appsettings src/TlaPlugin/appsettings.json --override src/TlaPlugin/appsettings.Stage.json` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1481a4608832fa8c0a04f9e6cc0d2