### PR TITLE
Add Stage WebView fallback coverage and friendlier Graph errors

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: "tests/playwright",
   use: {
     trace: "retain-on-failure",
-    screenshot: "only-on-failure",
+    screenshot: "on",
     video: "retain-on-failure"
   },
   reporter: [

--- a/tests/playwright/stage-dashboard.spec.js
+++ b/tests/playwright/stage-dashboard.spec.js
@@ -48,6 +48,76 @@ async function serveStageStatic(route) {
 }
 
 test.describe("Stage dashboard caching", () => {
+  test("falls back to built-in status snapshot when the API is unavailable", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage?.clear?.();
+    });
+
+    const roadmapPayload = {
+      activeStageId: "phase5",
+      stages: [
+        { id: "phase5", name: "阶段 5：上线准备", objective: "串联 Stage 数据", completed: false }
+      ],
+      tests: []
+    };
+
+    const localesPayload = [{ id: "zh-CN", displayName: "简体中文", isDefault: true }];
+    const configurationPayload = { supportedLanguages: ["zh-CN", "en-US"] };
+    const metricsPayload = {
+      usage: { totalRequests: 64, successRate: 0.94, window: "24h" },
+      cost: { monthlyUsd: 12.5, dailyUsd: 0.42 },
+      failures: [],
+      updatedAt: "2024-05-18T11:00:00Z"
+    };
+
+    await page.route("**/api/status", async (route) => {
+      await route.fulfill({ status: 503, body: "status offline" });
+    });
+
+    await page.route("**/api/roadmap", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(roadmapPayload)
+      });
+    });
+
+    await page.route("**/api/localization/locales", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(localesPayload)
+      });
+    });
+
+    await page.route("**/api/configuration", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(configurationPayload)
+      });
+    });
+
+    await page.route("**/api/metrics", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(metricsPayload)
+      });
+    });
+
+    await page.route("http://stage.test/**", serveStageStatic);
+
+    await page.goto("http://stage.test/webapp/index.html");
+
+    const statusUpdated = page.locator("[data-status-updated]");
+    await expect(statusUpdated).toHaveAttribute("data-source", "fallback");
+    await expect(statusUpdated).toContainText("（内置数据）");
+    await expect(page.locator("[data-overall-text]")).toContainText("80%");
+    await expect(page.locator("[data-next-steps] li").first()).toContainText("Runbook");
+    await expect(page.locator("[data-stage-five-diagnostics]")).toContainText("Graph 作用域缺失");
+  });
+
   test("reuses cached status data when the network fails", async ({ page }) => {
     await page.addInitScript(() => {
       window.localStorage?.clear?.();
@@ -256,5 +326,86 @@ test.describe("Stage dashboard caching", () => {
     await expect(page.locator("[data-metric-usage-value]")).toHaveText("4,321");
     await expect(page.locator("[data-metric-cost-value]")).toHaveText("$128.40");
     expect(metricsCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  test("uses built-in metrics snapshot when the metrics API is offline", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage?.clear?.();
+    });
+
+    const statusPayload = {
+      currentStageId: "phase5",
+      overallCompletionPercent: 88,
+      stages: [
+        { id: "phase1", completed: true },
+        { id: "phase5", completed: false, name: "阶段 5：上线准备" }
+      ],
+      stageFiveDiagnostics: {
+        stageReady: true,
+        smokeTestRecent: true,
+        lastSmokeSuccess: "2024-05-18T10:00:00Z",
+        failureReason: null
+      },
+      frontend: { completionPercent: 92 },
+      updatedAt: "2024-05-18T10:00:00Z"
+    };
+
+    const roadmapPayload = {
+      activeStageId: "phase5",
+      stages: [
+        { id: "phase5", name: "阶段 5：上线准备", objective: "串联 Stage 数据" }
+      ],
+      tests: []
+    };
+
+    const localesPayload = [{ id: "zh-CN", displayName: "简体中文", isDefault: true }];
+    const configurationPayload = { supportedLanguages: ["zh-CN", "en-US"] };
+
+    await page.route("**/api/status", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(statusPayload)
+      });
+    });
+
+    await page.route("**/api/roadmap", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(roadmapPayload)
+      });
+    });
+
+    await page.route("**/api/localization/locales", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(localesPayload)
+      });
+    });
+
+    await page.route("**/api/configuration", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(configurationPayload)
+      });
+    });
+
+    await page.route("**/api/metrics", async (route) => {
+      await route.fulfill({ status: 503, body: "metrics offline" });
+    });
+
+    await page.route("http://stage.test/**", serveStageStatic);
+
+    await page.goto("http://stage.test/webapp/index.html");
+
+    await expect(page.locator("[data-metric-usage-value]")).toHaveText("15,872");
+    await expect(page.locator("[data-metric-cost-value]")).toHaveText("US$312.45");
+    const metricsUpdated = page.locator("[data-metrics-updated]");
+    await expect(metricsUpdated).toHaveAttribute("data-source", "fallback");
+    await expect(metricsUpdated).toContainText("（内置数据）");
+    await expect(page.locator("[data-failure-reasons] li").first()).toContainText("RateLimitExceeded");
   });
 });


### PR DESCRIPTION
## Summary
- cover Stage dashboard status and metrics success, cache, and built-in fallback flows in Playwright WebView tests
- expand Stage compose WebView tests to validate ReplyDispatches, audit data, and budget guard messaging
- improve Graph error parsing for user-friendly previews and capture screenshots from every run

## Testing
- npm run test:playwright -- --grep "Stage" *(fails: unable to download Playwright Chromium binaries because outbound requests return 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f9f377799c832f9e4deeb0a87d3cb3